### PR TITLE
deployment: Fix show resource type command

### DIFF
--- a/cmd/deployment/show.go
+++ b/cmd/deployment/show.go
@@ -84,7 +84,7 @@ var showCmd = &cobra.Command{
 func init() {
 	Command.AddCommand(showCmd)
 	showCmd.Flags().String("type", "", "Optional deployment type to show resource information (elasticsearch, kibana, apm, or appsearch)")
-	showCmd.Flags().String("ref-id", "", "Optional deployment type RefId, if not set, the RefId will be auto-discovered through an API call")
+	showCmd.Flags().String("ref-id", "", "Optional deployment type RefId, if not set, the RefId will be auto-discovered")
 	showCmd.Flags().Bool("plans", false, "Shows the deployment plans")
 	showCmd.Flags().Bool("plan-logs", false, "Shows the deployment plan logs")
 	showCmd.Flags().Bool("plan-defaults", false, "Shows the deployment plan defaults")

--- a/docs/ecctl_deployment_show.md
+++ b/docs/ecctl_deployment_show.md
@@ -16,6 +16,9 @@ ecctl deployment show <deployment-id> [flags]
 
 * Shows kibana resource information from a given deployment:
   ecctl deployment show <deployment-id> --type kibana
+
+* Shows apm resource information from a given deployment with a specified ref-id.
+  ecctl deployment show <deployment-id> --type apm --ref-id apm-server
 ```
 
 ### Options
@@ -26,6 +29,7 @@ ecctl deployment show <deployment-id> [flags]
       --plan-defaults   Shows the deployment plan defaults
       --plan-logs       Shows the deployment plan logs
       --plans           Shows the deployment plans
+      --ref-id string   Optional deployment type RefId, if not set, the RefId will be auto-discovered through an API call
   -s, --settings        Shows the deployment settings
       --type string     Optional deployment type to show resource information (elasticsearch, kibana, apm, or appsearch)
 ```

--- a/docs/ecctl_deployment_show.md
+++ b/docs/ecctl_deployment_show.md
@@ -29,7 +29,7 @@ ecctl deployment show <deployment-id> [flags]
       --plan-defaults   Shows the deployment plan defaults
       --plan-logs       Shows the deployment plan logs
       --plans           Shows the deployment plans
-      --ref-id string   Optional deployment type RefId, if not set, the RefId will be auto-discovered through an API call
+      --ref-id string   Optional deployment type RefId, if not set, the RefId will be auto-discovered
   -s, --settings        Shows the deployment settings
       --type string     Optional deployment type to show resource information (elasticsearch, kibana, apm, or appsearch)
 ```

--- a/pkg/deployment/get.go
+++ b/pkg/deployment/get.go
@@ -37,6 +37,10 @@ type GetParams struct {
 
 	// Optional parameters
 	deputil.QueryParams
+
+	// RefID, when specified, skips auto-discovering the deployment resource
+	// RefID and instead uses the one that's passed.
+	RefID string
 }
 
 // Validate ensures that the parameters are usable by the consuming function.
@@ -49,6 +53,7 @@ func (params GetParams) Validate() error {
 	if len(params.DeploymentID) != 32 {
 		merr = multierror.Append(merr, deputil.NewInvalidDeploymentIDError(params.DeploymentID))
 	}
+
 	return merr.ErrorOrNil()
 }
 
@@ -72,6 +77,7 @@ func Get(params GetParams) (*models.DeploymentGetResponse, error) {
 	if err != nil {
 		return nil, api.UnwrapError(err)
 	}
+
 	return res.Payload, nil
 }
 
@@ -84,7 +90,7 @@ func GetApm(params GetParams) (*models.ApmResourceInfo, error) {
 	res, err := params.API.V1API.Deployments.GetDeploymentApmResourceInfo(
 		deployments.NewGetDeploymentApmResourceInfoParams().
 			WithDeploymentID(params.DeploymentID).
-			WithRefID("main-apm").
+			WithRefID(params.RefID).
 			WithShowPlans(ec.Bool(params.ShowPlans)).
 			WithShowPlanDefaults(ec.Bool(params.ShowPlanDefaults)).
 			WithShowPlanLogs(ec.Bool(params.ShowPlanLogs)).
@@ -107,7 +113,7 @@ func GetAppSearch(params GetParams) (*models.AppSearchResourceInfo, error) {
 	res, err := params.API.V1API.Deployments.GetDeploymentAppsearchResourceInfo(
 		deployments.NewGetDeploymentAppsearchResourceInfoParams().
 			WithDeploymentID(params.DeploymentID).
-			WithRefID("main-appsearch").
+			WithRefID(params.RefID).
 			WithShowPlans(ec.Bool(params.ShowPlans)).
 			WithShowPlanDefaults(ec.Bool(params.ShowPlanDefaults)).
 			WithShowPlanLogs(ec.Bool(params.ShowPlanLogs)).
@@ -130,7 +136,7 @@ func GetElasticsearch(params GetParams) (*models.ElasticsearchResourceInfo, erro
 	res, err := params.API.V1API.Deployments.GetDeploymentEsResourceInfo(
 		deployments.NewGetDeploymentEsResourceInfoParams().
 			WithDeploymentID(params.DeploymentID).
-			WithRefID("main-elasticsearch").
+			WithRefID(params.RefID).
 			WithShowPlans(ec.Bool(params.ShowPlans)).
 			WithShowPlanDefaults(ec.Bool(params.ShowPlanDefaults)).
 			WithShowPlanLogs(ec.Bool(params.ShowPlanLogs)).
@@ -154,7 +160,7 @@ func GetKibana(params GetParams) (*models.KibanaResourceInfo, error) {
 	res, err := params.API.V1API.Deployments.GetDeploymentKibResourceInfo(
 		deployments.NewGetDeploymentKibResourceInfoParams().
 			WithDeploymentID(params.DeploymentID).
-			WithRefID("main-kibana").
+			WithRefID(params.RefID).
 			WithShowPlans(ec.Bool(params.ShowPlans)).
 			WithShowPlanDefaults(ec.Bool(params.ShowPlanDefaults)).
 			WithShowPlanLogs(ec.Bool(params.ShowPlanLogs)).

--- a/pkg/deployment/get_resource.go
+++ b/pkg/deployment/get_resource.go
@@ -19,8 +19,6 @@ package deployment
 
 import (
 	"fmt"
-
-	"github.com/hashicorp/go-multierror"
 )
 
 // GetResourceParams is consumed by GetResource.
@@ -28,14 +26,6 @@ type GetResourceParams struct {
 	GetParams
 
 	Type string
-}
-
-// Validate ensures that the parameters are usable by the consuming function.
-func (params GetResourceParams) Validate() error {
-	var merr = new(multierror.Error)
-	merr = multierror.Append(merr, params.GetParams.Validate())
-
-	return merr.ErrorOrNil()
 }
 
 // GetResource is a high level function which either returns the top level

--- a/pkg/deployment/get_resource.go
+++ b/pkg/deployment/get_resource.go
@@ -1,0 +1,112 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package deployment
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+// GetResourceParams is consumed by GetResource.
+type GetResourceParams struct {
+	GetParams
+
+	Type string
+}
+
+// Validate ensures that the parameters are usable by the consuming function.
+func (params GetResourceParams) Validate() error {
+	var merr = new(multierror.Error)
+	merr = multierror.Append(merr, params.GetParams.Validate())
+
+	return merr.ErrorOrNil()
+}
+
+// GetResource is a high level function which either returns the top level
+// deployment information when no params.Type is specified, or it returns a
+// specific deployment resource information by RefID. If no RefID is defined,
+// It will perform an additional API call to obtain the top level
+func GetResource(params GetResourceParams) (interface{}, error) {
+	if err := params.Validate(); err != nil {
+		return nil, err
+	}
+
+	var noRefIDAndType = params.GetParams.RefID == "" && params.Type != ""
+	if noRefIDAndType {
+		refID, err := GetTypeRefID(params)
+		if err != nil {
+			return nil, err
+		}
+		params.GetParams.RefID = refID
+	}
+
+	switch params.Type {
+	case "apm":
+		return GetApm(params.GetParams)
+	case "kibana":
+		return GetKibana(params.GetParams)
+	case "elasticsearch":
+		return GetElasticsearch(params.GetParams)
+	case "appsearch":
+		return GetAppSearch(params.GetParams)
+	default:
+		// If the is specified but not supported, return an error.
+		if params.Type != "" {
+			return nil, fmt.Errorf(
+				"deployment get: resource type %s is not valid", params.Type,
+			)
+		}
+		return Get(params.GetParams)
+	}
+}
+
+// GetTypeRefID obtains a resource type RefID. If the type is not supported
+// an error is returned.
+func GetTypeRefID(params GetResourceParams) (string, error) {
+	res, err := Get(params.GetParams)
+	if err != nil {
+		return "", err
+	}
+
+	var refID string
+	switch params.Type {
+	case "apm":
+		for _, resource := range res.Resources.Apm {
+			refID = *resource.RefID
+		}
+	case "kibana":
+		for _, resource := range res.Resources.Kibana {
+			refID = *resource.RefID
+		}
+	case "elasticsearch":
+		for _, resource := range res.Resources.Elasticsearch {
+			refID = *resource.RefID
+		}
+	case "appsearch":
+		for _, resource := range res.Resources.Appsearch {
+			refID = *resource.RefID
+		}
+	}
+
+	if refID == "" {
+		return "", fmt.Errorf("deployment get: resource type %s is not available", params.Type)
+	}
+
+	return refID, nil
+}

--- a/pkg/deployment/get_resource_test.go
+++ b/pkg/deployment/get_resource_test.go
@@ -1,0 +1,358 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package deployment
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/elastic/ecctl/pkg/deployment/deputil"
+	"github.com/elastic/ecctl/pkg/util"
+)
+
+var errGet500 = `{
+  "errors": [
+    {
+      "code": "deployment.missing",
+      "fields": null,
+      "message": null
+    }
+  ]
+}`
+
+func TestGetResource(t *testing.T) {
+	type args struct {
+		params GetResourceParams
+	}
+	tests := []struct {
+		name string
+		args args
+		want interface{}
+		err  error
+	}{
+		{
+			name: "fails due to param validation",
+			args: args{params: GetResourceParams{}},
+			err: &multierror.Error{Errors: []error{
+				util.ErrAPIReq,
+				deputil.NewInvalidDeploymentIDError(""),
+			}},
+		},
+		{
+			name: "obtains a apm resource with a set RefID",
+			args: args{params: GetResourceParams{
+				GetParams: GetParams{
+					API: api.NewMock(mock.New200Response(mock.NewStructBody(
+						models.ApmResourceInfo{
+							ElasticsearchClusterRefID: ec.String("elasticsearch"),
+							ID:                        ec.String("3531aaf988594efa87c1aabb7caed337"),
+							RefID:                     ec.String("apm"),
+						},
+					))),
+					DeploymentID: "3531aaf988594efa87c1aabb7caed337",
+					RefID:        "apm",
+				},
+				Type: "apm",
+			}},
+			want: &models.ApmResourceInfo{
+				ElasticsearchClusterRefID: ec.String("elasticsearch"),
+				ID:                        ec.String("3531aaf988594efa87c1aabb7caed337"),
+				RefID:                     ec.String("apm"),
+			},
+		},
+		{
+			name: "obtains a apm resource without a RefID",
+			args: args{params: GetResourceParams{
+				GetParams: GetParams{
+					API: api.NewMock(
+						mock.New200Response(mock.NewStructBody(models.DeploymentGetResponse{
+							Healthy: ec.Bool(true),
+							ID:      ec.String("3531aaf988594efa87c1aabb7caed337"),
+							Resources: &models.DeploymentResources{
+								Apm: []*models.ApmResourceInfo{{
+									ElasticsearchClusterRefID: ec.String("elasticsearch"),
+									ID:                        ec.String("3531aaf988594efa87c1aabb7caed337"),
+									RefID:                     ec.String("apm"),
+								}},
+							},
+						})),
+						mock.New200Response(mock.NewStructBody(models.ApmResourceInfo{
+							ElasticsearchClusterRefID: ec.String("elasticsearch"),
+							ID:                        ec.String("3531aaf988594efa87c1aabb7caed337"),
+							RefID:                     ec.String("apm"),
+						})),
+					),
+					DeploymentID: "3531aaf988594efa87c1aabb7caed337",
+				},
+				Type: "apm",
+			}},
+			want: &models.ApmResourceInfo{
+				ElasticsearchClusterRefID: ec.String("elasticsearch"),
+				ID:                        ec.String("3531aaf988594efa87c1aabb7caed337"),
+				RefID:                     ec.String("apm"),
+			},
+		},
+		{
+			name: "obtains an elasticsearch resource with a set RefID",
+			args: args{params: GetResourceParams{
+				GetParams: GetParams{
+					API: api.NewMock(mock.New200Response(mock.NewStructBody(
+						models.ElasticsearchResourceInfo{
+							ID:    ec.String("3531aaf988594efa87c1aabb7caed337"),
+							RefID: ec.String("elasticsearch"),
+						},
+					))),
+					DeploymentID: "3531aaf988594efa87c1aabb7caed337",
+					RefID:        "elasticsearch",
+				},
+				Type: "elasticsearch",
+			}},
+			want: &models.ElasticsearchResourceInfo{
+				ID:    ec.String("3531aaf988594efa87c1aabb7caed337"),
+				RefID: ec.String("elasticsearch"),
+			},
+		},
+		{
+			name: "obtains an elasticsearch resource without a RefID",
+			args: args{params: GetResourceParams{
+				Type: "elasticsearch",
+				GetParams: GetParams{
+					API: api.NewMock(
+						mock.New200Response(mock.NewStructBody(models.DeploymentGetResponse{
+							Healthy: ec.Bool(true),
+							ID:      ec.String("3531aaf988594efa87c1aabb7caed337"),
+							Resources: &models.DeploymentResources{
+								Elasticsearch: []*models.ElasticsearchResourceInfo{{
+									ID:    ec.String("3531aaf988594efa87c1aabb7caed337"),
+									RefID: ec.String("elasticsearch"),
+								}},
+							},
+						})),
+						mock.New200Response(mock.NewStructBody(
+							models.ElasticsearchResourceInfo{
+								RefID: ec.String("elasticsearch"),
+								ID:    ec.String("3531aaf988594efa87c1aabb7caed337"),
+							},
+						)),
+					),
+					DeploymentID: "3531aaf988594efa87c1aabb7caed337",
+				},
+			}},
+			want: &models.ElasticsearchResourceInfo{
+				ID:    ec.String("3531aaf988594efa87c1aabb7caed337"),
+				RefID: ec.String("elasticsearch"),
+			},
+		},
+		{
+			name: "obtains a kibana resource with a set RefID",
+			args: args{params: GetResourceParams{
+				GetParams: GetParams{
+					API: api.NewMock(mock.New200Response(mock.NewStructBody(
+						models.KibanaResourceInfo{
+							ElasticsearchClusterRefID: ec.String("elasticsearch"),
+							ID:                        ec.String("3531aaf988594efa87c1aabb7caed337"),
+							RefID:                     ec.String("kibana"),
+						},
+					))),
+					DeploymentID: "3531aaf988594efa87c1aabb7caed337",
+					RefID:        "kibana",
+				},
+				Type: "kibana",
+			}},
+			want: &models.KibanaResourceInfo{
+				ElasticsearchClusterRefID: ec.String("elasticsearch"),
+				ID:                        ec.String("3531aaf988594efa87c1aabb7caed337"),
+				RefID:                     ec.String("kibana"),
+			},
+		},
+		{
+			name: "obtains a kibana resource without a RefID",
+			args: args{params: GetResourceParams{
+				GetParams: GetParams{
+					API: api.NewMock(
+						mock.New200Response(mock.NewStructBody(models.DeploymentGetResponse{
+							Healthy: ec.Bool(true),
+							ID:      ec.String("3531aaf988594efa87c1aabb7caed337"),
+							Resources: &models.DeploymentResources{
+								Kibana: []*models.KibanaResourceInfo{{
+									ID:    ec.String("3531aaf988594efa87c1aabb7caed337"),
+									RefID: ec.String("elasticsearch"),
+								}},
+							},
+						})),
+						mock.New200Response(mock.NewStructBody(
+							models.KibanaResourceInfo{
+								ElasticsearchClusterRefID: ec.String("elasticsearch"),
+								ID:                        ec.String("3531aaf988594efa87c1aabb7caed337"),
+								RefID:                     ec.String("kibana"),
+							},
+						)),
+					),
+					DeploymentID: "3531aaf988594efa87c1aabb7caed337",
+				},
+				Type: "kibana",
+			}},
+			want: &models.KibanaResourceInfo{
+				ElasticsearchClusterRefID: ec.String("elasticsearch"),
+				ID:                        ec.String("3531aaf988594efa87c1aabb7caed337"),
+				RefID:                     ec.String("kibana"),
+			},
+		},
+		{
+			name: "obtains a appsearch resource with a set RefID",
+			args: args{params: GetResourceParams{
+				GetParams: GetParams{
+					API: api.NewMock(mock.New200Response(mock.NewStructBody(
+						models.AppSearchResourceInfo{
+							ElasticsearchClusterRefID: ec.String("elasticsearch"),
+							ID:                        ec.String("3531aaf988594efa87c1aabb7caed337"),
+							RefID:                     ec.String("appsearch"),
+						},
+					))),
+					DeploymentID: "3531aaf988594efa87c1aabb7caed337",
+					RefID:        "appsearch",
+				},
+				Type: "appsearch",
+			}},
+			want: &models.AppSearchResourceInfo{
+				ElasticsearchClusterRefID: ec.String("elasticsearch"),
+				ID:                        ec.String("3531aaf988594efa87c1aabb7caed337"),
+				RefID:                     ec.String("appsearch"),
+			},
+		},
+		{
+			name: "obtains a appsearch resource without a RefID",
+			args: args{params: GetResourceParams{
+				GetParams: GetParams{
+					API: api.NewMock(
+						mock.New200Response(mock.NewStructBody(models.DeploymentGetResponse{
+							Healthy: ec.Bool(true),
+							ID:      ec.String("3531aaf988594efa87c1aabb7caed337"),
+							Resources: &models.DeploymentResources{
+								Appsearch: []*models.AppSearchResourceInfo{{
+									ID:    ec.String("3531aaf988594efa87c1aabb7caed337"),
+									RefID: ec.String("appsearch"),
+								}},
+							},
+						})),
+						mock.New200Response(mock.NewStructBody(
+							models.AppSearchResourceInfo{
+								ElasticsearchClusterRefID: ec.String("elasticsearch"),
+								ID:                        ec.String("3531aaf988594efa87c1aabb7caed337"),
+								RefID:                     ec.String("appsearch"),
+							},
+						)),
+					),
+					DeploymentID: "3531aaf988594efa87c1aabb7caed337",
+				},
+				Type: "appsearch",
+			}},
+			want: &models.AppSearchResourceInfo{
+				ElasticsearchClusterRefID: ec.String("elasticsearch"),
+				ID:                        ec.String("3531aaf988594efa87c1aabb7caed337"),
+				RefID:                     ec.String("appsearch"),
+			},
+		},
+		{
+			name: "obtains an invalid resource type INVALID without a RefID",
+			args: args{params: GetResourceParams{
+				GetParams: GetParams{
+					API: api.NewMock(
+						mock.New200Response(mock.NewStructBody(models.DeploymentGetResponse{
+							Healthy: ec.Bool(true),
+							ID:      ec.String("3531aaf988594efa87c1aabb7caed337"),
+							Resources: &models.DeploymentResources{
+								Appsearch: []*models.AppSearchResourceInfo{{
+									ID:    ec.String("3531aaf988594efa87c1aabb7caed337"),
+									RefID: ec.String("appsearch"),
+								}},
+							},
+						})),
+					),
+					DeploymentID: "3531aaf988594efa87c1aabb7caed337",
+				},
+				Type: "INVALID",
+			}},
+			err: errors.New("deployment get: resource type INVALID is not available"),
+		},
+		{
+			name: "returns an error when the RefID discovery fails",
+			args: args{params: GetResourceParams{
+				GetParams: GetParams{
+					API: api.NewMock(mock.New500Response(mock.NewStructBody(&models.BasicFailedReply{
+						Errors: []*models.BasicFailedReplyElement{
+							{Code: ec.String("deployment.missing")},
+						},
+					}))),
+					DeploymentID: "3531aaf988594efa87c1aabb7caed337",
+				},
+				Type: "INVALID",
+			}},
+			err: errors.New(errGet500),
+		},
+		{
+			name: "tries to obtain an INVALID resource with a set RefID",
+			args: args{params: GetResourceParams{
+				GetParams: GetParams{
+					API:          api.NewMock(),
+					DeploymentID: "3531aaf988594efa87c1aabb7caed337",
+					RefID:        "appsearch",
+				},
+				Type: "INVALID",
+			}},
+			err: errors.New("deployment get: resource type INVALID is not valid"),
+		},
+		{
+			name: "obtains the whole deployment when Type is empty",
+			args: args{params: GetResourceParams{
+				GetParams: GetParams{
+					API: api.NewMock(mock.New200Response(mock.NewStructBody(
+						models.DeploymentGetResponse{
+							Healthy: ec.Bool(true),
+							ID:      ec.String("f1d329b0fb34470ba8b18361cabdd2bc"),
+						},
+					))),
+					DeploymentID: "f1d329b0fb34470ba8b18361cabdd2bc",
+				},
+			}},
+			want: &models.DeploymentGetResponse{
+				Healthy: ec.Bool(true),
+				ID:      ec.String("f1d329b0fb34470ba8b18361cabdd2bc"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetResource(tt.args.params)
+			if !reflect.DeepEqual(err, tt.err) {
+				t.Errorf("GetResource() error = %v, wantErr %v", err, tt.err)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetResource() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Fixes the the `deployment show --type=<type>` by removing the harcoded
API calls with the RefId set to `main-<type>`. Additionally solves the
problem of an unspecified (by default) RefId to be autodiscovered with
an API call which obtains the RefId of the resource type when Type is
specified but --ref-id is not.

Additionally adds a `--ref-id` flag which allows the users to override
the default "auto-discovery" behavior and obtain a specific resource if
the RefId is known by the user.

Furthermore, moves all the switch cases to obtain different kind of
resources from the deployment to the more appropriate applicaiton logic
package rather than the `cmd` presentation layer.

Adds an example of this behavior to the help/docs.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Resolves #56.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

