### PR TITLE
cmd: Add --track flag to deployment commands

### DIFF
--- a/cmd/deployment/create.go
+++ b/cmd/deployment/create.go
@@ -170,21 +170,15 @@ var createCmd = &cobra.Command{
 		}
 
 		var track, _ = cmd.Flags().GetBool("track")
-		if err := ecctl.Get().Formatter.Format("", res); err != nil {
-			if !track {
-				return err
-			}
-			fmt.Fprintln(ecctl.Get().Config.OutputDevice, err)
-		}
-
-		if !track {
-			return nil
-		}
-
-		return depresource.TrackResources(depresource.TrackResourcesParams{
-			API:          ecctl.Get().API,
-			Resources:    res.Resources,
-			OutputDevice: ecctl.Get().Config.OutputDevice,
+		return cmdutil.Track(cmdutil.TrackParams{
+			TrackResourcesParams: depresource.TrackResourcesParams{
+				API:          ecctl.Get().API,
+				Resources:    res.Resources,
+				OutputDevice: ecctl.Get().Config.OutputDevice,
+			},
+			Formatter: ecctl.Get().Formatter,
+			Track:     track,
+			Response:  res,
 		})
 	},
 }

--- a/cmd/deployment/create.go
+++ b/cmd/deployment/create.go
@@ -26,12 +26,14 @@ import (
 
 	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/deployment"
+	"github.com/elastic/ecctl/pkg/deployment/depresource"
 	"github.com/elastic/ecctl/pkg/ecctl"
 	"github.com/elastic/ecctl/pkg/util"
 )
 
 const createLong = `Creates a deployment from a file definition with an automatically generated idempotency token.
 On creation failure, please use the displayed idempotency token to retry the cluster creation with --request-id=<token>.
+To track the creation of the resources toggle the --track flag.
 
 Read more about the deployment definition in https://www.elastic.co/guide/en/cloud-enterprise/current/Deployment_-_CRUD.html`
 
@@ -167,12 +169,29 @@ var createCmd = &cobra.Command{
 			return err
 		}
 
-		return ecctl.Get().Formatter.Format("", res)
+		var track, _ = cmd.Flags().GetBool("track")
+		if err := ecctl.Get().Formatter.Format("", res); err != nil {
+			if !track {
+				return err
+			}
+			fmt.Fprintln(ecctl.Get().Config.OutputDevice, err)
+		}
+
+		if !track {
+			return nil
+		}
+
+		return depresource.TrackResources(depresource.TrackResourcesParams{
+			API:          ecctl.Get().API,
+			Resources:    res.Resources,
+			OutputDevice: ecctl.Get().Config.OutputDevice,
+		})
 	},
 }
 
 func init() {
 	Command.AddCommand(createCmd)
+	createCmd.Flags().BoolP("track", "t", false, cmdutil.TrackFlagMessage)
 	createCmd.Flags().String("name", "", "Overrides the deployment name")
 	createCmd.Flags().String("version", "", "Overrides all thee deployment's resources to the specified version")
 	createCmd.Flags().String("request-id", "", "Optional idempotency token - Can be found in the Stderr device when a previous deployment creation failed, for more information see the examples in the help command page")

--- a/cmd/deployment/shutdown.go
+++ b/cmd/deployment/shutdown.go
@@ -18,7 +18,6 @@
 package cmddeployment
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -54,21 +53,16 @@ var shutdownCmd = &cobra.Command{
 		}
 
 		var track, _ = cmd.Flags().GetBool("track")
-		if err := ecctl.Get().Formatter.Format("deployment/shutdown", res); err != nil {
-			if !track {
-				return err
-			}
-			fmt.Fprintln(ecctl.Get().Config.OutputDevice, err)
-		}
-
-		if !track {
-			return nil
-		}
-
-		return depresource.TrackResources(depresource.TrackResourcesParams{
-			API:          ecctl.Get().API,
-			Orphaned:     res.Orphaned,
-			OutputDevice: ecctl.Get().Config.OutputDevice,
+		return cmdutil.Track(cmdutil.TrackParams{
+			Template: "deployment/shutdown",
+			TrackResourcesParams: depresource.TrackResourcesParams{
+				API:          ecctl.Get().API,
+				Orphaned:     res.Orphaned,
+				OutputDevice: ecctl.Get().Config.OutputDevice,
+			},
+			Formatter: ecctl.Get().Formatter,
+			Track:     track,
+			Response:  res,
 		})
 	},
 }

--- a/cmd/deployment/update.go
+++ b/cmd/deployment/update.go
@@ -18,7 +18,6 @@
 package cmddeployment
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/elastic/cloud-sdk-go/pkg/models"
@@ -168,21 +167,16 @@ var updateCmd = &cobra.Command{
 		}
 
 		var track, _ = cmd.Flags().GetBool("track")
-		if err := ecctl.Get().Formatter.Format("", res); err != nil {
-			if !track {
-				return err
-			}
-			fmt.Fprintln(ecctl.Get().Config.OutputDevice, err)
-		}
-
-		if !track {
-			return nil
-		}
-
-		return depresource.TrackResources(depresource.TrackResourcesParams{
-			API:          ecctl.Get().API,
-			Resources:    res.Resources,
-			OutputDevice: ecctl.Get().Config.OutputDevice,
+		return cmdutil.Track(cmdutil.TrackParams{
+			TrackResourcesParams: depresource.TrackResourcesParams{
+				API:          ecctl.Get().API,
+				Resources:    res.Resources,
+				Orphaned:     res.ShutdownResources,
+				OutputDevice: ecctl.Get().Config.OutputDevice,
+			},
+			Formatter: ecctl.Get().Formatter,
+			Track:     track,
+			Response:  res,
 		})
 	},
 }

--- a/docs/ecctl_deployment_create.md
+++ b/docs/ecctl_deployment_create.md
@@ -6,6 +6,7 @@ Creates a deployment from a file definition, allowing certain flag overrides
 
 Creates a deployment from a file definition with an automatically generated idempotency token.
 On creation failure, please use the displayed idempotency token to retry the cluster creation with --request-id=<token>.
+To track the creation of the resources toggle the --track flag.
 
 Read more about the deployment definition in https://www.elastic.co/guide/en/cloud-enterprise/current/Deployment_-_CRUD.html
 
@@ -110,6 +111,7 @@ $ ecctl deployment create -f deployment_example.json --name adeploy --version=7.
   -h, --help                help for create
       --name string         Overrides the deployment name
       --request-id string   Optional idempotency token - Can be found in the Stderr device when a previous deployment creation failed, for more information see the examples in the help command page
+  -t, --track               Tracks the progress of the performed task
       --version string      Overrides all thee deployment's resources to the specified version
 ```
 

--- a/docs/ecctl_deployment_shutdown.md
+++ b/docs/ecctl_deployment_shutdown.md
@@ -16,6 +16,7 @@ ecctl deployment shutdown <deployment-id> [flags]
   -h, --help            help for shutdown
       --hide            Hides the deployment and its resources after it has been shut down
       --skip-snapshot   Skips taking an Elasticsearch snapshot prior to shutting down the deployment
+  -t, --track           Tracks the progress of the performed task
 ```
 
 ### Options inherited from parent commands

--- a/docs/ecctl_deployment_update.md
+++ b/docs/ecctl_deployment_update.md
@@ -6,6 +6,7 @@ Updates a deployment from a file definition, allowing certain flag overrides
 
 updates a deployment from a file definition, defaulting prune_orphans=false, making the default
 update action safe for partial updates, to override this behavior toggle --prune-orphans.
+To track the changes toggle the --track flag.
 
 Read more about the deployment definition in https://www.elastic.co/guide/en/cloud-enterprise/current/Deployment_-_CRUD.html
 
@@ -112,6 +113,7 @@ setting --prune-orphans to "true" will cause any resources not specified in the 
       --hide-pruned-orphans   Hides orphaned resources that were shut down (only relevant if --prune-orphans=true)
       --prune-orphans         When set to true, it will remove any resources not specified in the update request, treating the json file contents as the authoritative deployment definition
       --skip-snapshot         Skips taking an Elasticsearch snapshot prior to shutting down the deployment
+  -t, --track                 Tracks the progress of the performed task
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds the --track flag and resource tracking after a plan change to the
deployment subcommands which incur plan changes: `create`, `update` and
`shutdown`.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Resolves #78 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
