### PR TITLE
deployment: Add restore command

### DIFF
--- a/cmd/deployment/restore.go
+++ b/cmd/deployment/restore.go
@@ -1,0 +1,62 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmddeployment
+
+import (
+	"github.com/spf13/cobra"
+
+	cmdutil "github.com/elastic/ecctl/cmd/util"
+	"github.com/elastic/ecctl/pkg/deployment"
+	"github.com/elastic/ecctl/pkg/ecctl"
+)
+
+const restoreLong = `Use --restore-snapshot to automatically restore the latest available Elasticsearch snapshot (if applicable)`
+
+var restoreExamples = `
+$ ecctl deployment restore 5c17ad7c8df73206baa54b6e2829d9bc
+{
+  "id": "5c17ad7c8df73206baa54b6e2829d9bc"
+}
+`[1:]
+
+var restoreCmd = &cobra.Command{
+	Use:     "restore <deployment-id>",
+	Short:   "Restores a previously shut down deployment and all of its associated sub-resources",
+	Long:    restoreLong,
+	Example: restoreExamples,
+	PreRunE: cmdutil.MinimumNArgsAndUUID(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		restoreSnapshot, _ := cmd.Flags().GetBool("restore-snapshot")
+
+		res, err := deployment.Restore(deployment.RestoreParams{
+			API:             ecctl.Get().API,
+			DeploymentID:    args[0],
+			RestoreSnapshot: restoreSnapshot,
+		})
+		if err != nil {
+			return err
+		}
+
+		return ecctl.Get().Formatter.Format("", res)
+	},
+}
+
+func init() {
+	Command.AddCommand(restoreCmd)
+	restoreCmd.Flags().Bool("restore-snapshot", false, "Restores snapshots for those resources that allow it (Elasticsearch)")
+}

--- a/docs/ecctl_deployment_restore.md
+++ b/docs/ecctl_deployment_restore.md
@@ -1,19 +1,30 @@
-## ecctl deployment
+## ecctl deployment restore
 
-Manages deployments
+Restores a previously shut down deployment and all of its associated sub-resources
 
 ### Synopsis
 
-Manages deployments
+Use --restore-snapshot to automatically restore the latest available Elasticsearch snapshot (if applicable)
 
 ```
-ecctl deployment [flags]
+ecctl deployment restore <deployment-id> [flags]
+```
+
+### Examples
+
+```
+$ ecctl deployment restore 5c17ad7c8df73206baa54b6e2829d9bc
+{
+  "id": "5c17ad7c8df73206baa54b6e2829d9bc"
+}
+
 ```
 
 ### Options
 
 ```
-  -h, --help   help for deployment
+  -h, --help               help for restore
+      --restore-snapshot   Restores snapshots for those resources that allow it (Elasticsearch)
 ```
 
 ### Options inherited from parent commands
@@ -39,16 +50,5 @@ ecctl deployment [flags]
 
 ### SEE ALSO
 
-* [ecctl](ecctl.md)	 - Elastic Cloud Control
-* [ecctl deployment apm](ecctl_deployment_apm.md)	 - Manages APM deployments
-* [ecctl deployment create](ecctl_deployment_create.md)	 - Creates a deployment from a file definition, allowing certain flag overrides
-* [ecctl deployment delete](ecctl_deployment_delete.md)	 - Deletes a previously stopped deployment from the platform
-* [ecctl deployment elasticsearch](ecctl_deployment_elasticsearch.md)	 - Manages Elasticsearch clusters
-* [ecctl deployment kibana](ecctl_deployment_kibana.md)	 - Manages Kibana clusters
-* [ecctl deployment list](ecctl_deployment_list.md)	 - Lists the platform's deployments
-* [ecctl deployment note](ecctl_deployment_note.md)	 - Manages a deployment's notes
-* [ecctl deployment restore](ecctl_deployment_restore.md)	 - Restores a previously shut down deployment and all of its associated sub-resources
-* [ecctl deployment search](ecctl_deployment_search.md)	 - Performs advanced deployment search using the Elasticsearch Query DSL
-* [ecctl deployment show](ecctl_deployment_show.md)	 - Shows the specified deployment resources
-* [ecctl deployment shutdown](ecctl_deployment_shutdown.md)	 - Shuts down a deployment and all of its associated sub-resources
+* [ecctl deployment](ecctl_deployment.md)	 - Manages deployments
 

--- a/pkg/deployment/restore.go
+++ b/pkg/deployment/restore.go
@@ -1,0 +1,70 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package deployment
+
+import (
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/client/deployments"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/elastic/ecctl/pkg/util"
+)
+
+// RestoreParams is consumed by Restore.
+type RestoreParams struct {
+	*api.API
+	DeploymentID string
+
+	RestoreSnapshot bool
+}
+
+// Validate ensures the parameters are usable by Restore.
+func (params RestoreParams) Validate() error {
+	var merr = new(multierror.Error)
+
+	if params.API == nil {
+		merr = multierror.Append(merr, util.ErrAPIReq)
+	}
+
+	if len(params.DeploymentID) != 32 {
+		merr = multierror.Append(merr, util.ErrDeploymentID)
+	}
+
+	return merr.ErrorOrNil()
+}
+
+// Restore restores a deployment which has been previously shut down.
+func Restore(params RestoreParams) (*models.DeploymentRestoreResponse, error) {
+	if err := params.Validate(); err != nil {
+		return nil, err
+	}
+
+	res, err := params.V1API.Deployments.RestoreDeployment(
+		deployments.NewRestoreDeploymentParams().
+			WithDeploymentID(params.DeploymentID).
+			WithRestoreSnapshot(ec.Bool(params.RestoreSnapshot)),
+		params.AuthWriter,
+	)
+	if err != nil {
+		return nil, api.UnwrapError(err)
+	}
+
+	return res.Payload, nil
+}

--- a/pkg/deployment/restore_test.go
+++ b/pkg/deployment/restore_test.go
@@ -1,0 +1,84 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package deployment
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/elastic/ecctl/pkg/util"
+)
+
+func TestRestore(t *testing.T) {
+	type args struct {
+		params RestoreParams
+	}
+	tests := []struct {
+		name string
+		args args
+		want *models.DeploymentRestoreResponse
+		err  error
+	}{
+		{
+			name: "fails on parameter validation",
+			err: &multierror.Error{Errors: []error{
+				util.ErrAPIReq,
+				util.ErrDeploymentID,
+			}},
+		},
+		{
+			name: "fails on API error",
+			args: args{params: RestoreParams{
+				API:          api.NewMock(mock.New500Response(mock.NewStringBody("error"))),
+				DeploymentID: util.ValidClusterID,
+			}},
+			err: errors.New("unknown error (status 500)"),
+		},
+		{
+			name: "Succeeds",
+			args: args{params: RestoreParams{
+				API: api.NewMock(mock.New200Response(mock.NewStructBody(models.DeploymentRestoreResponse{
+					ID: ec.String(util.ValidClusterID),
+				}))),
+				DeploymentID: util.ValidClusterID,
+			}},
+			want: &models.DeploymentRestoreResponse{
+				ID: ec.String(util.ValidClusterID),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Restore(tt.args.params)
+			if !reflect.DeepEqual(err, tt.err) {
+				t.Errorf("Restore() error = %v, wantErr %v", err, tt.err)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Restore() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail. -->
Adds the restore command with a --restore-snapshot boolean flag to
trigger snapshot restore on Elasticsearch instances if applicable.

### TODO
- [x] Rebase after elastic/ecctl#36 is merged and run `make docs`

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
