### PR TITLE
Add CONTIBUTING note about GitHub Actions in Forks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,8 +62,9 @@ The codebase is maintained using the "contributor workflow" where everyone witho
 To contribute a patch, make sure you follow this workflow:
 
 1. Fork repository
-2. Create topic branch
-3. Commit patches
+2. Enable GitHub actions to run in your fork
+3. Create topic branch
+4. Commit patches
 
 ### Commit Messages
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds the contributing remark to help contributors have the CI running in their GH actions fork