### PR TITLE
scripts: Add SKIP_DEPCHECK flag to makefile

### DIFF
--- a/build/Makefile.deps
+++ b/build/Makefile.deps
@@ -1,6 +1,7 @@
 ## Installs all the required binaries for the makefile targets.
 .PHONY: deps
 deps:
+ifndef SKIP_DEPCHECK
 	@ echo "-> Installing project dependencies..."
 	@ GO111MODULE=off go get -u github.com/myitcv/gobin
 	@ $(GOBIN)/gobin github.com/elastic/go-licenser@v0.3.0
@@ -8,3 +9,4 @@ deps:
 	@ $(GOBIN)/gobin golang.org/x/lint/golint
 	@ curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(GOBIN) v1.19.0
 	@ echo "-> Done."
+endif

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -5,4 +5,4 @@ exec 1>&2
 
 echo "-> Running pre-commit hook..."
 
-make lint unit docs
+make lint unit docs SKIP_DEPCHECK=true


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
This patch adds a Makefile flag which allows the user to skip
downloading the project's defined dependencies, which can help speed up
any of the commands which directly deppend on that target.

Additionally adds SKIP_DEPCHECK=true to the available to install
githooks.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Sometimes targets can take some time to perform the dep version checking / downloading. By allowing the user to set that flag, it can help speed up when internet connection is not the greatest.
