### PR TITLE
Bump Go version to 1.13

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,15 +3,14 @@ name: Go
 on: [push, pull_request]
 
 jobs:
-
   build:
     name: Build
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.12
+    - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.12
+        go-version: 1.13
       id: go
 
     - name: Check out code into the Go module directory


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Bumps GitHub Actions to Go 1.13

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Go 1.13 is the latest and greatest! And all of the team seems to be running 1.13 anyway.

