### PR TITLE
cmd: Add deployment resource upgrade command

### DIFF
--- a/cmd/deployment/resource/command.go
+++ b/cmd/deployment/resource/command.go
@@ -15,36 +15,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package cmddeployment
+package cmddeploymentresource
 
 import (
 	"github.com/spf13/cobra"
-
-	cmdapm "github.com/elastic/ecctl/cmd/deployment/apm"
-	cmdelasticsearch "github.com/elastic/ecctl/cmd/deployment/elasticsearch"
-	cmdkibana "github.com/elastic/ecctl/cmd/deployment/kibana"
-	cmddeploymentnote "github.com/elastic/ecctl/cmd/deployment/note"
-	cmddeploymentplan "github.com/elastic/ecctl/cmd/deployment/plan"
-	cmddeploymentresource "github.com/elastic/ecctl/cmd/deployment/resource"
 )
 
 // Command is the deployment subcommand
 var Command = &cobra.Command{
-	Use:     "deployment",
-	Short:   "Manages deployments",
+	Use:     "resource",
+	Short:   "Manages deployment resources",
 	PreRunE: cobra.MaximumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()
 	},
-}
-
-func init() {
-	Command.AddCommand(
-		cmddeploymentnote.Command,
-		cmdelasticsearch.Command,
-		cmdkibana.Command,
-		cmdapm.Command,
-		cmddeploymentplan.Command,
-		cmddeploymentresource.Command,
-	)
 }

--- a/cmd/deployment/resource/upgrade.go
+++ b/cmd/deployment/resource/upgrade.go
@@ -30,7 +30,7 @@ import (
 // upgradeCmd is the deployment subcommand
 var upgradeCmd = &cobra.Command{
 	Use:     "upgrade <deployment id> --type <type> --ref-id <ref-id>",
-	Short:   "Upgrades a deploymnt resource",
+	Short:   "Upgrades a deployment resource",
 	Long:    upgradeLong,
 	PreRunE: cmdutil.MinimumNArgsAndUUID(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -67,8 +67,8 @@ var upgradeCmd = &cobra.Command{
 func init() {
 	Command.AddCommand(upgradeCmd)
 	upgradeCmd.Flags().BoolP("track", "t", false, cmdutil.TrackFlagMessage)
-	upgradeCmd.Flags().String("type", "", "Optional deployment type to show resource information (elasticsearch, kibana, apm, or appsearch)")
+	upgradeCmd.Flags().String("type", "", "Optional stateless deployment type to upgrade (kibana, apm, or appsearch)")
 	upgradeCmd.MarkFlagRequired("type")
-	upgradeCmd.Flags().String("ref-id", "", "Optional deployment type RefId, if not set, the RefId will be auto-discovered")
+	upgradeCmd.Flags().String("ref-id", "", "Optional deployment RefId, if not set, the RefId will be auto-discovered")
 	upgradeCmd.MarkFlagRequired("ref-id")
 }

--- a/cmd/deployment/resource/upgrade.go
+++ b/cmd/deployment/resource/upgrade.go
@@ -1,0 +1,74 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmddeploymentresource
+
+import (
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+	"github.com/spf13/cobra"
+
+	cmdutil "github.com/elastic/ecctl/cmd/util"
+	"github.com/elastic/ecctl/pkg/deployment/depresource"
+	"github.com/elastic/ecctl/pkg/ecctl"
+)
+
+// upgradeCmd is the deployment subcommand
+var upgradeCmd = &cobra.Command{
+	Use:     "upgrade <deployment id> --type <type> --ref-id <ref-id>",
+	Short:   "Upgrades a deploymnt resource",
+	Long:    upgradeLong,
+	PreRunE: cmdutil.MinimumNArgsAndUUID(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		resType, _ := cmd.Flags().GetString("type")
+		refID, _ := cmd.Flags().GetString("ref-id")
+
+		res, err := depresource.UpgradeStateless(depresource.UpgradeStatelessParams{
+			API:          ecctl.Get().API,
+			DeploymentID: args[0],
+			Type:         resType,
+			RefID:        refID,
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if track, _ := cmd.Flags().GetBool("track"); !track {
+			return nil
+		}
+
+		return depresource.TrackResources(depresource.TrackResourcesParams{
+			API:          ecctl.Get().API,
+			OutputDevice: ecctl.Get().Config.OutputDevice,
+			Resources: []*models.DeploymentResource{{
+				ID:    ec.String(res.ResourceID),
+				Kind:  ec.String(resType),
+				RefID: ec.String(refID),
+			}},
+		})
+	},
+}
+
+func init() {
+	Command.AddCommand(upgradeCmd)
+	upgradeCmd.Flags().BoolP("track", "t", false, cmdutil.TrackFlagMessage)
+	upgradeCmd.Flags().String("type", "", "Optional deployment type to show resource information (elasticsearch, kibana, apm, or appsearch)")
+	upgradeCmd.MarkFlagRequired("type")
+	upgradeCmd.Flags().String("ref-id", "", "Optional deployment type RefId, if not set, the RefId will be auto-discovered")
+	upgradeCmd.MarkFlagRequired("ref-id")
+}

--- a/cmd/deployment/resource/upgrade_help.go
+++ b/cmd/deployment/resource/upgrade_help.go
@@ -1,0 +1,23 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmddeploymentresource
+
+const (
+	upgradeLong = `Upgrades a stateless deployment resource so it matches the Elasticsearch
+deployment version. Only stateless resources are supported in the --type flag`
+)

--- a/docs/ecctl_deployment.md
+++ b/docs/ecctl_deployment.md
@@ -47,6 +47,7 @@ ecctl deployment [flags]
 * [ecctl deployment list](ecctl_deployment_list.md)	 - Lists the platform's deployments
 * [ecctl deployment note](ecctl_deployment_note.md)	 - Manages a deployment's notes
 * [ecctl deployment plan](ecctl_deployment_plan.md)	 - Manages deployment plans
+* [ecctl deployment resource](ecctl_deployment_resource.md)	 - Manages deployment resources
 * [ecctl deployment restore](ecctl_deployment_restore.md)	 - Restores a previously shut down deployment and all of its associated sub-resources
 * [ecctl deployment search](ecctl_deployment_search.md)	 - Performs advanced deployment search using the Elasticsearch Query DSL
 * [ecctl deployment show](ecctl_deployment_show.md)	 - Shows the specified deployment resources

--- a/docs/ecctl_deployment_resource.md
+++ b/docs/ecctl_deployment_resource.md
@@ -39,5 +39,5 @@ ecctl deployment resource [flags]
 ### SEE ALSO
 
 * [ecctl deployment](ecctl_deployment.md)	 - Manages deployments
-* [ecctl deployment resource upgrade](ecctl_deployment_resource_upgrade.md)	 - Upgrades a deploymnt resource
+* [ecctl deployment resource upgrade](ecctl_deployment_resource_upgrade.md)	 - Upgrades a deployment resource
 

--- a/docs/ecctl_deployment_resource.md
+++ b/docs/ecctl_deployment_resource.md
@@ -1,0 +1,43 @@
+## ecctl deployment resource
+
+Manages deployment resources
+
+### Synopsis
+
+Manages deployment resources
+
+```
+ecctl deployment resource [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for resource
+```
+
+### Options inherited from parent commands
+
+```
+      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
+      --force              Do not ask for confirmation
+      --format string      Formats the output using a Go template
+      --host string        Base URL to use
+      --insecure           Skips all TLS validation
+      --message string     A message to set on cluster operation
+      --output string      Output format [text|json] (default "text")
+      --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
+      --pprof              Enables pprofing and saves the profile to pprof-20060102150405
+  -q, --quiet              Suppresses the configuration file used for the run, if any
+      --timeout duration   Timeout to use on all HTTP calls (default 30s)
+      --trace              Enables tracing saves the trace to trace-20060102150405
+      --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)
+      --verbose            Enable verbose mode
+```
+
+### SEE ALSO
+
+* [ecctl deployment](ecctl_deployment.md)	 - Manages deployments
+* [ecctl deployment resource upgrade](ecctl_deployment_resource_upgrade.md)	 - Upgrades a deploymnt resource
+

--- a/docs/ecctl_deployment_resource_upgrade.md
+++ b/docs/ecctl_deployment_resource_upgrade.md
@@ -1,0 +1,46 @@
+## ecctl deployment resource upgrade
+
+Upgrades a deploymnt resource
+
+### Synopsis
+
+Upgrades a stateless deployment resource so it matches the Elasticsearch
+deployment version. Only stateless resources are supported in the --type flag
+
+```
+ecctl deployment resource upgrade <deployment id> --type <type> --ref-id <ref-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for upgrade
+      --ref-id string   Optional deployment type RefId, if not set, the RefId will be auto-discovered
+  -t, --track           Tracks the progress of the performed task
+      --type string     Optional deployment type to show resource information (elasticsearch, kibana, apm, or appsearch)
+```
+
+### Options inherited from parent commands
+
+```
+      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
+      --force              Do not ask for confirmation
+      --format string      Formats the output using a Go template
+      --host string        Base URL to use
+      --insecure           Skips all TLS validation
+      --message string     A message to set on cluster operation
+      --output string      Output format [text|json] (default "text")
+      --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
+      --pprof              Enables pprofing and saves the profile to pprof-20060102150405
+  -q, --quiet              Suppresses the configuration file used for the run, if any
+      --timeout duration   Timeout to use on all HTTP calls (default 30s)
+      --trace              Enables tracing saves the trace to trace-20060102150405
+      --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)
+      --verbose            Enable verbose mode
+```
+
+### SEE ALSO
+
+* [ecctl deployment resource](ecctl_deployment_resource.md)	 - Manages deployment resources
+

--- a/docs/ecctl_deployment_resource_upgrade.md
+++ b/docs/ecctl_deployment_resource_upgrade.md
@@ -1,6 +1,6 @@
 ## ecctl deployment resource upgrade
 
-Upgrades a deploymnt resource
+Upgrades a deployment resource
 
 ### Synopsis
 
@@ -15,9 +15,9 @@ ecctl deployment resource upgrade <deployment id> --type <type> --ref-id <ref-id
 
 ```
   -h, --help            help for upgrade
-      --ref-id string   Optional deployment type RefId, if not set, the RefId will be auto-discovered
+      --ref-id string   Optional deployment RefId, if not set, the RefId will be auto-discovered
   -t, --track           Tracks the progress of the performed task
-      --type string     Optional deployment type to show resource information (elasticsearch, kibana, apm, or appsearch)
+      --type string     Optional stateless deployment type to upgrade (kibana, apm, or appsearch)
 ```
 
 ### Options inherited from parent commands

--- a/pkg/deployment/depresource/upgrade_stateless.go
+++ b/pkg/deployment/depresource/upgrade_stateless.go
@@ -1,0 +1,79 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package depresource
+
+import (
+	"errors"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/client/deployments"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/elastic/ecctl/pkg/deployment/deputil"
+	"github.com/elastic/ecctl/pkg/util"
+)
+
+// UpgradeStatelessParams is consumed by UpgradeStateless
+type UpgradeStatelessParams struct {
+	*api.API
+
+	DeploymentID string
+	Type         string
+	RefID        string
+}
+
+// Validate ensures the parameters are usable by the consuming function.
+func (params UpgradeStatelessParams) Validate() error {
+	var merr = new(multierror.Error)
+
+	if params.API == nil {
+		merr = multierror.Append(merr, util.ErrAPIReq)
+	}
+
+	if len(params.DeploymentID) != 32 {
+		merr = multierror.Append(merr, deputil.NewInvalidDeploymentIDError(params.DeploymentID))
+	}
+
+	if params.Type == "" {
+		merr = multierror.Append(merr, errors.New("deployment resource type cannot be empty"))
+	}
+
+	return merr.ErrorOrNil()
+}
+
+// UpgradeStateless upgrades a stateless deployment resource like APM, Kibana
+// and AppSearch.
+func UpgradeStateless(params UpgradeStatelessParams) (*models.DeploymentResourceUpgradeResponse, error) {
+	if err := params.Validate(); err != nil {
+		return nil, err
+	}
+
+	res, err := params.V1API.Deployments.UpgradeDeploymentStatelessResource(
+		deployments.NewUpgradeDeploymentStatelessResourceParams().
+			WithStatelessResourceKind(params.Type).
+			WithDeploymentID(params.DeploymentID).
+			WithRefID(params.RefID),
+		params.AuthWriter,
+	)
+	if err != nil {
+		return nil, api.UnwrapError(err)
+	}
+
+	return res.Payload, nil
+}

--- a/pkg/deployment/depresource/upgrade_stateless_test.go
+++ b/pkg/deployment/depresource/upgrade_stateless_test.go
@@ -1,0 +1,90 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package depresource
+
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/elastic/ecctl/pkg/util"
+)
+
+func TestUpgradeStateless(t *testing.T) {
+	var internalError = models.BasicFailedReply{
+		Errors: []*models.BasicFailedReplyElement{
+			{},
+		},
+	}
+	internalErrorBytes, _ := json.MarshalIndent(internalError, "", "  ")
+	type args struct {
+		params UpgradeStatelessParams
+	}
+	tests := []struct {
+		name string
+		args args
+		want *models.DeploymentResourceUpgradeResponse
+		err  error
+	}{
+		{
+			name: "fails due to parameter validation",
+			args: args{},
+			err: &multierror.Error{Errors: []error{
+				util.ErrAPIReq,
+				errors.New("id \"\" is invalid"),
+				errors.New("deployment resource type cannot be empty"),
+			}},
+		},
+		{
+			name: "fails due to API error",
+			args: args{params: UpgradeStatelessParams{
+				API:          api.NewMock(mock.New404Response(mock.NewStructBody(internalError))),
+				DeploymentID: util.ValidClusterID,
+				Type:         "kibana",
+			}},
+			err: errors.New(string(internalErrorBytes)),
+		},
+		{
+			name: "succeeds",
+			args: args{params: UpgradeStatelessParams{
+				API:          api.NewMock(mock.New202Response(mock.NewStringBody(""))),
+				DeploymentID: util.ValidClusterID,
+				Type:         "kibana",
+			}},
+			want: new(models.DeploymentResourceUpgradeResponse),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := UpgradeStateless(tt.args.params)
+			if !reflect.DeepEqual(err, tt.err) {
+				t.Errorf("UpgradeStateless() error = %v, wantErr %v", err, tt.err)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("UpgradeStateless() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds a command which allows upgrading a stateless resource as specified
in the help and long description for commands. The supported type is any
of the stateless resource types, which for now are apm, appsearch and
kibana.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Implementing more of the deployment/resource APIs.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
