### PR TITLE
cmd: Fix init command on unexisting .ecctl folder

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -62,7 +62,7 @@ var initCmd = &cobra.Command{
 				return err
 			}
 			cfg = defaultViper.ConfigFileUsed()
-			fmt.Fprintln(defaultOutput, "\nConfig written in:", cfg)
+			fmt.Fprintln(defaultOutput, "\nConfig written to", cfg)
 		}
 
 		return nil


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
There was a small mistake in the directory permission mask when the
folder `~/.ecctl` does not exist, it was previously creating it without
the execution premission which prevents anyone from actually accessing
the folder.

Additionally it prints the location of the configuration that's been
written down at the end of initialising the config.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Resolves #63

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```console
$ make ecctl
[...]
$ rm -rf ~/.ecctl
$ ./bin/ecctl init
Welcome to the Elastic Cloud CLI! This command will guide you through authenticating and setting some default values.

Missing configuration file, would you like to initialise it? [y/n]: y
Enter the URL of your ECE installation: http://somehost:12300

What default output format would you like?
  [1] text - Human-readable output format, commands with no output templates defined will fall back to JSON.
  [2] json - JSON formatted output API responses.

Please enter a choice: 1


Which authentication mechanism would you like to use?
  [1] API Keys (Recommended).
  [2] Username and Password login.

Please enter your choice: 2

Type in your username: admin
Type in your password:

Your credentials seem to be valid, and show you're authenticated as "admin".

You're all set! Here are some commands to try:
  $ ecctl auth user key list
  $ ecctl deployment elasticsearch list

Config written to /Users/marc/.ecctl/ce-aws.json
```

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
