### PR TITLE
deployment: Add create command

### DIFF
--- a/build/errcheck-exclusions.txt
+++ b/build/errcheck-exclusions.txt
@@ -1,5 +1,7 @@
 (*github.com/spf13/cobra.Command).MarkFlagRequired
+(*github.com/spf13/cobra.Command).MarkFlagFilename
 github.com/spf13/cobra.MarkFlagRequired
+github.com/spf13/cobra.MarkFlagFilename
 github.com/spf13/cobra.MarkFlagFilename
 (*github.com/spf13/cobra.Command).Help
 (*github.com/spf13/viper.Viper).BindPFlags

--- a/cmd/deployment/create.go
+++ b/cmd/deployment/create.go
@@ -27,6 +27,7 @@ import (
 	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/deployment"
 	"github.com/elastic/ecctl/pkg/ecctl"
+	"github.com/elastic/ecctl/pkg/util"
 )
 
 const createLong = `Creates a deployment from a file definition with an automatically generated idempotency token.
@@ -144,7 +145,7 @@ var createCmd = &cobra.Command{
 
 		reqID, _ := cmd.Flags().GetString("request-id")
 		if reqID == "" {
-			reqID = cmdutil.RandomString(64)
+			reqID = util.RandomString(64)
 		}
 
 		res, err := deployment.Create(deployment.CreateParams{

--- a/cmd/deployment/create.go
+++ b/cmd/deployment/create.go
@@ -45,14 +45,17 @@ $ cat deployment_example.json
                 "ref_id": "my-apm-instance",
                 "elasticsearch_cluster_ref_id": "my-es-cluster",
                 "plan": {
-                    "zone_count": 1,
                     "apm": {
                         "version": "6.8.4"
                     },
-                    "size":{
-                        "resource": "memory",
-                        "value": 512
-                    }
+                    "cluster_topology": [{
+                        "instance_configuration_id": "apm",
+                        "size": {
+                            "resource": "memory",
+                            "value": 512
+                        },
+                        "zone_count": 1
+                    }]
                 }
             }
         ],

--- a/cmd/deployment/create.go
+++ b/cmd/deployment/create.go
@@ -30,7 +30,7 @@ import (
 )
 
 const createLong = `Creates a deployment from a file definition with an automatically generated idempotency token.
-On creation failure, please use the displayed idempotency token to retry the cluster creation.
+On creation failure, please use the displayed idempotency token to retry the cluster creation with --request-id=<token>.
 
 Read more about the deployment definition in https://www.elastic.co/guide/en/cloud-enterprise/current/Deployment_-_CRUD.html`
 
@@ -107,6 +107,15 @@ $ cat deployment_example.json
     }
 }
 $ ecctl deployment create -f deployment_example.json --version=7.4.1
+[...]
+
+## If th previous deployment creation failed
+$ ecctl deployment create -f deployment_example.json --name adeploy --version=7.4.1
+The deployment creation returned with an error, please use the displayed idempotency token
+to recreate the deployment resources
+Idempotency token: GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhGUSMXrEIzVXoBykSVRsKncNb
+unknown error (status 500)
+$ ecctl deployment create -f deployment_example.json --name adeploy --version=7.4.1 --request-id=GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhGUSMXrEIzVXoBykSVRsKncNb
 [...]`[1:]
 
 var createCmd = &cobra.Command{
@@ -162,7 +171,7 @@ func init() {
 	Command.AddCommand(createCmd)
 	createCmd.Flags().String("name", "", "Overrides the deployment name")
 	createCmd.Flags().String("version", "", "Overrides all thee deployment's resources to the specified version")
-	createCmd.Flags().String("request-id", "", "Optional idempotency token - if two create requests share the same request_id token (min size 32 characters, max 128) then only one deployment will be created, the second request will return the info of that deployment (in the same format described below, but with blanks for auth-related fields)")
+	createCmd.Flags().String("request-id", "", "Optional idempotency token - Can be found in the Stderr device when a previous deployment creation failed, for more information see the examples in the help command page")
 	createCmd.Flags().StringP("file", "f", "", "JSON file that contains JSON-style domain-specific deployment definition")
 	createCmd.MarkFlagRequired("file")
 	createCmd.MarkFlagFilename("file", "*.json")

--- a/cmd/deployment/create.go
+++ b/cmd/deployment/create.go
@@ -1,0 +1,169 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmddeployment
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/spf13/cobra"
+
+	cmdutil "github.com/elastic/ecctl/cmd/util"
+	"github.com/elastic/ecctl/pkg/deployment"
+	"github.com/elastic/ecctl/pkg/ecctl"
+)
+
+const createLong = `Creates a deployment from a file definition with an automatically generated idempotency token.
+On creation failure, please use the displayed idempotency token to retry the cluster creation.
+
+Read more about the deployment definition in https://www.elastic.co/guide/en/cloud-enterprise/current/Deployment_-_CRUD.html`
+
+var createExample = `
+$ cat deployment_example.json
+{
+    "name": "my example cluster",
+    "resources": {
+        "apm": [
+            {
+                "display_name": "my apm instance",
+                "ref_id": "my-apm-instance",
+                "elasticsearch_cluster_ref_id": "my-es-cluster",
+                "plan": {
+                    "zone_count": 1,
+                    "apm": {
+                        "version": "6.8.4"
+                    },
+                    "size":{
+                        "resource": "memory",
+                        "value": 512
+                    }
+                }
+            }
+        ],
+        "elasticsearch": [
+            {
+                "display_name": "my elasticsearch cluster",
+                "ref_id": "my-es-cluster",
+                "plan": {
+                    "deployment_template": {
+                        "id": "default"
+                    },
+                    "elasticsearch": {
+                        "version": "6.8.4"
+                    },
+                    "cluster_topology": [
+                        {
+                            "instance_configuration_id": "data.default",
+                            "memory_per_node": 1024,
+                            "node_count_per_zone": 1,
+                            "node_type": {
+                                "data": true,
+                                "ingest": true,
+                                "master": true,
+                                "ml": false
+                            },
+                            "zone_count": 1
+                        }
+                    ]
+                }
+            }
+        ],
+        "kibana": [
+            {
+                "display_name": "my kibana instance",
+                "ref_id": "my-kibana-instance",
+                "elasticsearch_cluster_ref_id": "my-es-cluster",
+                "plan": {
+                    "zone_count": 1,
+                    "kibana": {
+                        "version": "6.8.4"
+                    },
+                    "cluster_topology": [
+                        {
+                            "instance_configuration_id": "kibana",
+                            "memory_per_node": 1024,
+                            "node_count_per_zone": 1
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}
+$ ecctl deployment create -f deployment_example.json --version=7.4.1
+[...]`[1:]
+
+var createCmd = &cobra.Command{
+	Use:     `create -f <file definition.json>`,
+	Short:   "Creates a deployment from a file definition, allowing certain flag overrides",
+	Long:    createLong,
+	Example: createExample,
+	PreRunE: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		filename, _ := cmd.Flags().GetString("file")
+		var r models.DeploymentCreateRequest
+		if err := cmdutil.DecodeFile(filename, &r); err != nil {
+			return err
+		}
+
+		var region string
+		if ecctl.Get().Config.Region == "" {
+			region = cmdutil.DefaultECERegion
+		}
+
+		name, _ := cmd.Flags().GetString("name")
+		version, _ := cmd.Flags().GetString("version")
+
+		reqID, _ := cmd.Flags().GetString("request-id")
+		if reqID == "" {
+			reqID = cmdutil.RandomString(64)
+		}
+
+		res, err := deployment.Create(deployment.CreateParams{
+			API:       ecctl.Get().API,
+			RequestID: reqID,
+			Request:   &r,
+			Overrides: &deployment.CreateOverrides{
+				Name:    name,
+				Region:  region,
+				Version: version,
+			},
+		})
+
+		if err != nil {
+			fmt.Fprintln(os.Stderr,
+				"The deployment creation returned with an error, please use the displayed idempotency token to recreate the deployment resources",
+			)
+			fmt.Fprintln(os.Stderr, "Idempotency token:", reqID)
+			return err
+		}
+
+		return ecctl.Get().Formatter.Format("", res)
+	},
+}
+
+func init() {
+	Command.AddCommand(createCmd)
+	createCmd.Flags().String("name", "", "Overrides the deployment name")
+	createCmd.Flags().String("version", "", "Overrides all thee deployment's resources to the specified version")
+	createCmd.Flags().String("request-id", "", "Optional idempotency token - if two create requests share the same request_id token (min size 32 characters, max 128) then only one deployment will be created, the second request will return the info of that deployment (in the same format described below, but with blanks for auth-related fields)")
+	createCmd.Flags().StringP("file", "f", "", "JSON file that contains JSON-style domain-specific deployment definition")
+	createCmd.MarkFlagRequired("file")
+	createCmd.MarkFlagFilename("file", "*.json")
+}

--- a/cmd/util/random.go
+++ b/cmd/util/random.go
@@ -15,33 +15,21 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package cmddeployment
+package cmdutil
 
 import (
-	"github.com/spf13/cobra"
-
-	cmdutil "github.com/elastic/ecctl/cmd/util"
-	"github.com/elastic/ecctl/pkg/deployment"
-	"github.com/elastic/ecctl/pkg/ecctl"
+	"math/rand"
+	"time"
 )
 
-var deleteCmd = &cobra.Command{
-	Use:     "delete <deployment-id>",
-	Short:   "Deletes a previously stopped deployment from the platform",
-	PreRunE: cmdutil.MinimumNArgsAndUUID(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		res, err := deployment.Delete(deployment.DeleteParams{
-			API:          ecctl.Get().API,
-			DeploymentID: args[0],
-		})
-		if err != nil {
-			return err
-		}
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
-		return ecctl.Get().Formatter.Format("", res)
-	},
-}
-
-func init() {
-	Command.AddCommand(deleteCmd)
+// RandomString generates a random strings with a defined length.
+func RandomString(n int) string {
+	rand.Seed(time.Now().UnixNano())
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return string(b)
 }

--- a/cmd/util/region.go
+++ b/cmd/util/region.go
@@ -15,33 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package cmddeployment
+package cmdutil
 
-import (
-	"github.com/spf13/cobra"
-
-	cmdutil "github.com/elastic/ecctl/cmd/util"
-	"github.com/elastic/ecctl/pkg/deployment"
-	"github.com/elastic/ecctl/pkg/ecctl"
-)
-
-var deleteCmd = &cobra.Command{
-	Use:     "delete <deployment-id>",
-	Short:   "Deletes a previously stopped deployment from the platform",
-	PreRunE: cmdutil.MinimumNArgsAndUUID(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		res, err := deployment.Delete(deployment.DeleteParams{
-			API:          ecctl.Get().API,
-			DeploymentID: args[0],
-		})
-		if err != nil {
-			return err
-		}
-
-		return ecctl.Get().Formatter.Format("", res)
-	},
-}
-
-func init() {
-	Command.AddCommand(deleteCmd)
-}
+// DefaultECERegion is the region for ECE
+const DefaultECERegion = "ece-region"

--- a/docs/ecctl_deployment.md
+++ b/docs/ecctl_deployment.md
@@ -41,7 +41,8 @@ ecctl deployment [flags]
 
 * [ecctl](ecctl.md)	 - Elastic Cloud Control
 * [ecctl deployment apm](ecctl_deployment_apm.md)	 - Manages APM deployments
-* [ecctl deployment delete](ecctl_deployment_delete.md)	 - deletes a previously stopped deployment from the platform
+* [ecctl deployment create](ecctl_deployment_create.md)	 - Creates a deployment from a file definition, allowing certain flag overrides
+* [ecctl deployment delete](ecctl_deployment_delete.md)	 - Deletes a previously stopped deployment from the platform
 * [ecctl deployment elasticsearch](ecctl_deployment_elasticsearch.md)	 - Manages Elasticsearch clusters
 * [ecctl deployment kibana](ecctl_deployment_kibana.md)	 - Manages Kibana clusters
 * [ecctl deployment list](ecctl_deployment_list.md)	 - Lists the platform's deployments

--- a/docs/ecctl_deployment_create.md
+++ b/docs/ecctl_deployment_create.md
@@ -1,0 +1,128 @@
+## ecctl deployment create
+
+Creates a deployment from a file definition, allowing certain flag overrides
+
+### Synopsis
+
+Creates a deployment from a file definition with an automatically generated idempotency token.
+On creation failure, please use the displayed idempotency token to retry the cluster creation.
+
+Read more about the deployment definition in https://www.elastic.co/guide/en/cloud-enterprise/current/Deployment_-_CRUD.html
+
+```
+ecctl deployment create -f <file definition.json> [flags]
+```
+
+### Examples
+
+```
+$ cat deployment_example.json
+{
+    "name": "my example cluster",
+    "resources": {
+        "apm": [
+            {
+                "display_name": "my apm instance",
+                "ref_id": "my-apm-instance",
+                "elasticsearch_cluster_ref_id": "my-es-cluster",
+                "plan": {
+                    "zone_count": 1,
+                    "apm": {
+                        "version": "6.8.4"
+                    },
+                    "size":{
+                        "resource": "memory",
+                        "value": 512
+                    }
+                }
+            }
+        ],
+        "elasticsearch": [
+            {
+                "display_name": "my elasticsearch cluster",
+                "ref_id": "my-es-cluster",
+                "plan": {
+                    "deployment_template": {
+                        "id": "default"
+                    },
+                    "elasticsearch": {
+                        "version": "6.8.4"
+                    },
+                    "cluster_topology": [
+                        {
+                            "instance_configuration_id": "data.default",
+                            "memory_per_node": 1024,
+                            "node_count_per_zone": 1,
+                            "node_type": {
+                                "data": true,
+                                "ingest": true,
+                                "master": true,
+                                "ml": false
+                            },
+                            "zone_count": 1
+                        }
+                    ]
+                }
+            }
+        ],
+        "kibana": [
+            {
+                "display_name": "my kibana instance",
+                "ref_id": "my-kibana-instance",
+                "elasticsearch_cluster_ref_id": "my-es-cluster",
+                "plan": {
+                    "zone_count": 1,
+                    "kibana": {
+                        "version": "6.8.4"
+                    },
+                    "cluster_topology": [
+                        {
+                            "instance_configuration_id": "kibana",
+                            "memory_per_node": 1024,
+                            "node_count_per_zone": 1
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}
+$ ecctl deployment create -f deployment_example.json --version=7.4.1
+[...]
+```
+
+### Options
+
+```
+  -f, --file string         JSON file that contains JSON-style domain-specific deployment definition
+  -h, --help                help for create
+      --name string         Overrides the deployment name
+      --request-id string   Optional idempotency token - if two create requests share the same request_id token (min size 32 characters, max 128) then only one deployment will be created, the second request will return the info of that deployment (in the same format described below, but with blanks for auth-related fields)
+      --version string      Overrides all thee deployment's resources to the specified version
+```
+
+### Options inherited from parent commands
+
+```
+      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
+      --force              Do not ask for confirmation
+      --format string      Formats the output using a Go template
+      --host string        Base URL to use (default "https://api.elastic-cloud.com")
+      --insecure           Skips all TLS validation
+      --message string     A message to set on cluster operation
+      --output string      Output format [text|json] (default "text")
+      --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
+      --pprof              Enables pprofing and saves the profile to pprof-20060102150405
+  -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elastic Cloud region
+      --timeout duration   Timeout to use on all HTTP calls (default 30s)
+      --trace              Enables tracing saves the trace to trace-20060102150405
+      --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)
+      --verbose            Enable verbose mode
+```
+
+### SEE ALSO
+
+* [ecctl deployment](ecctl_deployment.md)	 - Manages deployments
+

--- a/docs/ecctl_deployment_create.md
+++ b/docs/ecctl_deployment_create.md
@@ -26,14 +26,17 @@ $ cat deployment_example.json
                 "ref_id": "my-apm-instance",
                 "elasticsearch_cluster_ref_id": "my-es-cluster",
                 "plan": {
-                    "zone_count": 1,
                     "apm": {
                         "version": "6.8.4"
                     },
-                    "size":{
-                        "resource": "memory",
-                        "value": 512
-                    }
+                    "cluster_topology": [{
+                        "instance_configuration_id": "apm",
+                        "size": {
+                            "resource": "memory",
+                            "value": 512
+                        },
+                        "zone_count": 1
+                    }]
                 }
             }
         ],

--- a/docs/ecctl_deployment_create.md
+++ b/docs/ecctl_deployment_create.md
@@ -5,7 +5,7 @@ Creates a deployment from a file definition, allowing certain flag overrides
 ### Synopsis
 
 Creates a deployment from a file definition with an automatically generated idempotency token.
-On creation failure, please use the displayed idempotency token to retry the cluster creation.
+On creation failure, please use the displayed idempotency token to retry the cluster creation with --request-id=<token>.
 
 Read more about the deployment definition in https://www.elastic.co/guide/en/cloud-enterprise/current/Deployment_-_CRUD.html
 
@@ -89,6 +89,15 @@ $ cat deployment_example.json
 }
 $ ecctl deployment create -f deployment_example.json --version=7.4.1
 [...]
+
+## If th previous deployment creation failed
+$ ecctl deployment create -f deployment_example.json --name adeploy --version=7.4.1
+The deployment creation returned with an error, please use the displayed idempotency token
+to recreate the deployment resources
+Idempotency token: GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhGUSMXrEIzVXoBykSVRsKncNb
+unknown error (status 500)
+$ ecctl deployment create -f deployment_example.json --name adeploy --version=7.4.1 --request-id=GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhGUSMXrEIzVXoBykSVRsKncNb
+[...]
 ```
 
 ### Options
@@ -97,7 +106,7 @@ $ ecctl deployment create -f deployment_example.json --version=7.4.1
   -f, --file string         JSON file that contains JSON-style domain-specific deployment definition
   -h, --help                help for create
       --name string         Overrides the deployment name
-      --request-id string   Optional idempotency token - if two create requests share the same request_id token (min size 32 characters, max 128) then only one deployment will be created, the second request will return the info of that deployment (in the same format described below, but with blanks for auth-related fields)
+      --request-id string   Optional idempotency token - Can be found in the Stderr device when a previous deployment creation failed, for more information see the examples in the help command page
       --version string      Overrides all thee deployment's resources to the specified version
 ```
 

--- a/docs/ecctl_deployment_delete.md
+++ b/docs/ecctl_deployment_delete.md
@@ -1,10 +1,10 @@
 ## ecctl deployment delete
 
-deletes a previously stopped deployment from the platform
+Deletes a previously stopped deployment from the platform
 
 ### Synopsis
 
-deletes a previously stopped deployment from the platform
+Deletes a previously stopped deployment from the platform
 
 ```
 ecctl deployment delete <deployment-id> [flags]

--- a/pkg/deployment/create.go
+++ b/pkg/deployment/create.go
@@ -1,0 +1,159 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package deployment
+
+import (
+	"errors"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/client/deployments"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/elastic/ecctl/pkg/util"
+)
+
+// CreateParams is consumed by Create.
+type CreateParams struct {
+	*api.API
+
+	Request *models.DeploymentCreateRequest
+
+	RequestID string
+
+	// deployment Overrides
+	Overrides *CreateOverrides
+}
+
+// CreateOverrides represent the override settings to
+type CreateOverrides struct {
+	// If set, it will override the deployment name.
+	Name string
+
+	// If set, it will override the region when not present in the
+	// DeploymentCreateRequest.
+	// Note this behaviour is different from the rest of overrides
+	// since this field tends to be populated by the global region
+	// field which is implicit (by config) rather than explicit by flag.
+	Region string
+
+	// If set, it'll override all versions to match this one.
+	Version string
+}
+
+// Validate ensures the parameters are usable by Shutdown.
+func (params CreateParams) Validate() error {
+	var merr = new(multierror.Error)
+
+	if params.API == nil {
+		merr = multierror.Append(merr, util.ErrAPIReq)
+	}
+
+	if params.Request == nil {
+		merr = multierror.Append(merr, errors.New("deployment create: request payload cannot be empty"))
+	}
+
+	return merr.ErrorOrNil()
+}
+
+// Create performs a Create using the specified Request against the API.
+func Create(params CreateParams) (*models.DeploymentCreateResponse, error) {
+	if err := params.Validate(); err != nil {
+		return nil, err
+	}
+
+	setOverrides(params.Request, params.Overrides)
+
+	var id *string
+	if params.RequestID != "" {
+		id = &params.RequestID
+	}
+
+	res, res2, err := params.V1API.Deployments.CreateDeployment(
+		deployments.NewCreateDeploymentParams().
+			WithRequestID(id).
+			WithBody(params.Request),
+		params.AuthWriter,
+	)
+	if err != nil {
+		return nil, api.UnwrapError(err)
+	}
+
+	if res == nil {
+		return res2.Payload, nil
+	}
+
+	return res.Payload, nil
+}
+
+// setOverrides sets a series of overrides
+// nolint
+func setOverrides(req *models.DeploymentCreateRequest, overrides *CreateOverrides) {
+	if req == nil || overrides == nil || req.Resources == nil {
+		return
+	}
+
+	if overrides.Name != "" {
+		req.Name = overrides.Name
+	}
+
+	for _, resource := range req.Resources.Apm {
+		if resource.Region == nil && overrides.Region != "" {
+			resource.Region = &overrides.Region
+		}
+
+		if overrides.Version != "" {
+			if resource.Plan != nil && resource.Plan.Apm != nil {
+				resource.Plan.Apm.Version = overrides.Version
+			}
+		}
+	}
+
+	for _, resource := range req.Resources.Appsearch {
+		if resource.Region == nil && overrides.Region != "" {
+			resource.Region = &overrides.Region
+		}
+		if overrides.Version != "" {
+			if resource.Plan != nil && resource.Plan.Appsearch != nil {
+				resource.Plan.Appsearch.Version = overrides.Version
+			}
+		}
+	}
+
+	for _, resource := range req.Resources.Elasticsearch {
+		if resource.Region == nil && overrides.Region != "" {
+			resource.Region = &overrides.Region
+		}
+		if overrides.Version != "" {
+			if resource.Plan != nil && resource.Plan.Elasticsearch != nil {
+				resource.Plan.Elasticsearch.Version = overrides.Version
+			}
+		}
+	}
+
+	for _, resource := range req.Resources.Kibana {
+		if resource.Region == nil && overrides.Region != "" {
+			resource.Region = &overrides.Region
+		}
+		if overrides.Version != "" {
+			if resource.Plan != nil && resource.Plan.Kibana != nil {
+				resource.Plan.Kibana.Version = overrides.Version
+			}
+		}
+	}
+}

--- a/pkg/deployment/create_test.go
+++ b/pkg/deployment/create_test.go
@@ -1,0 +1,353 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package deployment
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/elastic/ecctl/pkg/util"
+)
+
+var basicESCluster = `{
+  "created": true,
+  "id": "0837d2cd080743e9be080bca163c0b92",
+  "name": "my example cluster",
+  "resources": [{
+    "cloud_id": "my_elasticsearch_cluster:MTkyLjE2OC40NC4xMC5pcC5lcy5pbzo5MjQzJDAxZmEyODU4NzZmNTRlNjk5ZGEzZDNkNmZkOGE4NGYxJGNhOGFjNjU1NWYwZDQzZDhiYTEwNDhjOThlYTYwMjY1",
+    "credentials": {
+      "password": "6n7Q5fXoFZDnpLOVPi5FnVLa",
+      "username": "elastic"
+    },
+    "id": "01fa285876f54e699da3d3d6fd8a84f1",
+    "kind": "elasticsearch",
+    "ref_id": "my-es-cluster",
+    "region": "ece-region"
+  }, {
+    "elasticsearch_cluster_ref_id": "my-es-cluster",
+    "id": "ca8ac6555f0d43d8ba1048c98ea60265",
+    "kind": "kibana",
+    "ref_id": "my-kibana-instance",
+    "region": "ece-region"
+  }]
+}`
+
+func TestCreate(t *testing.T) {
+	type args struct {
+		params CreateParams
+	}
+	tests := []struct {
+		name string
+		args args
+		want *models.DeploymentCreateResponse
+		err  error
+	}{
+		{
+			name: "fails on parameter validation",
+			err: &multierror.Error{Errors: []error{
+				util.ErrAPIReq,
+				errors.New("deployment create: request payload cannot be empty"),
+			}},
+		},
+		{
+			name: "fails on API error",
+			args: args{params: CreateParams{
+				API:     api.NewMock(mock.New500Response(mock.NewStringBody("error"))),
+				Request: &models.DeploymentCreateRequest{},
+			}},
+			err: errors.New("unknown error (status 500)"),
+		},
+		{
+			name: "succeeds",
+			args: args{params: CreateParams{
+				API: api.NewMock(mock.New200Response(mock.NewStringBody(basicESCluster))),
+				Request: &models.DeploymentCreateRequest{
+					Name: "my example cluster",
+					Resources: &models.DeploymentCreateResources{
+						Elasticsearch: []*models.ElasticsearchPayload{
+							{Plan: &models.ElasticsearchClusterPlan{
+								Elasticsearch: &models.ElasticsearchConfiguration{Version: "6.8.4"},
+							}},
+						},
+						Kibana: []*models.KibanaPayload{
+							{Plan: &models.KibanaClusterPlan{
+								Kibana: &models.KibanaConfiguration{Version: "6.8.4"},
+							}},
+						},
+					},
+				},
+			}},
+			want: &models.DeploymentCreateResponse{
+				Created: ec.Bool(true),
+				ID:      ec.String("0837d2cd080743e9be080bca163c0b92"),
+				Name:    ec.String("my example cluster"),
+				Resources: []*models.DeploymentResource{
+					{
+						CloudID: "my_elasticsearch_cluster:MTkyLjE2OC40NC4xMC5pcC5lcy5pbzo5MjQzJDAxZmEyODU4NzZmNTRlNjk5ZGEzZDNkNmZkOGE4NGYxJGNhOGFjNjU1NWYwZDQzZDhiYTEwNDhjOThlYTYwMjY1",
+						Credentials: &models.ClusterCredentials{
+							Password: "6n7Q5fXoFZDnpLOVPi5FnVLa",
+							Username: "elastic",
+						},
+						ID:     ec.String("01fa285876f54e699da3d3d6fd8a84f1"),
+						Kind:   ec.String("elasticsearch"),
+						RefID:  ec.String("my-es-cluster"),
+						Region: ec.String("ece-region"),
+					},
+					{
+						ElasticsearchClusterRefID: "my-es-cluster",
+						ID:                        ec.String("ca8ac6555f0d43d8ba1048c98ea60265"),
+						Kind:                      ec.String("kibana"),
+						RefID:                     ec.String("my-kibana-instance"),
+						Region:                    ec.String("ece-region"),
+					},
+				},
+			},
+		},
+		{
+			name: "succeeds with idempotency ID",
+			args: args{params: CreateParams{
+				RequestID: "1232131231",
+				API:       api.NewMock(mock.New200Response(mock.NewStringBody(basicESCluster))),
+				Request: &models.DeploymentCreateRequest{
+					Name: "my example cluster",
+					Resources: &models.DeploymentCreateResources{
+						Elasticsearch: []*models.ElasticsearchPayload{
+							{Plan: &models.ElasticsearchClusterPlan{
+								Elasticsearch: &models.ElasticsearchConfiguration{Version: "6.8.4"},
+							}},
+						},
+						Kibana: []*models.KibanaPayload{
+							{Plan: &models.KibanaClusterPlan{
+								Kibana: &models.KibanaConfiguration{Version: "6.8.4"},
+							}},
+						},
+					},
+				},
+			}},
+			want: &models.DeploymentCreateResponse{
+				Created: ec.Bool(true),
+				ID:      ec.String("0837d2cd080743e9be080bca163c0b92"),
+				Name:    ec.String("my example cluster"),
+				Resources: []*models.DeploymentResource{
+					{
+						CloudID: "my_elasticsearch_cluster:MTkyLjE2OC40NC4xMC5pcC5lcy5pbzo5MjQzJDAxZmEyODU4NzZmNTRlNjk5ZGEzZDNkNmZkOGE4NGYxJGNhOGFjNjU1NWYwZDQzZDhiYTEwNDhjOThlYTYwMjY1",
+						Credentials: &models.ClusterCredentials{
+							Password: "6n7Q5fXoFZDnpLOVPi5FnVLa",
+							Username: "elastic",
+						},
+						ID:     ec.String("01fa285876f54e699da3d3d6fd8a84f1"),
+						Kind:   ec.String("elasticsearch"),
+						RefID:  ec.String("my-es-cluster"),
+						Region: ec.String("ece-region"),
+					},
+					{
+						ElasticsearchClusterRefID: "my-es-cluster",
+						ID:                        ec.String("ca8ac6555f0d43d8ba1048c98ea60265"),
+						Kind:                      ec.String("kibana"),
+						RefID:                     ec.String("my-kibana-instance"),
+						Region:                    ec.String("ece-region"),
+					},
+				},
+			},
+		},
+		{
+			name: "succeeds with idempotency ID returns a 202 when the resource is still creating with the same ID",
+			args: args{params: CreateParams{
+				RequestID: "1232131231",
+				API:       api.NewMock(mock.New202Response(mock.NewStringBody(basicESCluster))),
+				Request: &models.DeploymentCreateRequest{
+					Name: "my example cluster",
+					Resources: &models.DeploymentCreateResources{
+						Elasticsearch: []*models.ElasticsearchPayload{
+							{Plan: &models.ElasticsearchClusterPlan{
+								Elasticsearch: &models.ElasticsearchConfiguration{Version: "6.8.4"},
+							}},
+						},
+						Kibana: []*models.KibanaPayload{
+							{Plan: &models.KibanaClusterPlan{
+								Kibana: &models.KibanaConfiguration{Version: "6.8.4"},
+							}},
+						},
+					},
+				},
+			}},
+			want: &models.DeploymentCreateResponse{
+				Created: ec.Bool(true),
+				ID:      ec.String("0837d2cd080743e9be080bca163c0b92"),
+				Name:    ec.String("my example cluster"),
+				Resources: []*models.DeploymentResource{
+					{
+						CloudID: "my_elasticsearch_cluster:MTkyLjE2OC40NC4xMC5pcC5lcy5pbzo5MjQzJDAxZmEyODU4NzZmNTRlNjk5ZGEzZDNkNmZkOGE4NGYxJGNhOGFjNjU1NWYwZDQzZDhiYTEwNDhjOThlYTYwMjY1",
+						Credentials: &models.ClusterCredentials{
+							Password: "6n7Q5fXoFZDnpLOVPi5FnVLa",
+							Username: "elastic",
+						},
+						ID:     ec.String("01fa285876f54e699da3d3d6fd8a84f1"),
+						Kind:   ec.String("elasticsearch"),
+						RefID:  ec.String("my-es-cluster"),
+						Region: ec.String("ece-region"),
+					},
+					{
+						ElasticsearchClusterRefID: "my-es-cluster",
+						ID:                        ec.String("ca8ac6555f0d43d8ba1048c98ea60265"),
+						Kind:                      ec.String("kibana"),
+						RefID:                     ec.String("my-kibana-instance"),
+						Region:                    ec.String("ece-region"),
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Create(tt.args.params)
+			if !reflect.DeepEqual(err, tt.err) {
+				t.Errorf("Create() error = %v, wantErr %v", err, tt.err)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Create() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_setOverrides(t *testing.T) {
+	var eceRegion = "ece-region"
+	type args struct {
+		req       *models.DeploymentCreateRequest
+		overrides *CreateOverrides
+	}
+	tests := []struct {
+		name string
+		args args
+		want *models.DeploymentCreateRequest
+	}{
+		{
+			name: "set name override",
+			args: args{
+				req: &models.DeploymentCreateRequest{
+					Name:      "Some",
+					Resources: &models.DeploymentCreateResources{},
+				},
+				overrides: &CreateOverrides{Name: "some other"},
+			},
+			want: &models.DeploymentCreateRequest{
+				Name:      "some other",
+				Resources: &models.DeploymentCreateResources{},
+			},
+		},
+		{
+			name: "set name, version and region override",
+			args: args{
+				overrides: &CreateOverrides{
+					Name:    "some other",
+					Version: "7.4.1",
+					Region:  eceRegion,
+				},
+				req: &models.DeploymentCreateRequest{
+					Name: "Some",
+					Resources: &models.DeploymentCreateResources{
+						Apm: []*models.ApmPayload{
+							{
+								Plan: &models.ApmPlan{
+									Apm: &models.ApmConfiguration{Version: "1.2.3"},
+								},
+							},
+						},
+						Appsearch: []*models.AppSearchPayload{
+							{
+								Plan: &models.AppSearchPlan{
+									Appsearch: &models.AppSearchConfiguration{Version: "1.2.3"},
+								},
+							},
+						},
+						Elasticsearch: []*models.ElasticsearchPayload{
+							{
+								Plan: &models.ElasticsearchClusterPlan{
+									Elasticsearch: &models.ElasticsearchConfiguration{Version: "1.2.3"},
+								},
+							},
+						},
+						Kibana: []*models.KibanaPayload{
+							{
+								Plan: &models.KibanaClusterPlan{
+									Kibana: &models.KibanaConfiguration{Version: "1.2.3"},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &models.DeploymentCreateRequest{
+				Name: "some other",
+				Resources: &models.DeploymentCreateResources{
+					Apm: []*models.ApmPayload{
+						{
+							Region: &eceRegion,
+							Plan: &models.ApmPlan{
+								Apm: &models.ApmConfiguration{Version: "7.4.1"},
+							},
+						},
+					},
+					Appsearch: []*models.AppSearchPayload{
+						{
+							Region: &eceRegion,
+							Plan: &models.AppSearchPlan{
+								Appsearch: &models.AppSearchConfiguration{Version: "7.4.1"},
+							},
+						},
+					},
+					Elasticsearch: []*models.ElasticsearchPayload{
+						{
+							Region: &eceRegion,
+							Plan: &models.ElasticsearchClusterPlan{
+								Elasticsearch: &models.ElasticsearchConfiguration{Version: "7.4.1"},
+							},
+						},
+					},
+					Kibana: []*models.KibanaPayload{
+						{
+							Region: &eceRegion,
+							Plan: &models.KibanaClusterPlan{
+								Kibana: &models.KibanaConfiguration{Version: "7.4.1"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var req = tt.args.req
+			setOverrides(req, tt.args.overrides)
+
+			if !reflect.DeepEqual(req, tt.want) {
+				t.Errorf("Create() = %v, want %v", req, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/util/random.go
+++ b/pkg/util/random.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package cmdutil
+package util
 
 import (
 	"math/rand"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds the deployment create command which enables the creation of
multi-resource deployments from a file definition in one API call. The
main features are two flag overrides (name and version) which allow the
file definition to be used more like a template.

Additionally, a `--request-id` flag is provided which enables setting an
idempotency token for the API calls. By default an auto-generated value
is sent to the API and printed to the Standard Error device so that
users can use the token in case the deployment creation fails.

```
$ dev-cli deployment create -f deployment_example.json --name marcdeploy --version=7.4.1
The deployment creation returned with an error, please use the displayed idempotency token
to recreate the deployment resources
Idempotency token: GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhGUSMXrEIzVXoBykSVRsKncNb
unknown error (status 500)
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
There's a small bug in the return code which returns a 201 instead of a 200 so the whole API call returns an error via the Go autogenerated code. Will push a fix on the SDK shortly.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
