### PR TITLE
init: Remove mentions of ESS in config bootstrap

### DIFF
--- a/docs/ecctl-getting-started.asciidoc
+++ b/docs/ecctl-getting-started.asciidoc
@@ -113,7 +113,7 @@ $ ecctl init
 Welcome to the Elastic Cloud CLI! This command will guide you through authenticating and setting some default values.
 
 Missing configuration file, would you like to initialise it? [y/n]: y
-Enter the URL of the Elastic Cloud API or your ECE installation: https://api.elastic-cloud.com
+Enter the URL of your ECE installation: http://192.168.44.10:12300
 
 What default output format would you like?
   [1] text - Human-readable output format, commands with no output templates defined will fall back to JSON.

--- a/pkg/ecctl/init.go
+++ b/pkg/ecctl/init.go
@@ -56,7 +56,7 @@ const (
 	missingConfigMsg  = `Missing configuration file, would you like to initialise it? [y/n]: `
 	existingConfigMsg = `Would you like to change your current settings? [y/n]: `
 
-	hostMsg = "Enter the URL of the Elastic Cloud API or your ECE installation: "
+	hostMsg = "Enter the URL of your ECE installation: "
 
 	apiKeyMsg = "Paste your API Key and press enter: "
 	userMsg   = "Type in your username: "


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Removes any mention of the ESS service in the init command and the
default ESS API URL.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Resolves #43 

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Documentation
