### PR TITLE
cmd: Add deployment resource shutdown command

### DIFF
--- a/cmd/deployment/resource/shutdown.go
+++ b/cmd/deployment/resource/shutdown.go
@@ -1,0 +1,60 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmddeploymentresource
+
+import (
+	"github.com/spf13/cobra"
+
+	cmdutil "github.com/elastic/ecctl/cmd/util"
+	"github.com/elastic/ecctl/pkg/deployment/depresource"
+	"github.com/elastic/ecctl/pkg/ecctl"
+)
+
+// shutdownCmd is the deployment subcommand
+var shutdownCmd = &cobra.Command{
+	Use:     "shutdown <deployment id> --type <type> --ref-id <ref-id>",
+	Short:   "Shuts down a deployment resource by its type and ref-id",
+	Long:    shutdownLong,
+	PreRunE: cmdutil.MinimumNArgsAndUUID(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		resType, _ := cmd.Flags().GetString("type")
+		refID, _ := cmd.Flags().GetString("ref-id")
+		skipSnapshot, _ := cmd.Flags().GetBool("skip-snapshot")
+		hide, _ := cmd.Flags().GetBool("hide")
+
+		return depresource.Shutdown(depresource.ShutdownParams{
+			API:          ecctl.Get().API,
+			DeploymentID: args[0],
+			Type:         resType,
+			RefID:        refID,
+			SkipSnapshot: skipSnapshot,
+			Hide:         hide,
+		})
+
+	},
+}
+
+func init() {
+	Command.AddCommand(shutdownCmd)
+	shutdownCmd.Flags().String("type", "", "Required deployment type to shutdown (elasticsearch, kibana, apm, or appsearch)")
+	shutdownCmd.MarkFlagRequired("type")
+	shutdownCmd.Flags().String("ref-id", "", "Required deployment RefId")
+	shutdownCmd.MarkFlagRequired("ref-id")
+	shutdownCmd.Flags().Bool("skip-snapshot", false, "Optional flag to toggle skipping the resource snapshot before shutting it down")
+	shutdownCmd.Flags().Bool("hide", false, "Optionally hides the deployment resource from being listed by default")
+}

--- a/cmd/deployment/resource/shutdown_help.go
+++ b/cmd/deployment/resource/shutdown_help.go
@@ -1,0 +1,23 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmddeploymentresource
+
+const (
+	shutdownLong = `Shuts down a deployment resource type (APM, Appsearch, Elasticsearch, Kibana). Shutting down a
+type doesn't necessarily shut down the deployment itself but rather a specific  resource.`
+)

--- a/docs/ecctl_deployment_resource_shutdown.md
+++ b/docs/ecctl_deployment_resource_shutdown.md
@@ -1,19 +1,24 @@
-## ecctl deployment resource
+## ecctl deployment resource shutdown
 
-Manages deployment resources
+Shuts down a deployment resource by its type and ref-id
 
 ### Synopsis
 
-Manages deployment resources
+Shuts down a deployment resource type (APM, Appsearch, Elasticsearch, Kibana). Shutting down a
+type doesn't necessarily shut down the deployment itself but rather a specific  resource.
 
 ```
-ecctl deployment resource [flags]
+ecctl deployment resource shutdown <deployment id> --type <type> --ref-id <ref-id> [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for resource
+  -h, --help                   help for shutdown
+      --hide string            Optionally hides the deployment resource from being listed by default
+      --ref-id string          Required deployment RefId
+      --skip-snapshot string   Optional flag to toggle skipping the resource snapshot before shutting it down
+      --type string            Required deployment type to shutdown (elasticsearch, kibana, apm, or appsearch)
 ```
 
 ### Options inherited from parent commands
@@ -38,7 +43,5 @@ ecctl deployment resource [flags]
 
 ### SEE ALSO
 
-* [ecctl deployment](ecctl_deployment.md)	 - Manages deployments
-* [ecctl deployment resource shutdown](ecctl_deployment_resource_shutdown.md)	 - Shuts down a deployment resource by its type and ref-id
-* [ecctl deployment resource upgrade](ecctl_deployment_resource_upgrade.md)	 - Upgrades a deployment resource
+* [ecctl deployment resource](ecctl_deployment_resource.md)	 - Manages deployment resources
 

--- a/docs/ecctl_deployment_resource_shutdown.md
+++ b/docs/ecctl_deployment_resource_shutdown.md
@@ -16,7 +16,7 @@ ecctl deployment resource shutdown <deployment id> --type <type> --ref-id <ref-i
 ```
   -h, --help            help for shutdown
       --hide            Optionally hides the deployment resource from being listed by default
-      --ref-id string   Required deployment RefId
+      --ref-id string   Optional deployment RefId, auto-discovered if not specified
       --skip-snapshot   Optional flag to toggle skipping the resource snapshot before shutting it down
       --type string     Required deployment type to shutdown (elasticsearch, kibana, apm, or appsearch)
 ```

--- a/docs/ecctl_deployment_resource_shutdown.md
+++ b/docs/ecctl_deployment_resource_shutdown.md
@@ -14,11 +14,11 @@ ecctl deployment resource shutdown <deployment id> --type <type> --ref-id <ref-i
 ### Options
 
 ```
-  -h, --help                   help for shutdown
-      --hide string            Optionally hides the deployment resource from being listed by default
-      --ref-id string          Required deployment RefId
-      --skip-snapshot string   Optional flag to toggle skipping the resource snapshot before shutting it down
-      --type string            Required deployment type to shutdown (elasticsearch, kibana, apm, or appsearch)
+  -h, --help            help for shutdown
+      --hide            Optionally hides the deployment resource from being listed by default
+      --ref-id string   Required deployment RefId
+      --skip-snapshot   Optional flag to toggle skipping the resource snapshot before shutting it down
+      --type string     Required deployment type to shutdown (elasticsearch, kibana, apm, or appsearch)
 ```
 
 ### Options inherited from parent commands

--- a/pkg/deployment/depresource/shutdown.go
+++ b/pkg/deployment/depresource/shutdown.go
@@ -18,23 +18,15 @@
 package depresource
 
 import (
-	"errors"
-
-	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/client/deployments"
-	"github.com/hashicorp/go-multierror"
 
-	"github.com/elastic/ecctl/pkg/deployment/deputil"
+	"github.com/elastic/ecctl/pkg/deployment"
 	"github.com/elastic/ecctl/pkg/util"
 )
 
 // ShutdownParams is consumed by Shutdown.
 type ShutdownParams struct {
-	*api.API
-
-	DeploymentID string
-	RefID        string
-	Type         string
+	deployment.ResourceParams
 
 	// Optional Values
 	// Skips taking a snapshot before shutting down the deployment resource.
@@ -44,31 +36,8 @@ type ShutdownParams struct {
 	Hide bool
 }
 
-// Validate ensures the parameters are usable by the consuming function.
-func (params ShutdownParams) Validate() error {
-	var merr = new(multierror.Error)
-
-	if params.API == nil {
-		merr = multierror.Append(merr, util.ErrAPIReq)
-	}
-
-	if len(params.DeploymentID) != 32 {
-		merr = multierror.Append(merr, deputil.NewInvalidDeploymentIDError(params.DeploymentID))
-	}
-
-	if params.RefID == "" {
-		merr = multierror.Append(merr, errors.New("deployment resource ref id cannot be empty"))
-	}
-
-	if params.Type == "" {
-		merr = multierror.Append(merr, errors.New("deployment resource type cannot be empty"))
-	}
-
-	return merr.ErrorOrNil()
-}
-
 // Shutdown stops all the running instances for the specified resource type ref
-// ID on a Deployment.
+// ID on a Deployment. If no refID is specified, it tries to autodiscover it.
 func Shutdown(params ShutdownParams) error {
 	if err := params.Validate(); err != nil {
 		return err

--- a/pkg/deployment/depresource/shutdown.go
+++ b/pkg/deployment/depresource/shutdown.go
@@ -1,0 +1,101 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package depresource
+
+import (
+	"errors"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/client/deployments"
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/elastic/ecctl/pkg/deployment/deputil"
+	"github.com/elastic/ecctl/pkg/util"
+)
+
+// ShutdownParams is consumed by Shutdown.
+type ShutdownParams struct {
+	*api.API
+
+	DeploymentID string
+	RefID        string
+	Type         string
+
+	// Optional Values
+	// Skips taking a snapshot before shutting down the deployment resource.
+	SkipSnapshot bool
+
+	// Hides the resource. Hidden resources are not listed by default.
+	Hide bool
+}
+
+// Validate ensures the parameters are usable by the consuming function.
+func (params ShutdownParams) Validate() error {
+	var merr = new(multierror.Error)
+
+	if params.API == nil {
+		merr = multierror.Append(merr, util.ErrAPIReq)
+	}
+
+	if len(params.DeploymentID) != 32 {
+		merr = multierror.Append(merr, deputil.NewInvalidDeploymentIDError(params.DeploymentID))
+	}
+
+	if params.RefID == "" {
+		merr = multierror.Append(merr, errors.New("deployment resource ref id cannot be empty"))
+	}
+
+	if params.Type == "" {
+		merr = multierror.Append(merr, errors.New("deployment resource type cannot be empty"))
+	}
+
+	return merr.ErrorOrNil()
+}
+
+// Shutdown stops all the running instances for the specified resource type ref
+// ID on a Deployment.
+func Shutdown(params ShutdownParams) error {
+	if err := params.Validate(); err != nil {
+		return err
+	}
+
+	if params.Type == "elasticsearch" {
+		return util.ReturnErrOnly(
+			params.V1API.Deployments.ShutdownDeploymentEsResource(
+				deployments.NewShutdownDeploymentEsResourceParams().
+					WithDeploymentID(params.DeploymentID).
+					WithSkipSnapshot(&params.SkipSnapshot).
+					WithRefID(params.RefID).
+					WithHide(&params.Hide),
+				params.AuthWriter,
+			),
+		)
+	}
+
+	return util.ReturnErrOnly(
+		params.V1API.Deployments.ShutdownDeploymentStatelessResource(
+			deployments.NewShutdownDeploymentStatelessResourceParams().
+				WithDeploymentID(params.DeploymentID).
+				WithSkipSnapshot(&params.SkipSnapshot).
+				WithStatelessResourceKind(params.Type).
+				WithRefID(params.RefID).
+				WithHide(&params.Hide),
+			params.AuthWriter,
+		),
+	)
+}

--- a/pkg/deployment/depresource/shutdown_test.go
+++ b/pkg/deployment/depresource/shutdown_test.go
@@ -20,14 +20,17 @@ package depresource
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
 	"github.com/hashicorp/go-multierror"
 
+	"github.com/elastic/ecctl/pkg/deployment"
 	"github.com/elastic/ecctl/pkg/deployment/deputil"
 	"github.com/elastic/ecctl/pkg/util"
 )
@@ -51,65 +54,113 @@ func TestShutdown(t *testing.T) {
 			err: &multierror.Error{Errors: []error{
 				util.ErrAPIReq,
 				deputil.NewInvalidDeploymentIDError(""),
-				errors.New("deployment resource ref id cannot be empty"),
 				errors.New("deployment resource type cannot be empty"),
+				errors.New("failed auto-discovering the resource ref id: api reference is required for command"),
+				errors.New("failed auto-discovering the resource ref id: id \"\" is invalid"),
 			}},
 		},
 		{
 			name: "Returns error on type Elasticsearch and a received API error",
 			args: args{params: ShutdownParams{
-				API:          api.NewMock(mock.New404Response(mock.NewStructBody(error404))),
-				DeploymentID: util.ValidClusterID,
-				RefID:        "elasticsearch",
-				Type:         "elasticsearch",
+				ResourceParams: deployment.ResourceParams{
+					API:          api.NewMock(mock.New404Response(mock.NewStructBody(error404))),
+					DeploymentID: util.ValidClusterID,
+					RefID:        "elasticsearch",
+					Type:         "elasticsearch",
+				},
 			}},
 			err: errors.New(string(error404Byte)),
 		},
 		{
 			name: "Returns error on type APM and a received API error",
 			args: args{params: ShutdownParams{
-				API:          api.NewMock(mock.New404Response(mock.NewStructBody(error404))),
-				DeploymentID: util.ValidClusterID,
-				RefID:        "apm",
-				Type:         "apm",
+				ResourceParams: deployment.ResourceParams{
+					API:          api.NewMock(mock.New404Response(mock.NewStructBody(error404))),
+					DeploymentID: util.ValidClusterID,
+					RefID:        "apm",
+					Type:         "apm",
+				},
 			}},
 			err: errors.New(string(error404Byte)),
 		},
 		{
 			name: "Returns error on type Kibana and a received API error",
 			args: args{params: ShutdownParams{
-				API:          api.NewMock(mock.New404Response(mock.NewStructBody(error404))),
-				DeploymentID: util.ValidClusterID,
-				RefID:        "kibana",
-				Type:         "kibana",
+				ResourceParams: deployment.ResourceParams{
+					API:          api.NewMock(mock.New404Response(mock.NewStructBody(error404))),
+					DeploymentID: util.ValidClusterID,
+					RefID:        "kibana",
+					Type:         "kibana",
+				},
 			}},
 			err: errors.New(string(error404Byte)),
 		},
 		{
+			name: "Succeeds on type Elasticsearch with autodiscover of the type",
+			args: args{params: ShutdownParams{
+				ResourceParams: deployment.ResourceParams{
+					API: api.NewMock(
+						mock.New200Response(mock.NewStructBody(models.DeploymentGetResponse{
+							Healthy: ec.Bool(true),
+							ID:      ec.String(util.ValidClusterID),
+							Resources: &models.DeploymentResources{
+								Elasticsearch: []*models.ElasticsearchResourceInfo{{
+									ID:    ec.String(util.ValidClusterID),
+									RefID: ec.String("elasticsearch"),
+								}},
+							},
+						})),
+						mock.New200Response(mock.NewStructBody(struct{}{})),
+					),
+					DeploymentID: util.ValidClusterID,
+					Type:         "elasticsearch",
+				},
+			}},
+		},
+		{
+			name: "Fails on type Elasticsearch when autodiscover returns an error",
+			args: args{params: ShutdownParams{
+				ResourceParams: deployment.ResourceParams{
+					API:          api.NewMock(mock.New404Response(mock.NewStructBody(error404))),
+					DeploymentID: util.ValidClusterID,
+					Type:         "elasticsearch",
+				},
+			}},
+			err: &multierror.Error{Errors: []error{
+				fmt.Errorf("failed auto-discovering the resource ref id: %s", string(error404Byte)),
+			}},
+		},
+		{
 			name: "Succeeds on type Elasticsearch",
 			args: args{params: ShutdownParams{
-				API:          api.NewMock(mock.New200Response(mock.NewStructBody(struct{}{}))),
-				DeploymentID: util.ValidClusterID,
-				RefID:        "elasticsearch",
-				Type:         "elasticsearch",
+				ResourceParams: deployment.ResourceParams{
+					API:          api.NewMock(mock.New200Response(mock.NewStructBody(struct{}{}))),
+					DeploymentID: util.ValidClusterID,
+					RefID:        "elasticsearch",
+					Type:         "elasticsearch",
+				},
 			}},
 		},
 		{
 			name: "Succeeds on type APM",
 			args: args{params: ShutdownParams{
-				API:          api.NewMock(mock.New200Response(mock.NewStructBody(struct{}{}))),
-				DeploymentID: util.ValidClusterID,
-				RefID:        "apm",
-				Type:         "apm",
+				ResourceParams: deployment.ResourceParams{
+					API:          api.NewMock(mock.New200Response(mock.NewStructBody(struct{}{}))),
+					DeploymentID: util.ValidClusterID,
+					RefID:        "apm",
+					Type:         "apm",
+				},
 			}},
 		},
 		{
 			name: "Succeeds on type Kibana",
 			args: args{params: ShutdownParams{
-				API:          api.NewMock(mock.New200Response(mock.NewStructBody(struct{}{}))),
-				DeploymentID: util.ValidClusterID,
-				RefID:        "kibana",
-				Type:         "kibana",
+				ResourceParams: deployment.ResourceParams{
+					API:          api.NewMock(mock.New200Response(mock.NewStructBody(struct{}{}))),
+					DeploymentID: util.ValidClusterID,
+					RefID:        "kibana",
+					Type:         "kibana",
+				},
 			}},
 		},
 	}

--- a/pkg/deployment/depresource/shutdown_test.go
+++ b/pkg/deployment/depresource/shutdown_test.go
@@ -1,0 +1,123 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package depresource
+
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/elastic/ecctl/pkg/deployment/deputil"
+	"github.com/elastic/ecctl/pkg/util"
+)
+
+func TestShutdown(t *testing.T) {
+	var error404 = models.BasicFailedReply{Errors: []*models.BasicFailedReplyElement{
+		{},
+	}}
+	error404Byte, _ := json.MarshalIndent(error404, "", "  ")
+	type args struct {
+		params ShutdownParams
+	}
+	tests := []struct {
+		name string
+		args args
+		err  error
+	}{
+		{
+			name: "fails due to parameter validation",
+			args: args{},
+			err: &multierror.Error{Errors: []error{
+				util.ErrAPIReq,
+				deputil.NewInvalidDeploymentIDError(""),
+				errors.New("deployment resource ref id cannot be empty"),
+				errors.New("deployment resource type cannot be empty"),
+			}},
+		},
+		{
+			name: "Returns error on type Elasticsearch and a received API error",
+			args: args{params: ShutdownParams{
+				API:          api.NewMock(mock.New404Response(mock.NewStructBody(error404))),
+				DeploymentID: util.ValidClusterID,
+				RefID:        "elasticsearch",
+				Type:         "elasticsearch",
+			}},
+			err: errors.New(string(error404Byte)),
+		},
+		{
+			name: "Returns error on type APM and a received API error",
+			args: args{params: ShutdownParams{
+				API:          api.NewMock(mock.New404Response(mock.NewStructBody(error404))),
+				DeploymentID: util.ValidClusterID,
+				RefID:        "apm",
+				Type:         "apm",
+			}},
+			err: errors.New(string(error404Byte)),
+		},
+		{
+			name: "Returns error on type Kibana and a received API error",
+			args: args{params: ShutdownParams{
+				API:          api.NewMock(mock.New404Response(mock.NewStructBody(error404))),
+				DeploymentID: util.ValidClusterID,
+				RefID:        "kibana",
+				Type:         "kibana",
+			}},
+			err: errors.New(string(error404Byte)),
+		},
+		{
+			name: "Succeeds on type Elasticsearch",
+			args: args{params: ShutdownParams{
+				API:          api.NewMock(mock.New200Response(mock.NewStructBody(struct{}{}))),
+				DeploymentID: util.ValidClusterID,
+				RefID:        "elasticsearch",
+				Type:         "elasticsearch",
+			}},
+		},
+		{
+			name: "Succeeds on type APM",
+			args: args{params: ShutdownParams{
+				API:          api.NewMock(mock.New200Response(mock.NewStructBody(struct{}{}))),
+				DeploymentID: util.ValidClusterID,
+				RefID:        "apm",
+				Type:         "apm",
+			}},
+		},
+		{
+			name: "Succeeds on type Kibana",
+			args: args{params: ShutdownParams{
+				API:          api.NewMock(mock.New200Response(mock.NewStructBody(struct{}{}))),
+				DeploymentID: util.ValidClusterID,
+				RefID:        "kibana",
+				Type:         "kibana",
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := Shutdown(tt.args.params); !reflect.DeepEqual(err, tt.err) {
+				t.Errorf("Shutdown() error = %v, wantErr %v", err, tt.err)
+			}
+		})
+	}
+}

--- a/pkg/deployment/params.go
+++ b/pkg/deployment/params.go
@@ -1,0 +1,84 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package deployment
+
+import (
+	"errors"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/elastic/ecctl/pkg/deployment/deputil"
+	"github.com/elastic/ecctl/pkg/util"
+)
+
+// ResourceParams can be embedded in any structure which makes use of the
+// deployment/resource API which always require the fields. Also provides
+// RefID auto-discovery for the deployment resource kind if not specified.
+type ResourceParams struct {
+	*api.API
+
+	DeploymentID string
+	Type         string
+	RefID        string
+}
+
+// Validate ensures the parameters are usable by the consuming function.
+func (params *ResourceParams) Validate() error {
+	var merr = new(multierror.Error)
+
+	if params.API == nil {
+		merr = multierror.Append(merr, util.ErrAPIReq)
+	}
+
+	if len(params.DeploymentID) != 32 {
+		merr = multierror.Append(merr, deputil.NewInvalidDeploymentIDError(params.DeploymentID))
+	}
+
+	if params.Type == "" {
+		merr = multierror.Append(merr, errors.New("deployment resource type cannot be empty"))
+	}
+
+	// Ensures that RefID is either populated when the RefID isn't specified or
+	// returns an error when it fails obtaining the ref ID.
+	if err := params.fillDefaults(); err != nil {
+		merr = multierror.Append(merr,
+			util.WrapError("failed auto-discovering the resource ref id", err),
+		)
+	}
+
+	return merr.ErrorOrNil()
+}
+
+// fillDefaults populates the RefID through an API call.
+func (params *ResourceParams) fillDefaults() error {
+	if params.RefID != "" {
+		return nil
+	}
+
+	refID, err := GetTypeRefID(GetResourceParams{
+		GetParams: GetParams{
+			API:          params.API,
+			DeploymentID: params.DeploymentID,
+		},
+		Type: params.Type,
+	})
+
+	params.RefID = refID
+	return err
+}

--- a/pkg/deployment/params_test.go
+++ b/pkg/deployment/params_test.go
@@ -1,0 +1,98 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package deployment
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/elastic/ecctl/pkg/deployment/deputil"
+	"github.com/elastic/ecctl/pkg/util"
+)
+
+func TestResourceParams_Validate(t *testing.T) {
+	var error404 = models.BasicFailedReply{Errors: []*models.BasicFailedReplyElement{
+		{},
+	}}
+	error404Byte, _ := json.MarshalIndent(error404, "", "  ")
+	type fields struct {
+		API          *api.API
+		DeploymentID string
+		Type         string
+		RefID        string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		err    error
+	}{
+		{
+			name:   "fails on empty parameters",
+			fields: fields{},
+			err: &multierror.Error{Errors: []error{
+				util.ErrAPIReq,
+				deputil.NewInvalidDeploymentIDError(""),
+				errors.New("deployment resource type cannot be empty"),
+				errors.New("failed auto-discovering the resource ref id: api reference is required for command"),
+				errors.New(`failed auto-discovering the resource ref id: id "" is invalid`),
+			}},
+		},
+		{
+			name: "succeeds validation when refID is populated",
+			fields: fields{
+				API:          api.NewMock(),
+				DeploymentID: util.ValidClusterID,
+				Type:         "elasticsearch",
+				RefID:        "main-elasticsearch",
+			},
+		},
+		{
+			name: "returns error when autodiscovery of ref-id fails",
+			fields: fields{
+				API:          api.NewMock(mock.New404Response(mock.NewStructBody(error404))),
+				DeploymentID: util.ValidClusterID,
+				Type:         "elasticsearch",
+			},
+			err: &multierror.Error{Errors: []error{
+				fmt.Errorf("failed auto-discovering the resource ref id: %s", string(error404Byte)),
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := &ResourceParams{
+				API:          tt.fields.API,
+				DeploymentID: tt.fields.DeploymentID,
+				Type:         tt.fields.Type,
+				RefID:        tt.fields.RefID,
+			}
+
+			if err := params.Validate(); !reflect.DeepEqual(err, tt.err) {
+				t.Errorf("ResourceParams.Validate() error = %v, wantErr %v", err, tt.err)
+			}
+		})
+	}
+}

--- a/pkg/util/error_test.go
+++ b/pkg/util/error_test.go
@@ -1,0 +1,98 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package util
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+func TestWrapError(t *testing.T) {
+	type args struct {
+		text string
+		err  error
+	}
+	tests := []struct {
+		name string
+		args args
+		err  error
+	}{
+		{
+			name: "returns nil",
+		},
+		{
+			name: "returns a wrapped error",
+			args: args{
+				text: "some",
+				err:  errors.New("some error"),
+			},
+			err: errors.New("some: some error"),
+		},
+		{
+			name: "returns the error when the text is empty",
+			args: args{
+				text: "",
+				err:  errors.New("some error"),
+			},
+			err: errors.New("some error"),
+		},
+		{
+			name: "returns nil when error is empty",
+			args: args{
+				text: "",
+			},
+		},
+		{
+			name: "returns a wrapped multierror",
+			args: args{
+				text: "some wrapping text",
+				err: &multierror.Error{Errors: []error{
+					errors.New("error 1"),
+					errors.New("error 2"),
+				}},
+			},
+			err: &multierror.Error{Errors: []error{
+				errors.New("some wrapping text: error 1"),
+				errors.New("some wrapping text: error 2"),
+			}},
+		},
+		{
+			name: "returns the multierror when text is empty",
+			args: args{
+				err: &multierror.Error{Errors: []error{
+					errors.New("error 1"),
+					errors.New("error 2"),
+				}},
+			},
+			err: &multierror.Error{Errors: []error{
+				errors.New("error 1"),
+				errors.New("error 2"),
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := WrapError(tt.args.text, tt.args.err); !reflect.DeepEqual(err, tt.err) {
+				t.Errorf("WrapError() error = %v, wantErr %v", err, tt.err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds a `ecctl deployment resource shutdown` command which allows
specific deployment resources to be targetted for shutdown. It requires
two flags: `--ref-id` and `--type` which the user needs to specify as
per the shown help.

Additionally, two optional flags `--hide` and `--skip-snapshot` are
available to toggle those options

Furthermore, it extracts the common fields `API`, `DeploymentID`, `Type`
and `RefID`, adding RefID auto-discovery when not specified.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

