### PR TITLE
docs: Change the term Kibana Cluster to instance

### DIFF
--- a/cmd/deployment/kibana/command.go
+++ b/cmd/deployment/kibana/command.go
@@ -26,7 +26,7 @@ import (
 // Command represents the top level kibana command.
 var Command = &cobra.Command{
 	Use:     "kibana",
-	Short:   "Manages Kibana clusters",
+	Short:   "Manages Kibana instances",
 	PreRunE: cobra.MaximumNArgs(0),
 	Run:     func(cmd *cobra.Command, args []string) { cmd.Help() },
 }

--- a/cmd/deployment/kibana/create.go
+++ b/cmd/deployment/kibana/create.go
@@ -34,7 +34,7 @@ import (
 
 var createKibanaCmd = &cobra.Command{
 	Use:   "create -f <definition.json>",
-	Short: "Creates a Kibana Cluster",
+	Short: "Creates a Kibana instance",
 
 	PreRunE: cobra.MaximumNArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -95,7 +95,7 @@ func parseKibanaDefinitionFile(fp string) (models.CreateKibanaRequest, error) {
 
 func init() {
 	createKibanaCmd.Flags().BoolP("track", "t", false, cmdutil.TrackFlagMessage)
-	createKibanaCmd.Flags().StringP("file-template", "f", "", "JSON file that contains the Kibana cluster definition")
+	createKibanaCmd.Flags().StringP("file-template", "f", "", "JSON file that contains the Kibana instance definition")
 	createKibanaCmd.Flags().String("id", "", "Optional ID to set for the Elasticsearch cluster (Overrides ID if present).")
-	createKibanaCmd.Flags().String("name", "", "Optional name to set for the Kibana cluster (Overrides name if present).")
+	createKibanaCmd.Flags().String("name", "", "Optional name to set for the Kibana instance (Overrides name if present).")
 }

--- a/cmd/deployment/kibana/delete.go
+++ b/cmd/deployment/kibana/delete.go
@@ -28,7 +28,7 @@ import (
 
 var deleteKibanaCmd = &cobra.Command{
 	Use:     "delete <cluster id>",
-	Short:   "Deletes a Kibana cluster",
+	Short:   "Deletes a Kibana instance",
 	PreRunE: cmdutil.MinimumNArgsAndUUID(1),
 
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/deployment/kibana/list.go
+++ b/cmd/deployment/kibana/list.go
@@ -53,6 +53,6 @@ var kibanaListCmd = &cobra.Command{
 
 func init() {
 	kibanaListCmd.Flags().BoolP("metadata", "m", false, "Shows deployment metadata")
-	kibanaListCmd.Flags().Int64P("size", "s", 100, "Sets the upper limit of Kibana clusters to return")
+	kibanaListCmd.Flags().Int64P("size", "s", 100, "Sets the upper limit of Kibana instances to return")
 	kibanaListCmd.Flags().StringP("version", "v", "", "Filters per version")
 }

--- a/cmd/deployment/kibana/list.go
+++ b/cmd/deployment/kibana/list.go
@@ -29,7 +29,7 @@ import (
 
 var kibanaListCmd = &cobra.Command{
 	Use:     "list",
-	Short:   "Returns the list of clusters for a region",
+	Short:   "Returns the list of kibana instances",
 	PreRunE: cobra.MaximumNArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		size, _ := cmd.Flags().GetInt64("size")

--- a/cmd/deployment/kibana/reallocate.go
+++ b/cmd/deployment/kibana/reallocate.go
@@ -27,8 +27,8 @@ import (
 
 var reallocateKibanaClusterCmd = &cobra.Command{
 	Use:     "reallocate <cluster id>",
-	Short:   "Reallocates the Kibana cluster nodes",
-	Long:    "Reallocates the Kibana cluster nodes. If no \"--instances\" are specified all of the nodes will be restarted",
+	Short:   "Reallocates Kibana instances",
+	Long:    "Reallocates Kibana instances. If no \"--instances\" are specified all of the nodes will be restarted",
 	PreRunE: cmdutil.MinimumNArgsAndUUID(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		instances, _ := cmd.Flags().GetStringSlice("instances")

--- a/cmd/deployment/kibana/restart.go
+++ b/cmd/deployment/kibana/restart.go
@@ -28,7 +28,7 @@ import (
 
 var restartKibanaCmd = &cobra.Command{
 	Use:     "restart <cluster id>",
-	Short:   "Restarts a Kibana cluster",
+	Short:   "Restarts a Kibana instance",
 	PreRunE: cmdutil.MinimumNArgsAndUUID(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		track, _ := cmd.Flags().GetBool("track")

--- a/cmd/deployment/kibana/resync.go
+++ b/cmd/deployment/kibana/resync.go
@@ -29,10 +29,10 @@ import (
 
 var resyncKibanaCmd = &cobra.Command{
 	Use:     "resync <cluster id>",
-	Short:   "Resynchronizes the search index and cache for the selected Kibana cluster",
+	Short:   "Resynchronizes the search index and cache for the selected Kibana instance",
 	PreRunE: cmdutil.MinimumNArgsAndUUID(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		fmt.Printf("Resynchronizing Kibana cluster: %s\n", args[0])
+		fmt.Printf("Resynchronizing Kibana instance: %s\n", args[0])
 		return kibana.Resync(kibana.DeploymentParams{
 			API: ecctl.Get().API,
 			ID:  args[0],

--- a/cmd/deployment/kibana/start.go
+++ b/cmd/deployment/kibana/start.go
@@ -31,7 +31,7 @@ import (
 
 var startKibanaCmd = &cobra.Command{
 	Use:     "start <cluster id>",
-	Short:   "Starts a Kibana cluster",
+	Short:   "Starts a Kibana instance",
 	PreRunE: cmdutil.MinimumNArgsAndUUID(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		c, err := kibana.Get(kibana.ClusterParams{

--- a/cmd/deployment/kibana/stop.go
+++ b/cmd/deployment/kibana/stop.go
@@ -28,7 +28,7 @@ import (
 
 var stopKibanaCmd = &cobra.Command{
 	Use:     "stop <cluster id>",
-	Short:   "Downscales a Kibana cluster, so that it no longer contains any running instances.",
+	Short:   "Downscales a Kibana instance",
 	PreRunE: cmdutil.MinimumNArgsAndUUID(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		track, _ := cmd.Flags().GetBool("track")

--- a/cmd/deployment/kibana/upgrade.go
+++ b/cmd/deployment/kibana/upgrade.go
@@ -28,7 +28,7 @@ import (
 
 var upgradeKibanaCmd = &cobra.Command{
 	Use:     "upgrade <cluster id>>",
-	Short:   "Upgrades the Kibana cluster to the same version as the Elasticsearch one",
+	Short:   "Upgrades the Kibana instance to the same version as the Elasticsearch one",
 	PreRunE: cmdutil.MinimumNArgsAndUUID(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		track, _ := cmd.Flags().GetBool("track")

--- a/docs/ecctl_deployment.md
+++ b/docs/ecctl_deployment.md
@@ -44,7 +44,7 @@ ecctl deployment [flags]
 * [ecctl deployment create](ecctl_deployment_create.md)	 - Creates a deployment from a file definition, allowing certain flag overrides
 * [ecctl deployment delete](ecctl_deployment_delete.md)	 - Deletes a previously stopped deployment from the platform
 * [ecctl deployment elasticsearch](ecctl_deployment_elasticsearch.md)	 - Manages Elasticsearch clusters
-* [ecctl deployment kibana](ecctl_deployment_kibana.md)	 - Manages Kibana clusters
+* [ecctl deployment kibana](ecctl_deployment_kibana.md)	 - Manages Kibana instances
 * [ecctl deployment list](ecctl_deployment_list.md)	 - Lists the platform's deployments
 * [ecctl deployment note](ecctl_deployment_note.md)	 - Manages a deployment's notes
 * [ecctl deployment restore](ecctl_deployment_restore.md)	 - Restores a previously shut down deployment and all of its associated sub-resources

--- a/docs/ecctl_deployment_kibana.md
+++ b/docs/ecctl_deployment_kibana.md
@@ -1,10 +1,10 @@
 ## ecctl deployment kibana
 
-Manages Kibana clusters
+Manages Kibana instances
 
 ### Synopsis
 
-Manages Kibana clusters
+Manages Kibana instances
 
 ```
 ecctl deployment kibana [flags]
@@ -40,16 +40,16 @@ ecctl deployment kibana [flags]
 ### SEE ALSO
 
 * [ecctl deployment](ecctl_deployment.md)	 - Manages deployments
-* [ecctl deployment kibana create](ecctl_deployment_kibana_create.md)	 - Creates a Kibana Cluster
-* [ecctl deployment kibana delete](ecctl_deployment_kibana_delete.md)	 - Deletes a Kibana cluster
+* [ecctl deployment kibana create](ecctl_deployment_kibana_create.md)	 - Creates a Kibana instance
+* [ecctl deployment kibana delete](ecctl_deployment_kibana_delete.md)	 - Deletes a Kibana instance
 * [ecctl deployment kibana enable](ecctl_deployment_kibana_enable.md)	 - Enables a kibana instance in the selected deployment
 * [ecctl deployment kibana list](ecctl_deployment_kibana_list.md)	 - Returns the list of clusters for a region
 * [ecctl deployment kibana plan](ecctl_deployment_kibana_plan.md)	 - Manages Kibana plans
-* [ecctl deployment kibana reallocate](ecctl_deployment_kibana_reallocate.md)	 - Reallocates the Kibana cluster nodes
-* [ecctl deployment kibana restart](ecctl_deployment_kibana_restart.md)	 - Restarts a Kibana cluster
-* [ecctl deployment kibana resync](ecctl_deployment_kibana_resync.md)	 - Resynchronizes the search index and cache for the selected Kibana cluster
+* [ecctl deployment kibana reallocate](ecctl_deployment_kibana_reallocate.md)	 - Reallocates Kibana instances
+* [ecctl deployment kibana restart](ecctl_deployment_kibana_restart.md)	 - Restarts a Kibana instance
+* [ecctl deployment kibana resync](ecctl_deployment_kibana_resync.md)	 - Resynchronizes the search index and cache for the selected Kibana instance
 * [ecctl deployment kibana show](ecctl_deployment_kibana_show.md)	 - Returns the cluster information
-* [ecctl deployment kibana start](ecctl_deployment_kibana_start.md)	 - Starts a Kibana cluster
-* [ecctl deployment kibana stop](ecctl_deployment_kibana_stop.md)	 - Downscales a Kibana cluster, so that it no longer contains any running instances.
-* [ecctl deployment kibana upgrade](ecctl_deployment_kibana_upgrade.md)	 - Upgrades the Kibana cluster to the same version as the Elasticsearch one
+* [ecctl deployment kibana start](ecctl_deployment_kibana_start.md)	 - Starts a Kibana instance
+* [ecctl deployment kibana stop](ecctl_deployment_kibana_stop.md)	 - Downscales a Kibana instance
+* [ecctl deployment kibana upgrade](ecctl_deployment_kibana_upgrade.md)	 - Upgrades the Kibana instance to the same version as the Elasticsearch one
 

--- a/docs/ecctl_deployment_kibana.md
+++ b/docs/ecctl_deployment_kibana.md
@@ -43,7 +43,7 @@ ecctl deployment kibana [flags]
 * [ecctl deployment kibana create](ecctl_deployment_kibana_create.md)	 - Creates a Kibana instance
 * [ecctl deployment kibana delete](ecctl_deployment_kibana_delete.md)	 - Deletes a Kibana instance
 * [ecctl deployment kibana enable](ecctl_deployment_kibana_enable.md)	 - Enables a kibana instance in the selected deployment
-* [ecctl deployment kibana list](ecctl_deployment_kibana_list.md)	 - Returns the list of clusters for a region
+* [ecctl deployment kibana list](ecctl_deployment_kibana_list.md)	 - Returns the list of kibana instances
 * [ecctl deployment kibana plan](ecctl_deployment_kibana_plan.md)	 - Manages Kibana plans
 * [ecctl deployment kibana reallocate](ecctl_deployment_kibana_reallocate.md)	 - Reallocates Kibana instances
 * [ecctl deployment kibana restart](ecctl_deployment_kibana_restart.md)	 - Restarts a Kibana instance

--- a/docs/ecctl_deployment_kibana_create.md
+++ b/docs/ecctl_deployment_kibana_create.md
@@ -1,10 +1,10 @@
 ## ecctl deployment kibana create
 
-Creates a Kibana Cluster
+Creates a Kibana instance
 
 ### Synopsis
 
-Creates a Kibana Cluster
+Creates a Kibana instance
 
 ```
 ecctl deployment kibana create -f <definition.json> [flags]
@@ -13,10 +13,10 @@ ecctl deployment kibana create -f <definition.json> [flags]
 ### Options
 
 ```
-  -f, --file-template string   JSON file that contains the Kibana cluster definition
+  -f, --file-template string   JSON file that contains the Kibana instance definition
   -h, --help                   help for create
       --id string              Optional ID to set for the Elasticsearch cluster (Overrides ID if present).
-      --name string            Optional name to set for the Kibana cluster (Overrides name if present).
+      --name string            Optional name to set for the Kibana instance (Overrides name if present).
   -t, --track                  Tracks the progress of the performed task
 ```
 
@@ -43,5 +43,5 @@ ecctl deployment kibana create -f <definition.json> [flags]
 
 ### SEE ALSO
 
-* [ecctl deployment kibana](ecctl_deployment_kibana.md)	 - Manages Kibana clusters
+* [ecctl deployment kibana](ecctl_deployment_kibana.md)	 - Manages Kibana instances
 

--- a/docs/ecctl_deployment_kibana_delete.md
+++ b/docs/ecctl_deployment_kibana_delete.md
@@ -1,10 +1,10 @@
 ## ecctl deployment kibana delete
 
-Deletes a Kibana cluster
+Deletes a Kibana instance
 
 ### Synopsis
 
-Deletes a Kibana cluster
+Deletes a Kibana instance
 
 ```
 ecctl deployment kibana delete <cluster id> [flags]
@@ -41,5 +41,5 @@ ecctl deployment kibana delete <cluster id> [flags]
 
 ### SEE ALSO
 
-* [ecctl deployment kibana](ecctl_deployment_kibana.md)	 - Manages Kibana clusters
+* [ecctl deployment kibana](ecctl_deployment_kibana.md)	 - Manages Kibana instances
 

--- a/docs/ecctl_deployment_kibana_enable.md
+++ b/docs/ecctl_deployment_kibana_enable.md
@@ -40,5 +40,5 @@ ecctl deployment kibana enable <deployment id> [flags]
 
 ### SEE ALSO
 
-* [ecctl deployment kibana](ecctl_deployment_kibana.md)	 - Manages Kibana clusters
+* [ecctl deployment kibana](ecctl_deployment_kibana.md)	 - Manages Kibana instances
 

--- a/docs/ecctl_deployment_kibana_list.md
+++ b/docs/ecctl_deployment_kibana_list.md
@@ -15,7 +15,7 @@ ecctl deployment kibana list [flags]
 ```
   -h, --help             help for list
   -m, --metadata         Shows deployment metadata
-  -s, --size int         Sets the upper limit of Kibana clusters to return (default 100)
+  -s, --size int         Sets the upper limit of Kibana instances to return (default 100)
   -v, --version string   Filters per version
 ```
 
@@ -42,5 +42,5 @@ ecctl deployment kibana list [flags]
 
 ### SEE ALSO
 
-* [ecctl deployment kibana](ecctl_deployment_kibana.md)	 - Manages Kibana clusters
+* [ecctl deployment kibana](ecctl_deployment_kibana.md)	 - Manages Kibana instances
 

--- a/docs/ecctl_deployment_kibana_list.md
+++ b/docs/ecctl_deployment_kibana_list.md
@@ -1,10 +1,10 @@
 ## ecctl deployment kibana list
 
-Returns the list of clusters for a region
+Returns the list of kibana instances
 
 ### Synopsis
 
-Returns the list of clusters for a region
+Returns the list of kibana instances
 
 ```
 ecctl deployment kibana list [flags]

--- a/docs/ecctl_deployment_kibana_plan.md
+++ b/docs/ecctl_deployment_kibana_plan.md
@@ -39,6 +39,6 @@ ecctl deployment kibana plan [flags]
 
 ### SEE ALSO
 
-* [ecctl deployment kibana](ecctl_deployment_kibana.md)	 - Manages Kibana clusters
+* [ecctl deployment kibana](ecctl_deployment_kibana.md)	 - Manages Kibana instances
 * [ecctl deployment kibana plan monitor](ecctl_deployment_kibana_plan_monitor.md)	 - Monitors the pending plan
 

--- a/docs/ecctl_deployment_kibana_reallocate.md
+++ b/docs/ecctl_deployment_kibana_reallocate.md
@@ -1,10 +1,10 @@
 ## ecctl deployment kibana reallocate
 
-Reallocates the Kibana cluster nodes
+Reallocates Kibana instances
 
 ### Synopsis
 
-Reallocates the Kibana cluster nodes. If no "--instances" are specified all of the nodes will be restarted
+Reallocates Kibana instances. If no "--instances" are specified all of the nodes will be restarted
 
 ```
 ecctl deployment kibana reallocate <cluster id> [flags]
@@ -40,5 +40,5 @@ ecctl deployment kibana reallocate <cluster id> [flags]
 
 ### SEE ALSO
 
-* [ecctl deployment kibana](ecctl_deployment_kibana.md)	 - Manages Kibana clusters
+* [ecctl deployment kibana](ecctl_deployment_kibana.md)	 - Manages Kibana instances
 

--- a/docs/ecctl_deployment_kibana_restart.md
+++ b/docs/ecctl_deployment_kibana_restart.md
@@ -1,10 +1,10 @@
 ## ecctl deployment kibana restart
 
-Restarts a Kibana cluster
+Restarts a Kibana instance
 
 ### Synopsis
 
-Restarts a Kibana cluster
+Restarts a Kibana instance
 
 ```
 ecctl deployment kibana restart <cluster id> [flags]
@@ -40,5 +40,5 @@ ecctl deployment kibana restart <cluster id> [flags]
 
 ### SEE ALSO
 
-* [ecctl deployment kibana](ecctl_deployment_kibana.md)	 - Manages Kibana clusters
+* [ecctl deployment kibana](ecctl_deployment_kibana.md)	 - Manages Kibana instances
 

--- a/docs/ecctl_deployment_kibana_resync.md
+++ b/docs/ecctl_deployment_kibana_resync.md
@@ -1,10 +1,10 @@
 ## ecctl deployment kibana resync
 
-Resynchronizes the search index and cache for the selected Kibana cluster
+Resynchronizes the search index and cache for the selected Kibana instance
 
 ### Synopsis
 
-Resynchronizes the search index and cache for the selected Kibana cluster
+Resynchronizes the search index and cache for the selected Kibana instance
 
 ```
 ecctl deployment kibana resync <cluster id> [flags]
@@ -39,5 +39,5 @@ ecctl deployment kibana resync <cluster id> [flags]
 
 ### SEE ALSO
 
-* [ecctl deployment kibana](ecctl_deployment_kibana.md)	 - Manages Kibana clusters
+* [ecctl deployment kibana](ecctl_deployment_kibana.md)	 - Manages Kibana instances
 

--- a/docs/ecctl_deployment_kibana_show.md
+++ b/docs/ecctl_deployment_kibana_show.md
@@ -44,5 +44,5 @@ ecctl deployment kibana show <cluster id> [flags]
 
 ### SEE ALSO
 
-* [ecctl deployment kibana](ecctl_deployment_kibana.md)	 - Manages Kibana clusters
+* [ecctl deployment kibana](ecctl_deployment_kibana.md)	 - Manages Kibana instances
 

--- a/docs/ecctl_deployment_kibana_start.md
+++ b/docs/ecctl_deployment_kibana_start.md
@@ -1,10 +1,10 @@
 ## ecctl deployment kibana start
 
-Starts a Kibana cluster
+Starts a Kibana instance
 
 ### Synopsis
 
-Starts a Kibana cluster
+Starts a Kibana instance
 
 ```
 ecctl deployment kibana start <cluster id> [flags]
@@ -40,5 +40,5 @@ ecctl deployment kibana start <cluster id> [flags]
 
 ### SEE ALSO
 
-* [ecctl deployment kibana](ecctl_deployment_kibana.md)	 - Manages Kibana clusters
+* [ecctl deployment kibana](ecctl_deployment_kibana.md)	 - Manages Kibana instances
 

--- a/docs/ecctl_deployment_kibana_stop.md
+++ b/docs/ecctl_deployment_kibana_stop.md
@@ -1,10 +1,10 @@
 ## ecctl deployment kibana stop
 
-Downscales a Kibana cluster, so that it no longer contains any running instances.
+Downscales a Kibana instance
 
 ### Synopsis
 
-Downscales a Kibana cluster, so that it no longer contains any running instances.
+Downscales a Kibana instance
 
 ```
 ecctl deployment kibana stop <cluster id> [flags]
@@ -40,5 +40,5 @@ ecctl deployment kibana stop <cluster id> [flags]
 
 ### SEE ALSO
 
-* [ecctl deployment kibana](ecctl_deployment_kibana.md)	 - Manages Kibana clusters
+* [ecctl deployment kibana](ecctl_deployment_kibana.md)	 - Manages Kibana instances
 

--- a/docs/ecctl_deployment_kibana_upgrade.md
+++ b/docs/ecctl_deployment_kibana_upgrade.md
@@ -1,10 +1,10 @@
 ## ecctl deployment kibana upgrade
 
-Upgrades the Kibana cluster to the same version as the Elasticsearch one
+Upgrades the Kibana instance to the same version as the Elasticsearch one
 
 ### Synopsis
 
-Upgrades the Kibana cluster to the same version as the Elasticsearch one
+Upgrades the Kibana instance to the same version as the Elasticsearch one
 
 ```
 ecctl deployment kibana upgrade <cluster id>> [flags]
@@ -40,5 +40,5 @@ ecctl deployment kibana upgrade <cluster id>> [flags]
 
 ### SEE ALSO
 
-* [ecctl deployment kibana](ecctl_deployment_kibana.md)	 - Manages Kibana clusters
+* [ecctl deployment kibana](ecctl_deployment_kibana.md)	 - Manages Kibana instances
 

--- a/pkg/deployment/kibana/create_test.go
+++ b/pkg/deployment/kibana/create_test.go
@@ -129,7 +129,7 @@ func TestCreate(t *testing.T) {
 			},
 		},
 		{
-			name: "Succeeds creating a kibana cluster with no tracking",
+			name: "Succeeds creating a kibana instance with no tracking",
 			args: args{params: CreateParams{
 				CreateKibanaRequest: NewKibanaBody(NewKibanaBodyParams{}),
 				DeploymentParams: DeploymentParams{
@@ -147,7 +147,7 @@ func TestCreate(t *testing.T) {
 			},
 		},
 		{
-			name: "Succeeds creating a kibana cluster with tracking",
+			name: "Succeeds creating a kibana instance with tracking",
 			args: args{params: CreateParams{
 				CreateKibanaRequest: NewKibanaBody(NewKibanaBodyParams{}),
 				DeploymentParams: DeploymentParams{

--- a/pkg/deployment/kibana/enable.go
+++ b/pkg/deployment/kibana/enable.go
@@ -26,7 +26,7 @@ import (
 	"github.com/elastic/ecctl/pkg/util"
 )
 
-// Enable creates a new kibana cluster in the specified deployment
+// Enable creates a new kibana instance in the specified deployment
 func Enable(params DeploymentParams) (*models.ClusterCrudResponse, error) {
 	if err := params.Validate(); err != nil {
 		return nil, err

--- a/pkg/deployment/kibana/read.go
+++ b/pkg/deployment/kibana/read.go
@@ -56,7 +56,7 @@ func (params ListParams) Validate() error {
 	return merr.ErrorOrNil()
 }
 
-// Get returns the kibana cluster
+// Get returns the kibana instance
 func Get(params ClusterParams) (*models.KibanaClusterInfo, error) {
 	if err := params.Validate(); err != nil {
 		return nil, err
@@ -79,7 +79,7 @@ func Get(params ClusterParams) (*models.KibanaClusterInfo, error) {
 	return res.Payload, nil
 }
 
-// List lists all the kibana clusters matching the filters
+// List lists all the kibana instances matching the filters
 func List(params ListParams) (*models.KibanaClustersInfo, error) {
 	if err := params.Validate(); err != nil {
 		return nil, err

--- a/pkg/deployment/kibana/reallocate.go
+++ b/pkg/deployment/kibana/reallocate.go
@@ -49,7 +49,7 @@ func (params ReallocateParams) Validate() error {
 	return merr.ErrorOrNil()
 }
 
-// Reallocate will reallocate the Kibana cluster instances, if no
+// Reallocate will reallocate the Kibana instance instances, if no
 // Instances are specified, all of the instances will be moved.
 func Reallocate(params ReallocateParams) error {
 	if err := params.Validate(); err != nil {

--- a/pkg/deployment/kibana/reallocate_test.go
+++ b/pkg/deployment/kibana/reallocate_test.go
@@ -149,7 +149,7 @@ func TestReallocate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "should fail if get kibana cluster fails",
+			name: "should fail if get kibana instance fails",
 			params: ReallocateParams{
 				DeploymentParams: DeploymentParams{
 					ID: "853cfe89c4a74fb6a6477574d3c03771",

--- a/pkg/deployment/kibana/restart.go
+++ b/pkg/deployment/kibana/restart.go
@@ -25,7 +25,7 @@ import (
 	"github.com/elastic/ecctl/pkg/util"
 )
 
-// Restart restarts a Kibana cluster
+// Restart restarts a Kibana instance
 func Restart(params DeploymentParams) error {
 	if err := params.Validate(); err != nil {
 		return err

--- a/pkg/deployment/kibana/resync.go
+++ b/pkg/deployment/kibana/resync.go
@@ -24,7 +24,7 @@ import (
 )
 
 // Resync forces indexer to immediately resynchronize the search index
-// and cache for a given Kibana cluster.
+// and cache for a given Kibana instance.
 func Resync(params DeploymentParams) error {
 	if err := params.Validate(); err != nil {
 		return err

--- a/pkg/deployment/kibana/resync_test.go
+++ b/pkg/deployment/kibana/resync_test.go
@@ -83,7 +83,7 @@ func TestResync(t *testing.T) {
 			},
 		},
 		{
-			name: "Succeeds to resynchronize Kibana cluster without errors",
+			name: "Succeeds to resynchronize Kibana instance without errors",
 			args: args{params: DeploymentParams{
 				ID: "d324608c97154bdba2dff97511d40368",
 				API: api.NewMock(mock.Response{Response: http.Response{

--- a/pkg/platform/allocator/vacate_full_test.go
+++ b/pkg/platform/allocator/vacate_full_test.go
@@ -78,7 +78,7 @@ func TestVacate(t *testing.T) {
 			),
 		},
 		{
-			name: "Succeeds moving a single kibana cluster from a single allocator",
+			name: "Succeeds moving a single kibana instance from a single allocator",
 			args: args{
 				buf: sdkSync.NewBuffer(),
 				params: newVacateTestCase(t, vacateCase{

--- a/pkg/platform/allocator/vacate_responses_test.go
+++ b/pkg/platform/allocator/vacate_responses_test.go
@@ -340,7 +340,7 @@ type vacateCaseClusters struct {
 	Allocator string
 	// Elasticsearch clusters that will be simulated
 	elasticsearch []vacateCaseClusterConfig
-	// Kibana clusters that will be simulated
+	// Kibana instances that will be simulated
 	kibana []vacateCaseClusterConfig
 	// APM clusters that will be simulated
 	apm []vacateCaseClusterConfig

--- a/pkg/platform/allocator/vacate_test.go
+++ b/pkg/platform/allocator/vacate_test.go
@@ -704,7 +704,7 @@ func TestVacateCluster(t *testing.T) {
 			),
 		},
 		{
-			name: "Succeeds with a kibana cluster",
+			name: "Succeeds with a kibana instance",
 			args: args{
 				buf: new(bytes.Buffer),
 				params: &VacateClusterParams{
@@ -742,7 +742,7 @@ func TestVacateCluster(t *testing.T) {
 			),
 		},
 		{
-			name: "Moving kibana cluster fails",
+			name: "Moving kibana instance fails",
 			args: args{
 				buf: new(bytes.Buffer),
 				params: &VacateClusterParams{


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Kibana can have multiple instances but they do not form a cluster.
Changed the documentation to refer them as Kibana Instances

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Documentation