### PR TITLE
deployment: Add shutdown command

### DIFF
--- a/cmd/deployment/shutdown.go
+++ b/cmd/deployment/shutdown.go
@@ -30,7 +30,7 @@ import (
 var shutdownCmd = &cobra.Command{
 	Use:     "shutdown <deployment-id>",
 	Short:   "Shutdown's a platform deployment",
-	PreRunE: cobra.MinimumNArgs(1),
+	PreRunE: cmdutil.MinimumNArgsAndUUID(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		force, _ := cmd.Flags().GetBool("force")
 		var msg = "This action will delete the specified deployment ID and its associated sub-resources, do you want to continue? [y/n]: "

--- a/cmd/deployment/shutdown.go
+++ b/cmd/deployment/shutdown.go
@@ -1,0 +1,62 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmddeployment
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	cmdutil "github.com/elastic/ecctl/cmd/util"
+	"github.com/elastic/ecctl/pkg/deployment"
+	"github.com/elastic/ecctl/pkg/ecctl"
+)
+
+var shutdownCmd = &cobra.Command{
+	Use:     "shutdown <deployment-id>",
+	Short:   "Shutdown's a platform deployment",
+	PreRunE: cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		force, _ := cmd.Flags().GetBool("force")
+		var msg = "This action will delete the specified deployment ID and its associated sub-resources, do you want to continue? [y/n]: "
+		if !force && !cmdutil.ConfirmAction(msg, os.Stderr, os.Stdout) {
+			return nil
+		}
+
+		skipSnapshot, _ := cmd.Flags().GetBool("skip-snapshot")
+		hide, _ := cmd.Flags().GetBool("hide")
+
+		res, err := deployment.Shutdown(deployment.ShutdownParams{
+			API:          ecctl.Get().API,
+			DeploymentID: args[0],
+			SkipSnapshot: skipSnapshot,
+			Hide:         hide,
+		})
+		if err != nil {
+			return err
+		}
+
+		return ecctl.Get().Formatter.Format("deployment/shutdown", res)
+	},
+}
+
+func init() {
+	Command.AddCommand(shutdownCmd)
+	shutdownCmd.Flags().Bool("skip-snapshot", false, "Skips taking an Elasticsearch snapshot prior to shutting down the deployment")
+	shutdownCmd.Flags().Bool("hide", false, "Hides the deployment and its resources after it has been shut down")
+}

--- a/cmd/deployment/shutdown.go
+++ b/cmd/deployment/shutdown.go
@@ -29,7 +29,7 @@ import (
 
 var shutdownCmd = &cobra.Command{
 	Use:     "shutdown <deployment-id>",
-	Short:   "Shutdown's a platform deployment",
+	Short:   "Shuts down a deployment and all of its associated sub-resources",
 	PreRunE: cmdutil.MinimumNArgsAndUUID(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		force, _ := cmd.Flags().GetBool("force")

--- a/docs/ecctl_deployment.md
+++ b/docs/ecctl_deployment.md
@@ -46,5 +46,5 @@ ecctl deployment [flags]
 * [ecctl deployment list](ecctl_deployment_list.md)	 - Lists the platform's deployments
 * [ecctl deployment note](ecctl_deployment_note.md)	 - Manages a deployment's notes
 * [ecctl deployment show](ecctl_deployment_show.md)	 - Shows the specified deployment resources
-* [ecctl deployment shutdown](ecctl_deployment_shutdown.md)	 - Shutdown's a platform deployment
+* [ecctl deployment shutdown](ecctl_deployment_shutdown.md)	 - Shuts down a deployment and all of its associated sub-resources
 

--- a/docs/ecctl_deployment_shutdown.md
+++ b/docs/ecctl_deployment_shutdown.md
@@ -1,19 +1,21 @@
-## ecctl deployment
+## ecctl deployment shutdown
 
-Manages deployments
+Shutdown's a platform deployment
 
 ### Synopsis
 
-Manages deployments
+Shutdown's a platform deployment
 
 ```
-ecctl deployment [flags]
+ecctl deployment shutdown <deployment-id> [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for deployment
+  -h, --help            help for shutdown
+      --hide            Hides the deployment and its resources after it has been shut down
+      --skip-snapshot   Skips taking an Elasticsearch snapshot prior to shutting down the deployment
 ```
 
 ### Options inherited from parent commands
@@ -39,12 +41,5 @@ ecctl deployment [flags]
 
 ### SEE ALSO
 
-* [ecctl](ecctl.md)	 - Elastic Cloud Control
-* [ecctl deployment apm](ecctl_deployment_apm.md)	 - Manages APM deployments
-* [ecctl deployment elasticsearch](ecctl_deployment_elasticsearch.md)	 - Manages Elasticsearch clusters
-* [ecctl deployment kibana](ecctl_deployment_kibana.md)	 - Manages Kibana clusters
-* [ecctl deployment list](ecctl_deployment_list.md)	 - Lists the platform's deployments
-* [ecctl deployment note](ecctl_deployment_note.md)	 - Manages a deployment's notes
-* [ecctl deployment show](ecctl_deployment_show.md)	 - Shows the specified deployment resources
-* [ecctl deployment shutdown](ecctl_deployment_shutdown.md)	 - Shutdown's a platform deployment
+* [ecctl deployment](ecctl_deployment.md)	 - Manages deployments
 

--- a/docs/ecctl_deployment_shutdown.md
+++ b/docs/ecctl_deployment_shutdown.md
@@ -1,10 +1,10 @@
 ## ecctl deployment shutdown
 
-Shutdown's a platform deployment
+Shuts down a deployment and all of its associated sub-resources
 
 ### Synopsis
 
-Shutdown's a platform deployment
+Shuts down a deployment and all of its associated sub-resources
 
 ```
 ecctl deployment shutdown <deployment-id> [flags]

--- a/pkg/deployment/shutdown.go
+++ b/pkg/deployment/shutdown.go
@@ -1,0 +1,73 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package deployment
+
+import (
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/client/deployments"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/elastic/ecctl/pkg/util"
+)
+
+// ShutdownParams is consumed by Shutdown.
+type ShutdownParams struct {
+	*api.API
+	DeploymentID string
+
+	SkipSnapshot bool
+	Hide         bool
+}
+
+// Validate ensures the parameters are usable by Shutdown.
+func (params ShutdownParams) Validate() error {
+	var merr = new(multierror.Error)
+
+	if params.API == nil {
+		merr = multierror.Append(merr, util.ErrAPIReq)
+	}
+
+	if params.DeploymentID == "" {
+		merr = multierror.Append(merr, util.ErrDeploymentID)
+	}
+
+	return merr.ErrorOrNil()
+}
+
+// Shutdown shuts down a deployment and all of its associated resources. To
+// shutdown individual deployment resources use the type especific APIs.
+func Shutdown(params ShutdownParams) (*models.DeploymentShutdownResponse, error) {
+	if err := params.Validate(); err != nil {
+		return nil, err
+	}
+
+	res, err := params.V1API.Deployments.ShutdownDeployment(
+		deployments.NewShutdownDeploymentParams().
+			WithDeploymentID(params.DeploymentID).
+			WithSkipSnapshot(ec.Bool(params.SkipSnapshot)).
+			WithHide(ec.Bool(params.Hide)),
+		params.AuthWriter,
+	)
+	if err != nil {
+		return nil, api.UnwrapError(err)
+	}
+
+	return res.Payload, nil
+}

--- a/pkg/deployment/shutdown.go
+++ b/pkg/deployment/shutdown.go
@@ -44,7 +44,7 @@ func (params ShutdownParams) Validate() error {
 		merr = multierror.Append(merr, util.ErrAPIReq)
 	}
 
-	if params.DeploymentID == "" {
+	if len(params.DeploymentID) != 32 {
 		merr = multierror.Append(merr, util.ErrDeploymentID)
 	}
 

--- a/pkg/deployment/shutdown_test.go
+++ b/pkg/deployment/shutdown_test.go
@@ -1,0 +1,84 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package deployment
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/elastic/ecctl/pkg/util"
+)
+
+func TestShutdown(t *testing.T) {
+	type args struct {
+		params ShutdownParams
+	}
+	tests := []struct {
+		name string
+		args args
+		want *models.DeploymentShutdownResponse
+		err  error
+	}{
+		{
+			name: "fails on parameter validation",
+			err: &multierror.Error{Errors: []error{
+				util.ErrAPIReq,
+				util.ErrDeploymentID,
+			}},
+		},
+		{
+			name: "fails on API error",
+			args: args{params: ShutdownParams{
+				API:          api.NewMock(mock.New500Response(mock.NewStringBody("error"))),
+				DeploymentID: util.ValidClusterID,
+			}},
+			err: errors.New("unknown error (status 500)"),
+		},
+		{
+			name: "Succeeds",
+			args: args{params: ShutdownParams{
+				API: api.NewMock(mock.New200Response(mock.NewStructBody(models.DeploymentShutdownResponse{
+					ID: ec.String(util.ValidClusterID),
+				}))),
+				DeploymentID: util.ValidClusterID,
+			}},
+			want: &models.DeploymentShutdownResponse{
+				ID: ec.String(util.ValidClusterID),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Shutdown(tt.args.params)
+			if !reflect.DeepEqual(err, tt.err) {
+				t.Errorf("Shutdown() error = %v, wantErr %v", err, tt.err)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Shutdown() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/util/helper.go
+++ b/pkg/util/helper.go
@@ -37,6 +37,8 @@ var (
 	ErrAPIReq = errors.New("api reference is required for command")
 	// ErrClusterLength is the message returned when a provided cluster id is not of the expected length (32 chars)
 	ErrClusterLength = errors.New("cluster id should have a length of 32 characters")
+	// ErrDeploymentID is the message returned when a provided cluster id is not of the expected length (32 chars)
+	ErrDeploymentID = errors.New("deployment id should have a length of 32 characters")
 
 	// SkipMaintenanceHeaders tells the EC proxy layer to still send requests to the
 	// underlying cluster instances even if they are in maintenance mode


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds the deployment shutdown command with an interactive prompt
confirming the action which can be skipped by using the `--force` flag.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```console
$ dev-cli deployment shutdown a3eb4382ccca482ea15ad1232aabf2cc
This action will delete the specified deployment ID and its associated sub-resources, do you want to continue? [y/n]: y
{
  "id": "a3eb4382ccca482ea15ad1232aabf2cc",
  "name": "",
  "orphaned": {
    "apm": [],
    "appsearch": [],
    "elasticsearch": [
      {
        "dependents": [
          {
            "id": "7e44eee3e62f416a8512811bd6498d6e",
            "kind": "kibana"
          }
        ],
        "id": "a3eb4382ccca482ea15ad1232aabf2cc"
      }
    ],
    "kibana": []
  }
}

```

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
