### PR TITLE
elasticsearch: Add keystore management commands

### DIFF
--- a/cmd/deployment/elasticsearch/keystore/command.go
+++ b/cmd/deployment/elasticsearch/keystore/command.go
@@ -15,32 +15,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package cmdelasticsearch
+package cmdelasticsearchkeystore
 
 import (
 	"github.com/spf13/cobra"
-
-	cmdelasticsearchinstances "github.com/elastic/ecctl/cmd/deployment/elasticsearch/instances"
-	cmdelasticsearchkeystore "github.com/elastic/ecctl/cmd/deployment/elasticsearch/keystore"
-	cmdelasticsearchmonitoring "github.com/elastic/ecctl/cmd/deployment/elasticsearch/monitoring"
-	cmdelasticsearchplan "github.com/elastic/ecctl/cmd/deployment/elasticsearch/plan"
 )
 
-// Command defines the elasticsearch subcommand
+// Command is the elasticsearch keystore command
 var Command = &cobra.Command{
-	Use:     "elasticsearch",
-	Short:   "Manages Elasticsearch clusters",
-	PreRunE: cobra.MaximumNArgs(0),
-	Run: func(cmd *cobra.Command, args []string) {
-		cmd.Help()
+	Use:     `keystore`,
+	Short:   "Manages an Elasticsearch cluster's keystore",
+	PreRunE: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Help()
 	},
-}
-
-func init() {
-	Command.AddCommand(
-		cmdelasticsearchmonitoring.Command,
-		cmdelasticsearchplan.Command,
-		cmdelasticsearchinstances.Command,
-		cmdelasticsearchkeystore.Command,
-	)
 }

--- a/cmd/deployment/elasticsearch/keystore/get.go
+++ b/cmd/deployment/elasticsearch/keystore/get.go
@@ -1,0 +1,60 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmdelasticsearchkeystore
+
+import (
+	"github.com/spf13/cobra"
+
+	cmdutil "github.com/elastic/ecctl/cmd/util"
+	"github.com/elastic/ecctl/pkg/deployment/elasticsearch"
+	"github.com/elastic/ecctl/pkg/ecctl"
+)
+
+const keystoreShowExample = `$ ecctl deployment elasticsearch keystore show 4c052fb17f65467a9b3c36d060106377
+{
+  "secrets": {
+    "s3.client.foobar.access_key": {
+      "as_file": false
+    },
+    "s3.client.foobar.secret_key": {
+      "as_file": false
+    }
+  }
+}`
+
+var getCmd = &cobra.Command{
+	Use:     `show <cluster id>`,
+	Short:   "Shows the current Elasticsearch keystore settings",
+	Example: keystoreShowExample,
+	PreRunE: cmdutil.MinimumNArgsAndUUID(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := elasticsearch.GetKeystore(elasticsearch.GetKeystoreParams{
+			API:       ecctl.Get().API,
+			ClusterID: args[0],
+		})
+		if err != nil {
+			return err
+		}
+
+		return ecctl.Get().Formatter.Format("", res)
+	},
+}
+
+func init() {
+	Command.AddCommand(getCmd)
+}

--- a/cmd/deployment/elasticsearch/keystore/set.go
+++ b/cmd/deployment/elasticsearch/keystore/set.go
@@ -1,0 +1,88 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmdelasticsearchkeystore
+
+import (
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/spf13/cobra"
+
+	cmdutil "github.com/elastic/ecctl/cmd/util"
+	"github.com/elastic/ecctl/pkg/deployment/elasticsearch"
+	"github.com/elastic/ecctl/pkg/ecctl"
+)
+
+const setKeystoreLong = `Manages the keystore settings of an Elasticsearch cluster.
+Note that the underlying API call uses the PATCH method, meaning that each operation is add/modify only.`
+
+var setKeystoreExamples = `
+$ cat keystore_example.json
+{
+    "secrets": {
+        "s3.client.foobar.access_key": {
+            "value": "AKIXAIQFKXPHIFXSILUWPA",
+            "as_file": false
+        },
+        "s3.client.foobar.secret_key": {
+            "value": "18qXOpY2zGlApay1237dLXh+LG1X5LUNWjTHq5X1SWjf++m+p0"
+        }
+    }
+}
+$ ecctl deployment elasticsearch keystore set 4c052fb17f65467a9b3c36d060106377 --file keystore_example.json
+{
+  "secrets": {
+    "s3.client.foobar.access_key": {
+      "as_file": false
+    },
+    "s3.client.foobar.secret_key": {
+      "as_file": false
+    }
+  }
+}`[1:]
+
+var setCmd = &cobra.Command{
+	Use:     `set <cluster id> -f <file definition.json>`,
+	Short:   "Updates an Elasticsearch cluster keystore with the contents of a file",
+	Long:    setKeystoreLong,
+	Example: setKeystoreExamples,
+	PreRunE: cmdutil.MinimumNArgsAndUUID(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		filename, _ := cmd.Flags().GetString("file")
+		var req models.KeystoreContents
+		if err := cmdutil.DecodeFile(filename, &req); err != nil {
+			return err
+		}
+
+		res, err := elasticsearch.SetKeystore(elasticsearch.SetKeystoreParams{
+			API:       ecctl.Get().API,
+			ClusterID: args[0],
+			Request:   &req,
+		})
+		if err != nil {
+			return err
+		}
+
+		return ecctl.Get().Formatter.Format("", res)
+	},
+}
+
+func init() {
+	Command.AddCommand(setCmd)
+	setCmd.Flags().StringP("file", "f", "", "JSON file that contains JSON-style domain-specific keystore definition")
+	setCmd.MarkFlagRequired("file")
+	setCmd.MarkFlagFilename("file", "*.json")
+}

--- a/cmd/deployment/elasticsearch/keystore/set.go
+++ b/cmd/deployment/elasticsearch/keystore/set.go
@@ -27,7 +27,7 @@ import (
 )
 
 const setKeystoreLong = `Manages the keystore settings of an Elasticsearch cluster.
-Note that the underlying API call uses the PATCH method, meaning that each operation is add/modify only.`
+Note that each operation is add/modify only, unspecified existing keystore values will be unchanged.`
 
 var setKeystoreExamples = `
 $ cat keystore_example.json

--- a/cmd/deployment/elasticsearch/keystore/show.go
+++ b/cmd/deployment/elasticsearch/keystore/show.go
@@ -39,7 +39,7 @@ const keystoreShowExample = `$ ecctl deployment elasticsearch keystore show 4c05
 
 var getCmd = &cobra.Command{
 	Use:     `show <cluster id>`,
-	Short:   "Shows the current Elasticsearch keystore settings",
+	Short:   "Shows an Elasticsearch cluster's keystore settings",
 	Example: keystoreShowExample,
 	PreRunE: cmdutil.MinimumNArgsAndUUID(1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/docs/ecctl_deployment_elasticsearch.md
+++ b/docs/ecctl_deployment_elasticsearch.md
@@ -44,6 +44,7 @@ ecctl deployment elasticsearch [flags]
 * [ecctl deployment elasticsearch delete](ecctl_deployment_elasticsearch_delete.md)	 - Deletes an Elasticsearch cluster
 * [ecctl deployment elasticsearch diagnose](ecctl_deployment_elasticsearch_diagnose.md)	 - Generates a diagnostics bundle for the cluster
 * [ecctl deployment elasticsearch instances](ecctl_deployment_elasticsearch_instances.md)	 - Manages elasticsearch at the instance level
+* [ecctl deployment elasticsearch keystore](ecctl_deployment_elasticsearch_keystore.md)	 - Manages an Elasticsearch cluster's keystore
 * [ecctl deployment elasticsearch list](ecctl_deployment_elasticsearch_list.md)	 - Returns the list of Elasticsearch clusters
 * [ecctl deployment elasticsearch monitoring](ecctl_deployment_elasticsearch_monitoring.md)	 - Manages monitoring for an Elasticsearch cluster
 * [ecctl deployment elasticsearch plan](ecctl_deployment_elasticsearch_plan.md)	 - Manages Elasticsearch plans

--- a/docs/ecctl_deployment_elasticsearch_keystore.md
+++ b/docs/ecctl_deployment_elasticsearch_keystore.md
@@ -1,0 +1,44 @@
+## ecctl deployment elasticsearch keystore
+
+Manages an Elasticsearch cluster's keystore
+
+### Synopsis
+
+Manages an Elasticsearch cluster's keystore
+
+```
+ecctl deployment elasticsearch keystore [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for keystore
+```
+
+### Options inherited from parent commands
+
+```
+      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
+      --force              Do not ask for confirmation
+      --format string      Formats the output using a Go template
+      --host string        Base URL to use
+      --insecure           Skips all TLS validation
+      --message string     A message to set on cluster operation
+      --output string      Output format [text|json] (default "text")
+      --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
+      --pprof              Enables pprofing and saves the profile to pprof-20060102150405
+  -q, --quiet              Suppresses the configuration file used for the run, if any
+      --timeout duration   Timeout to use on all HTTP calls (default 30s)
+      --trace              Enables tracing saves the trace to trace-20060102150405
+      --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)
+      --verbose            Enable verbose mode
+```
+
+### SEE ALSO
+
+* [ecctl deployment elasticsearch](ecctl_deployment_elasticsearch.md)	 - Manages Elasticsearch clusters
+* [ecctl deployment elasticsearch keystore set](ecctl_deployment_elasticsearch_keystore_set.md)	 - Updates an Elasticsearch cluster keystore with the contents of a file
+* [ecctl deployment elasticsearch keystore show](ecctl_deployment_elasticsearch_keystore_show.md)	 - Shows the current Elasticsearch keystore settings
+

--- a/docs/ecctl_deployment_elasticsearch_keystore.md
+++ b/docs/ecctl_deployment_elasticsearch_keystore.md
@@ -40,5 +40,5 @@ ecctl deployment elasticsearch keystore [flags]
 
 * [ecctl deployment elasticsearch](ecctl_deployment_elasticsearch.md)	 - Manages Elasticsearch clusters
 * [ecctl deployment elasticsearch keystore set](ecctl_deployment_elasticsearch_keystore_set.md)	 - Updates an Elasticsearch cluster keystore with the contents of a file
-* [ecctl deployment elasticsearch keystore show](ecctl_deployment_elasticsearch_keystore_show.md)	 - Shows the current Elasticsearch keystore settings
+* [ecctl deployment elasticsearch keystore show](ecctl_deployment_elasticsearch_keystore_show.md)	 - Shows an Elasticsearch cluster's keystore settings
 

--- a/docs/ecctl_deployment_elasticsearch_keystore_set.md
+++ b/docs/ecctl_deployment_elasticsearch_keystore_set.md
@@ -5,7 +5,7 @@ Updates an Elasticsearch cluster keystore with the contents of a file
 ### Synopsis
 
 Manages the keystore settings of an Elasticsearch cluster.
-Note that the underlying API call uses the PATCH method, meaning that each operation is add/modify only.
+Note that each operation is add/modify only, unspecified existing keystore values will be unchanged.
 
 ```
 ecctl deployment elasticsearch keystore set <cluster id> -f <file definition.json> [flags]

--- a/docs/ecctl_deployment_elasticsearch_keystore_set.md
+++ b/docs/ecctl_deployment_elasticsearch_keystore_set.md
@@ -1,0 +1,72 @@
+## ecctl deployment elasticsearch keystore set
+
+Updates an Elasticsearch cluster keystore with the contents of a file
+
+### Synopsis
+
+Manages the keystore settings of an Elasticsearch cluster.
+Note that the underlying API call uses the PATCH method, meaning that each operation is add/modify only.
+
+```
+ecctl deployment elasticsearch keystore set <cluster id> -f <file definition.json> [flags]
+```
+
+### Examples
+
+```
+$ cat keystore_example.json
+{
+    "secrets": {
+        "s3.client.foobar.access_key": {
+            "value": "AKIXAIQFKXPHIFXSILUWPA",
+            "as_file": false
+        },
+        "s3.client.foobar.secret_key": {
+            "value": "18qXOpY2zGlApay1237dLXh+LG1X5LUNWjTHq5X1SWjf++m+p0"
+        }
+    }
+}
+$ ecctl deployment elasticsearch keystore set 4c052fb17f65467a9b3c36d060106377 --file keystore_example.json
+{
+  "secrets": {
+    "s3.client.foobar.access_key": {
+      "as_file": false
+    },
+    "s3.client.foobar.secret_key": {
+      "as_file": false
+    }
+  }
+}
+```
+
+### Options
+
+```
+  -f, --file string   JSON file that contains JSON-style domain-specific keystore definition
+  -h, --help          help for set
+```
+
+### Options inherited from parent commands
+
+```
+      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
+      --force              Do not ask for confirmation
+      --format string      Formats the output using a Go template
+      --host string        Base URL to use
+      --insecure           Skips all TLS validation
+      --message string     A message to set on cluster operation
+      --output string      Output format [text|json] (default "text")
+      --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
+      --pprof              Enables pprofing and saves the profile to pprof-20060102150405
+  -q, --quiet              Suppresses the configuration file used for the run, if any
+      --timeout duration   Timeout to use on all HTTP calls (default 30s)
+      --trace              Enables tracing saves the trace to trace-20060102150405
+      --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)
+      --verbose            Enable verbose mode
+```
+
+### SEE ALSO
+
+* [ecctl deployment elasticsearch keystore](ecctl_deployment_elasticsearch_keystore.md)	 - Manages an Elasticsearch cluster's keystore
+

--- a/docs/ecctl_deployment_elasticsearch_keystore_show.md
+++ b/docs/ecctl_deployment_elasticsearch_keystore_show.md
@@ -1,0 +1,58 @@
+## ecctl deployment elasticsearch keystore show
+
+Shows the current Elasticsearch keystore settings
+
+### Synopsis
+
+Shows the current Elasticsearch keystore settings
+
+```
+ecctl deployment elasticsearch keystore show <cluster id> [flags]
+```
+
+### Examples
+
+```
+$ ecctl deployment elasticsearch keystore show 4c052fb17f65467a9b3c36d060106377
+{
+  "secrets": {
+    "s3.client.foobar.access_key": {
+      "as_file": false
+    },
+    "s3.client.foobar.secret_key": {
+      "as_file": false
+    }
+  }
+}
+```
+
+### Options
+
+```
+  -h, --help   help for show
+```
+
+### Options inherited from parent commands
+
+```
+      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
+      --force              Do not ask for confirmation
+      --format string      Formats the output using a Go template
+      --host string        Base URL to use
+      --insecure           Skips all TLS validation
+      --message string     A message to set on cluster operation
+      --output string      Output format [text|json] (default "text")
+      --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
+      --pprof              Enables pprofing and saves the profile to pprof-20060102150405
+  -q, --quiet              Suppresses the configuration file used for the run, if any
+      --timeout duration   Timeout to use on all HTTP calls (default 30s)
+      --trace              Enables tracing saves the trace to trace-20060102150405
+      --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)
+      --verbose            Enable verbose mode
+```
+
+### SEE ALSO
+
+* [ecctl deployment elasticsearch keystore](ecctl_deployment_elasticsearch_keystore.md)	 - Manages an Elasticsearch cluster's keystore
+

--- a/docs/ecctl_deployment_elasticsearch_keystore_show.md
+++ b/docs/ecctl_deployment_elasticsearch_keystore_show.md
@@ -1,10 +1,10 @@
 ## ecctl deployment elasticsearch keystore show
 
-Shows the current Elasticsearch keystore settings
+Shows an Elasticsearch cluster's keystore settings
 
 ### Synopsis
 
-Shows the current Elasticsearch keystore settings
+Shows an Elasticsearch cluster's keystore settings
 
 ```
 ecctl deployment elasticsearch keystore show <cluster id> [flags]

--- a/pkg/deployment/elasticsearch/set_keystore.go
+++ b/pkg/deployment/elasticsearch/set_keystore.go
@@ -1,0 +1,80 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package elasticsearch
+
+import (
+	"errors"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/client/clusters_elasticsearch"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	multierror "github.com/hashicorp/go-multierror"
+
+	"github.com/elastic/ecctl/pkg/util"
+)
+
+// SetKeystoreParams is consumed by SetKeystore.
+type SetKeystoreParams struct {
+	*api.API
+	ClusterID string
+
+	Request *models.KeystoreContents
+}
+
+// Validate ensures the parameters are usabl by the consuming function.
+func (params SetKeystoreParams) Validate() error {
+	var merr = new(multierror.Error)
+
+	if params.API == nil {
+		merr = multierror.Append(merr, util.ErrAPIReq)
+	}
+
+	if len(params.ClusterID) != 32 {
+		merr = multierror.Append(merr, util.ErrClusterLength)
+	}
+
+	if params.Request == nil {
+		merr = multierror.Append(merr,
+			errors.New("elasticsarch keystore: set requires the keystore contents to be specified"),
+		)
+	}
+
+	return merr.ErrorOrNil()
+}
+
+// SetKeystore updates the Elasticsearch keystore values from a ClusterID.
+// The specified request is treated as a partial definition and the values in
+// it are used to either create / update the keystore values. Existing keystore
+// values will not be affected if missing from the request.
+func SetKeystore(params SetKeystoreParams) (*models.KeystoreContents, error) {
+	if err := params.Validate(); err != nil {
+		return nil, err
+	}
+
+	res, err := params.V1API.ClustersElasticsearch.SetEsClusterKeystore(
+		clusters_elasticsearch.NewSetEsClusterKeystoreParams().
+			WithClusterID(params.ClusterID).
+			WithBody(params.Request),
+		params.AuthWriter,
+	)
+	if err != nil {
+		return nil, api.UnwrapError(err)
+	}
+
+	return res.Payload, nil
+}

--- a/pkg/deployment/elasticsearch/set_keystore_test.go
+++ b/pkg/deployment/elasticsearch/set_keystore_test.go
@@ -1,0 +1,118 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package elasticsearch
+
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+	multierror "github.com/hashicorp/go-multierror"
+
+	"github.com/elastic/ecctl/pkg/util"
+)
+
+const secretGet = `{
+  "secrets": {
+    "s3.client.foobar.access_key": {
+      "as_file": false
+    },
+    "s3.client.foobar.secret_key": {
+      "as_file": false
+    }
+  }
+}`
+
+func TestSetKeystore(t *testing.T) {
+	const secretContents = `{
+		"secrets": {
+			"s3.client.foobar.access_key": {
+				"value": "AKIXAIQFKXPHIFXSILUWPA",
+				"as_file": false
+			},
+			"s3.client.foobar.secret_key": {
+				"value": "18qXOpY2zGlApay1237dLXh+LG1X5LUNWjTHq5X1SWjf++m+p0"
+			}
+		}
+	}`
+	var req models.KeystoreContents
+	json.Unmarshal([]byte(secretContents), &req)
+
+	type args struct {
+		params SetKeystoreParams
+	}
+	tests := []struct {
+		name string
+		args args
+		want *models.KeystoreContents
+		err  error
+	}{
+		{
+			name: "fails due to param validation",
+			err: &multierror.Error{Errors: []error{
+				util.ErrAPIReq,
+				util.ErrClusterLength,
+				errors.New("elasticsarch keystore: set requires the keystore contents to be specified"),
+			}},
+		},
+		{
+			name: "fails due to API error",
+			args: args{params: SetKeystoreParams{
+				API:       api.NewMock(mock.New500Response(mock.NewStringBody("error"))),
+				ClusterID: util.ValidClusterID,
+				Request:   &req,
+			}},
+			err: errors.New("error"),
+		},
+		{
+			name: "succeeds",
+			args: args{params: SetKeystoreParams{
+				API:       api.NewMock(mock.New202Response(mock.NewStringBody(secretGet))),
+				ClusterID: util.ValidClusterID,
+				Request:   &req,
+			}},
+			want: &models.KeystoreContents{
+				Secrets: map[string]models.KeystoreSecret{
+					"s3.client.foobar.access_key": {
+						AsFile: ec.Bool(false),
+					},
+					"s3.client.foobar.secret_key": {
+						AsFile: ec.Bool(false),
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := SetKeystore(tt.args.params)
+			if !reflect.DeepEqual(err, tt.err) {
+				t.Errorf("SetKeystore() error = %v, wantErr %v", err, tt.err)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SetKeystore() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/deployment/elasticsearch/show_keystore.go
+++ b/pkg/deployment/elasticsearch/show_keystore.go
@@ -1,0 +1,66 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package elasticsearch
+
+import (
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/client/clusters_elasticsearch"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	multierror "github.com/hashicorp/go-multierror"
+
+	"github.com/elastic/ecctl/pkg/util"
+)
+
+// GetKeystoreParams is consumed by GetKeystore.
+type GetKeystoreParams struct {
+	*api.API
+	ClusterID string
+}
+
+// Validate ensures the parameters are usabl by the consuming function.
+func (params GetKeystoreParams) Validate() error {
+	var merr = new(multierror.Error)
+
+	if params.API == nil {
+		merr = multierror.Append(merr, util.ErrAPIReq)
+	}
+
+	if len(params.ClusterID) != 32 {
+		merr = multierror.Append(merr, util.ErrClusterLength)
+	}
+
+	return merr.ErrorOrNil()
+}
+
+// GetKeystore obtains the Elasticsearch keystore values from a ClusterID.
+func GetKeystore(params GetKeystoreParams) (*models.KeystoreContents, error) {
+	if err := params.Validate(); err != nil {
+		return nil, err
+	}
+
+	res, err := params.V1API.ClustersElasticsearch.GetEsClusterKeystore(
+		clusters_elasticsearch.NewGetEsClusterKeystoreParams().
+			WithClusterID(params.ClusterID),
+		params.AuthWriter,
+	)
+	if err != nil {
+		return nil, api.UnwrapError(err)
+	}
+
+	return res.Payload, nil
+}

--- a/pkg/deployment/elasticsearch/show_keystore_test.go
+++ b/pkg/deployment/elasticsearch/show_keystore_test.go
@@ -1,0 +1,89 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package elasticsearch
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+	multierror "github.com/hashicorp/go-multierror"
+
+	"github.com/elastic/ecctl/pkg/util"
+)
+
+func TestGetKeystore(t *testing.T) {
+	type args struct {
+		params GetKeystoreParams
+	}
+	tests := []struct {
+		name string
+		args args
+		want *models.KeystoreContents
+		err  error
+	}{
+		{
+			name: "fails due to param validation",
+			err: &multierror.Error{Errors: []error{
+				util.ErrAPIReq,
+				util.ErrClusterLength,
+			}},
+		},
+		{
+			name: "fails due to API error",
+			args: args{params: GetKeystoreParams{
+				API:       api.NewMock(mock.New500Response(mock.NewStringBody("error"))),
+				ClusterID: util.ValidClusterID,
+			}},
+			err: errors.New("error"),
+		},
+		{
+			name: "succeeds",
+			args: args{params: GetKeystoreParams{
+				API:       api.NewMock(mock.New200Response(mock.NewStringBody(secretGet))),
+				ClusterID: util.ValidClusterID,
+			}},
+			want: &models.KeystoreContents{
+				Secrets: map[string]models.KeystoreSecret{
+					"s3.client.foobar.access_key": {
+						AsFile: ec.Bool(false),
+					},
+					"s3.client.foobar.secret_key": {
+						AsFile: ec.Bool(false),
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetKeystore(tt.args.params)
+			if !reflect.DeepEqual(err, tt.err) {
+				t.Errorf("GetKeystore() error = %v, wantErr %v", err, tt.err)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetKeystore() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds two new commands, which allow an Elasticsearch cluster's keystore
to be updated and to be shown:

* ecctl deployment elasticsearch keystore set <cluster id> -f def.json
* ecctl deployment elasticsearch keystore show <cluster id>

The specified keystore definition is treated as a partial and the values
in it are used to either create / update the keystore values. Existing
keystore values will not be affected if missing from the request.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Missing elasticsearch keystore management commands.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
