### PR TITLE
deployment: Add delete command

### DIFF
--- a/cmd/deployment/command.go
+++ b/cmd/deployment/command.go
@@ -1,0 +1,46 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmddeployment
+
+import (
+	"github.com/spf13/cobra"
+
+	cmdapm "github.com/elastic/ecctl/cmd/deployment/apm"
+	cmdelasticsearch "github.com/elastic/ecctl/cmd/deployment/elasticsearch"
+	cmdkibana "github.com/elastic/ecctl/cmd/deployment/kibana"
+	cmddeploymentnote "github.com/elastic/ecctl/cmd/deployment/note"
+)
+
+// Command is the deployment subcommand
+var Command = &cobra.Command{
+	Use:     "deployment",
+	Short:   "Manages deployments",
+	PreRunE: cobra.MaximumNArgs(0),
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+}
+
+func init() {
+	Command.AddCommand(
+		cmddeploymentnote.Command,
+		cmdelasticsearch.Command,
+		cmdkibana.Command,
+		cmdapm.Command,
+	)
+}

--- a/cmd/deployment/delete.go
+++ b/cmd/deployment/delete.go
@@ -20,28 +20,28 @@ package cmddeployment
 import (
 	"github.com/spf13/cobra"
 
-	cmdapm "github.com/elastic/ecctl/cmd/deployment/apm"
-	cmdelasticsearch "github.com/elastic/ecctl/cmd/deployment/elasticsearch"
-	cmdkibana "github.com/elastic/ecctl/cmd/deployment/kibana"
-	cmddeploymentnote "github.com/elastic/ecctl/cmd/deployment/note"
+	cmdutil "github.com/elastic/ecctl/cmd/util"
+	"github.com/elastic/ecctl/pkg/deployment"
+	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
-// Command is the deployment subcommand
-var Command = &cobra.Command{
-	Use:     "deployment",
-	Short:   "Manages deployments",
-	PreRunE: cobra.MaximumNArgs(0),
-	Run: func(cmd *cobra.Command, args []string) {
-		cmd.Help()
+var deleteCmd = &cobra.Command{
+	Use:     "delete <deployment-id>",
+	Short:   "deletes a previously stopped deployment from the platform",
+	PreRunE: cmdutil.MinimumNArgsAndUUID(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := deployment.Delete(deployment.DeleteParams{
+			API:          ecctl.Get().API,
+			DeploymentID: args[0],
+		})
+		if err != nil {
+			return err
+		}
+
+		return ecctl.Get().Formatter.Format("", res)
 	},
 }
 
 func init() {
-	Command.AddCommand(
-		cmddeploymentnote.Command,
-		cmdelasticsearch.Command,
-		cmdkibana.Command,
-		cmdapm.Command,
-		showCmd,
-	)
+	Command.AddCommand(deleteCmd)
 }

--- a/cmd/deployment/show.go
+++ b/cmd/deployment/show.go
@@ -87,6 +87,7 @@ var showCmd = &cobra.Command{
 }
 
 func init() {
+	Command.AddCommand(showCmd)
 	showCmd.Flags().String("type", "", "Optional deployment type to show resource information (elasticsearch, kibana, apm, or appsearch)")
 	showCmd.Flags().Bool("plans", false, "Shows the deployment plans")
 	showCmd.Flags().Bool("plan-logs", false, "Shows the deployment plan logs")

--- a/docs/ecctl_deployment_delete.md
+++ b/docs/ecctl_deployment_delete.md
@@ -1,19 +1,19 @@
-## ecctl deployment
+## ecctl deployment delete
 
-Manages deployments
+deletes a previously stopped deployment from the platform
 
 ### Synopsis
 
-Manages deployments
+deletes a previously stopped deployment from the platform
 
 ```
-ecctl deployment [flags]
+ecctl deployment delete <deployment-id> [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for deployment
+  -h, --help   help for delete
 ```
 
 ### Options inherited from parent commands
@@ -39,14 +39,5 @@ ecctl deployment [flags]
 
 ### SEE ALSO
 
-* [ecctl](ecctl.md)	 - Elastic Cloud Control
-* [ecctl deployment apm](ecctl_deployment_apm.md)	 - Manages APM deployments
-* [ecctl deployment delete](ecctl_deployment_delete.md)	 - deletes a previously stopped deployment from the platform
-* [ecctl deployment elasticsearch](ecctl_deployment_elasticsearch.md)	 - Manages Elasticsearch clusters
-* [ecctl deployment kibana](ecctl_deployment_kibana.md)	 - Manages Kibana clusters
-* [ecctl deployment list](ecctl_deployment_list.md)	 - Lists the platform's deployments
-* [ecctl deployment note](ecctl_deployment_note.md)	 - Manages a deployment's notes
-* [ecctl deployment search](ecctl_deployment_search.md)	 - Performs advanced deployment search using the Elasticsearch Query DSL
-* [ecctl deployment show](ecctl_deployment_show.md)	 - Shows the specified deployment resources
-* [ecctl deployment shutdown](ecctl_deployment_shutdown.md)	 - Shuts down a deployment and all of its associated sub-resources
+* [ecctl deployment](ecctl_deployment.md)	 - Manages deployments
 

--- a/pkg/deployment/delete.go
+++ b/pkg/deployment/delete.go
@@ -1,0 +1,66 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package deployment
+
+import (
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/client/deployments"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/elastic/ecctl/pkg/util"
+)
+
+// DeleteParams is consumed by Delete.
+type DeleteParams struct {
+	*api.API
+	DeploymentID string
+}
+
+// Validate ensures the parameters are usable by Delete.
+func (params DeleteParams) Validate() error {
+	var merr = new(multierror.Error)
+
+	if params.API == nil {
+		merr = multierror.Append(merr, util.ErrAPIReq)
+	}
+
+	if len(params.DeploymentID) != 32 {
+		merr = multierror.Append(merr, util.ErrDeploymentID)
+	}
+
+	return merr.ErrorOrNil()
+}
+
+// Delete removes the specified deployment ID from the platform.
+func Delete(params DeleteParams) (*models.DeploymentDeleteResponse, error) {
+	if err := params.Validate(); err != nil {
+		return nil, err
+	}
+
+	res, err := params.V1API.Deployments.DeleteDeployment(
+		deployments.NewDeleteDeploymentParams().
+			WithDeploymentID(params.DeploymentID),
+		params.AuthWriter,
+	)
+	if err != nil {
+		return nil, api.UnwrapError(err)
+	}
+
+	return res.Payload, nil
+}

--- a/pkg/deployment/delete_test.go
+++ b/pkg/deployment/delete_test.go
@@ -1,0 +1,84 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package deployment
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/elastic/ecctl/pkg/util"
+)
+
+func TestDelete(t *testing.T) {
+	type args struct {
+		params DeleteParams
+	}
+	tests := []struct {
+		name string
+		args args
+		want *models.DeploymentDeleteResponse
+		err  error
+	}{
+		{
+			name: "fails on parameter validation",
+			err: &multierror.Error{Errors: []error{
+				util.ErrAPIReq,
+				util.ErrDeploymentID,
+			}},
+		},
+		{
+			name: "fails on API error",
+			args: args{params: DeleteParams{
+				API:          api.NewMock(mock.New500Response(mock.NewStringBody("error"))),
+				DeploymentID: util.ValidClusterID,
+			}},
+			err: errors.New("unknown error (status 500)"),
+		},
+		{
+			name: "Succeeds",
+			args: args{params: DeleteParams{
+				API: api.NewMock(mock.New200Response(mock.NewStructBody(models.DeploymentDeleteResponse{
+					ID: ec.String(util.ValidClusterID),
+				}))),
+				DeploymentID: util.ValidClusterID,
+			}},
+			want: &models.DeploymentDeleteResponse{
+				ID: ec.String(util.ValidClusterID),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Delete(tt.args.params)
+			if !reflect.DeepEqual(err, tt.err) {
+				t.Errorf("Delete() error = %v, wantErr %v", err, tt.err)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Delete() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds the deployment delete command which can be used to remove
deployments which have been shut down previously. Additionally renames
`deployment.go` to `command.go`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

#### Deleting a deployment which has no running instances, succeeds

```console
$ dev-cli deployment delete a3eb4382ccca482ea15ad1232aabf2cc
{
  "id": "a3eb4382ccca482ea15ad1232aabf2cc",
  "name": "",
  "orphaned": {
    "apm": [],
    "appsearch": [],
    "elasticsearch": [
      {
        "dependents": [
          {
            "id": "7e44eee3e62f416a8512811bd6498d6e",
            "kind": "kibana"
          }
        ],
        "id": "a3eb4382ccca482ea15ad1232aabf2cc"
      }
    ],
    "kibana": []
  }
}
```
#### Deleting a deployment which has running instances returns an error

```console
$ dev-cli deployment delete 32051ab417b946ee9a3e834e8b29ebaf
{
  "errors": [
    {
      "code": "deployments.deployment_has_instances",
      "fields": null,
      "message": "Unable to delete deployment [DeploymentId(32051ab417b946ee9a3e834e8b29ebaf)] since it still has instances. ([ElasticsearchClusterType 32051ab417b946ee9a3e834e8b29ebaf])"
    }
  ]
}
```

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)