### PR TITLE
Remove ErrCatchTransport from default http client

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,7 +25,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/output"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
@@ -45,7 +44,7 @@ const (
 )
 
 var (
-	defaultClient = &http.Client{Transport: api.DefaultTransport}
+	defaultClient = new(http.Client)
 	defaultOutput = os.Stdout
 	defaultInput  = os.Stdin
 	defaultError  = os.Stderr
@@ -75,6 +74,7 @@ var RootCmd = &cobra.Command{
 		if err := setupDebug(defaultViper.GetBool("trace"), defaultViper.GetBool("pprof")); err != nil {
 			return err
 		}
+
 		return initApp(cmd, defaultClient, defaultViper)
 	},
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/chzyer/logex v1.1.10 // indirect
 	github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 // indirect
 	github.com/davecgh/go-spew v1.1.1
-	github.com/elastic/cloud-sdk-go v1.0.0-bc6
+	github.com/elastic/cloud-sdk-go v1.0.0-bc7
 	github.com/elastic/uptd v1.0.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-openapi/runtime v0.19.8

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/chzyer/logex v1.1.10 // indirect
 	github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 // indirect
 	github.com/davecgh/go-spew v1.1.1
-	github.com/elastic/cloud-sdk-go v1.0.0-bc7
+	github.com/elastic/cloud-sdk-go v1.0.0-bc8
 	github.com/elastic/uptd v1.0.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-openapi/runtime v0.19.8

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDD
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/elastic/cloud-sdk-go v1.0.0-bc6 h1:vxt738VM/thyF2QD3mBFNRR1n2Hv0qFJetOXQv/9NbQ=
 github.com/elastic/cloud-sdk-go v1.0.0-bc6/go.mod h1:19tuRaJglGTECDJfiWEDMOVj23ZL+9+YYoIV1fZIGzc=
+github.com/elastic/cloud-sdk-go v1.0.0-bc8 h1:ESKQ67Shc+1jZRhoi4l/I/qRX5YlgrTa8/ma6N/Il+A=
+github.com/elastic/cloud-sdk-go v1.0.0-bc8/go.mod h1:19tuRaJglGTECDJfiWEDMOVj23ZL+9+YYoIV1fZIGzc=
 github.com/elastic/uptd v1.0.0 h1:oUhbbTK6hjFYB5w5dwjo1HtbqrWyLiqj+6Sb05oawU8=
 github.com/elastic/uptd v1.0.0/go.mod h1:2Pm07gLal/a/gTPq3el2QgOjoxu97pB2I17AprXxa48=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/pkg/ecctl/init.go
+++ b/pkg/ecctl/init.go
@@ -178,14 +178,14 @@ func InitConfig(params InitConfigParams) error {
 		Client:       params.Client,
 		OutputDevice: outputDevice,
 		ErrorDevice:  params.ErrWriter,
-		// Insecure is set to true by default to allow API calls against HTTPS
-		// endpoints with self-signed certificates.
-		Insecure: true,
 	}
 	if err := params.Viper.Unmarshal(&cfg); err != nil {
 		return err
 	}
 
+	// Insecure is set to true by default to allow API calls against HTTPS
+	// endpoints with self-signed certificates.
+	cfg.Insecure = true
 	cfg.Host = scanner.Scan(hostMsg)
 
 	if err := askOutputFormat(&cfg, scanner, params.Writer, params.ErrWriter); err != nil {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Since the newer release of elastic/cloud-sdk-go@v1.0.0-bc7 already adds
the ErrCatchTransport on the construction of the api client, it is no
longer necessary to handle this on the client's side.

Additionally, changes the order on which the application's insecure flag
is set within `ecctl.InitConfig()`. Since the flag insecure comes with a
set default value (false), setting the value before viper.Unmarshal
causes any of the structure's values to be set to the default value
declared in the cobra flags that have been bound to viper.

## TODO

- [ ] Run `make vendor` after `elastic/cloud-sdk-go@v1.0.0-bc7` is published.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Resolves #65 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually running `dev-cli init` with an https URL.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
