### PR TITLE
Remove brew pin-tap step

### DIFF
--- a/docs/ecctl-getting-started.asciidoc
+++ b/docs/ecctl-getting-started.asciidoc
@@ -38,7 +38,6 @@ link:https://brew.sh/[Homebrew]:
 [source]
 ----
 $ brew tap elastic/ecctl
-$ brew tap-pin elastic/ecctl
 $ brew install elastic/ecctl/ecctl
 Updating Homebrew...
 => Installing ecctl from elastic/ecctl


### PR DESCRIPTION
Removed `brew tap-pin elastic/ecctl` step from the macOS install guide as it results in as it's not required and causes an error.