### PR TITLE
init: Skips TLS validation on API calls

### DIFF
--- a/pkg/ecctl/init.go
+++ b/pkg/ecctl/init.go
@@ -178,6 +178,9 @@ func InitConfig(params InitConfigParams) error {
 		Client:       params.Client,
 		OutputDevice: outputDevice,
 		ErrorDevice:  params.ErrWriter,
+		// Insecure is set to true by default to allow API calls against HTTPS
+		// endpoints with self-signed certificates.
+		Insecure: true,
 	}
 	if err := params.Viper.Unmarshal(&cfg); err != nil {
 		return err

--- a/pkg/ecctl/init_test.go
+++ b/pkg/ecctl/init_test.go
@@ -256,9 +256,10 @@ func TestInitConfig(t *testing.T) {
 				}))),
 			}},
 			wantSettings: map[string]interface{}{
-				"apikey": "somekey",
-				"host":   "https://ahost",
-				"output": "text",
+				"apikey":   "somekey",
+				"host":     "https://ahost",
+				"insecure": true,
+				"output":   "text",
 			},
 			wantOutput: disclaimer + missingConfigMsg + hostMsg +
 				formatChoiceMsg + "\n" + authChoiceMsg + "\n" + apiKeyMsg + "\n" +
@@ -291,10 +292,11 @@ func TestInitConfig(t *testing.T) {
 				),
 			}},
 			wantSettings: map[string]interface{}{
-				"host":   "https://ahost",
-				"output": "text",
-				"pass":   "apassword",
-				"user":   "auser",
+				"host":     "https://ahost",
+				"insecure": true,
+				"output":   "text",
+				"pass":     "apassword",
+				"user":     "auser",
 			},
 			wantOutput: disclaimer + missingConfigMsg + hostMsg +
 				formatChoiceMsg + "\n" + authChoiceMsg + "\n" + userMsg + passMsg +
@@ -322,9 +324,10 @@ func TestInitConfig(t *testing.T) {
 				}))),
 			}},
 			wantSettings: map[string]interface{}{
-				"apikey": "somekey",
-				"host":   "https://ahost",
-				"output": "text",
+				"apikey":   "somekey",
+				"host":     "https://ahost",
+				"insecure": true,
+				"output":   "text",
 			},
 			wantOutput: disclaimer +
 				fmt.Sprintf(settingsPathMsg, "test_files/userpassmodif.yaml") +
@@ -359,10 +362,11 @@ func TestInitConfig(t *testing.T) {
 				),
 			}},
 			wantSettings: map[string]interface{}{
-				"host":   "https://ahost",
-				"output": "text",
-				"pass":   "apassword",
-				"user":   "auser",
+				"host":     "https://ahost",
+				"insecure": true,
+				"output":   "text",
+				"pass":     "apassword",
+				"user":     "auser",
 			},
 			wantOutput: disclaimer +
 				fmt.Sprintf(settingsPathMsg, "test_files/apikeymodif.yaml") +


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Hardcodes the configuration for the `init` API calls to skip TLS
validation so that init works out of the box with self-signed TLS
certificates, common in ECE installations.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`ecctl init` doesn't work out of the box with self-signed certificates unless `--insecure` is specified.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
