### PR TITLE
cmd: Add deployment resource restore command

### DIFF
--- a/cmd/deployment/resource/restore.go
+++ b/cmd/deployment/resource/restore.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 
 	cmdutil "github.com/elastic/ecctl/cmd/util"
+	"github.com/elastic/ecctl/pkg/deployment"
 	"github.com/elastic/ecctl/pkg/deployment/depresource"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
@@ -53,10 +54,12 @@ var restoreCmd = &cobra.Command{
 		}
 
 		return depresource.Restore(depresource.RestoreParams{
-			API:             ecctl.Get().API,
-			DeploymentID:    args[0],
-			Type:            resType,
-			RefID:           refID,
+			ResourceParams: deployment.ResourceParams{
+				API:          ecctl.Get().API,
+				DeploymentID: args[0],
+				Type:         resType,
+				RefID:        refID,
+			},
 			RestoreSnapshot: restoreSnapshot,
 		})
 	},
@@ -66,7 +69,6 @@ func init() {
 	Command.AddCommand(restoreCmd)
 	restoreCmd.Flags().String("type", "", "Required deployment type to restore (elasticsearch, kibana, apm, or appsearch)")
 	restoreCmd.MarkFlagRequired("type")
-	restoreCmd.Flags().String("ref-id", "", "Required deployment RefId")
-	restoreCmd.MarkFlagRequired("ref-id")
+	restoreCmd.Flags().String("ref-id", "", "Optional deployment RefId, auto-discovered if not specified")
 	restoreCmd.Flags().Bool("restore-snapshot", false, "Optional flag to toggle restoring a snapshot for an Elasticsearch resource. It has no effect for other resources")
 }

--- a/cmd/deployment/resource/restore.go
+++ b/cmd/deployment/resource/restore.go
@@ -68,5 +68,5 @@ func init() {
 	restoreCmd.MarkFlagRequired("type")
 	restoreCmd.Flags().String("ref-id", "", "Required deployment RefId")
 	restoreCmd.MarkFlagRequired("ref-id")
-	restoreCmd.Flags().Bool("restore-snapshot", false, "Optional flag to toggle restoring a snapshot for an Elasticsearch resource. It has no eeffect for other resources")
+	restoreCmd.Flags().Bool("restore-snapshot", false, "Optional flag to toggle restoring a snapshot for an Elasticsearch resource. It has no effect for other resources")
 }

--- a/cmd/deployment/resource/restore.go
+++ b/cmd/deployment/resource/restore.go
@@ -1,0 +1,64 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmddeploymentresource
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	cmdutil "github.com/elastic/ecctl/cmd/util"
+	"github.com/elastic/ecctl/pkg/deployment/depresource"
+	"github.com/elastic/ecctl/pkg/ecctl"
+)
+
+// restoreCmd is the deployment subcommand
+var restoreCmd = &cobra.Command{
+	Use:     "restore <deployment id> --type <type> --ref-id <ref-id>",
+	Short:   "Restores a previously shut down deployment resource",
+	PreRunE: cmdutil.MinimumNArgsAndUUID(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		resType, _ := cmd.Flags().GetString("type")
+		refID, _ := cmd.Flags().GetString("ref-id")
+		restoreSnapshot, _ := cmd.Flags().GetBool("restore-snapshot")
+
+		force, _ := cmd.Flags().GetBool("force")
+		var dataLoss = resType == "elasticsearch" && !restoreSnapshot
+		var msg = "This action restore an Elasticsearch resource without its snapshot which might incur data loss, do you want to continue? [y/n]: "
+		if dataLoss && !force && !cmdutil.ConfirmAction(msg, os.Stderr, os.Stdout) {
+			return nil
+		}
+
+		return depresource.Restore(depresource.RestoreParams{
+			API:             ecctl.Get().API,
+			DeploymentID:    args[0],
+			Type:            resType,
+			RefID:           refID,
+			RestoreSnapshot: restoreSnapshot,
+		})
+	},
+}
+
+func init() {
+	Command.AddCommand(restoreCmd)
+	restoreCmd.Flags().String("type", "", "Required stateless deployment type to restore (elasticsearch, kibana, apm, or appsearch)")
+	restoreCmd.MarkFlagRequired("type")
+	restoreCmd.Flags().String("ref-id", "", "Required deployment RefId")
+	restoreCmd.MarkFlagRequired("ref-id")
+	restoreCmd.Flags().Bool("restore-snapshot", false, "Optional flag to toggle restoring a snapshot for an Elasticsearch resource")
+}

--- a/docs/ecctl_deployment_resource_restore.md
+++ b/docs/ecctl_deployment_resource_restore.md
@@ -15,8 +15,8 @@ ecctl deployment resource restore <deployment id> --type <type> --ref-id <ref-id
 ```
   -h, --help               help for restore
       --ref-id string      Required deployment RefId
-      --restore-snapshot   Optional flag to toggle restoring a snapshot for an Elasticsearch resource
-      --type string        Required stateless deployment type to restore (elasticsearch, kibana, apm, or appsearch)
+      --restore-snapshot   Optional flag to toggle restoring a snapshot for an Elasticsearch resource. It has no effect for other resources
+      --type string        Required deployment type to restore (elasticsearch, kibana, apm, or appsearch)
 ```
 
 ### Options inherited from parent commands

--- a/docs/ecctl_deployment_resource_restore.md
+++ b/docs/ecctl_deployment_resource_restore.md
@@ -14,7 +14,7 @@ ecctl deployment resource restore <deployment id> --type <type> --ref-id <ref-id
 
 ```
   -h, --help               help for restore
-      --ref-id string      Required deployment RefId
+      --ref-id string      Optional deployment RefId, auto-discovered if not specified
       --restore-snapshot   Optional flag to toggle restoring a snapshot for an Elasticsearch resource. It has no effect for other resources
       --type string        Required deployment type to restore (elasticsearch, kibana, apm, or appsearch)
 ```

--- a/docs/ecctl_deployment_resource_restore.md
+++ b/docs/ecctl_deployment_resource_restore.md
@@ -1,19 +1,22 @@
-## ecctl deployment resource
+## ecctl deployment resource restore
 
-Manages deployment resources
+Restores a previously shut down deployment resource
 
 ### Synopsis
 
-Manages deployment resources
+Restores a previously shut down deployment resource
 
 ```
-ecctl deployment resource [flags]
+ecctl deployment resource restore <deployment id> --type <type> --ref-id <ref-id> [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for resource
+  -h, --help               help for restore
+      --ref-id string      Required deployment RefId
+      --restore-snapshot   Optional flag to toggle restoring a snapshot for an Elasticsearch resource
+      --type string        Required stateless deployment type to restore (elasticsearch, kibana, apm, or appsearch)
 ```
 
 ### Options inherited from parent commands
@@ -38,8 +41,5 @@ ecctl deployment resource [flags]
 
 ### SEE ALSO
 
-* [ecctl deployment](ecctl_deployment.md)	 - Manages deployments
-* [ecctl deployment resource restore](ecctl_deployment_resource_restore.md)	 - Restores a previously shut down deployment resource
-* [ecctl deployment resource shutdown](ecctl_deployment_resource_shutdown.md)	 - Shuts down a deployment resource by its type and ref-id
-* [ecctl deployment resource upgrade](ecctl_deployment_resource_upgrade.md)	 - Upgrades a deployment resource
+* [ecctl deployment resource](ecctl_deployment_resource.md)	 - Manages deployment resources
 

--- a/pkg/deployment/depresource/restore.go
+++ b/pkg/deployment/depresource/restore.go
@@ -18,49 +18,18 @@
 package depresource
 
 import (
-	"errors"
-
-	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/client/deployments"
-	"github.com/hashicorp/go-multierror"
 
-	"github.com/elastic/ecctl/pkg/deployment/deputil"
+	"github.com/elastic/ecctl/pkg/deployment"
 	"github.com/elastic/ecctl/pkg/util"
 )
 
 // RestoreParams is consumed by Restore
 type RestoreParams struct {
-	*api.API
-
-	DeploymentID string
-	Type         string
-	RefID        string
+	deployment.ResourceParams
 
 	// Optional
 	RestoreSnapshot bool
-}
-
-// Validate ensures the parameters are usable by the consuming function.
-func (params RestoreParams) Validate() error {
-	var merr = new(multierror.Error)
-
-	if params.API == nil {
-		merr = multierror.Append(merr, util.ErrAPIReq)
-	}
-
-	if len(params.DeploymentID) != 32 {
-		merr = multierror.Append(merr, deputil.NewInvalidDeploymentIDError(params.DeploymentID))
-	}
-
-	if params.RefID == "" {
-		merr = multierror.Append(merr, errors.New("deployment resource ref id cannot be empty"))
-	}
-
-	if params.Type == "" {
-		merr = multierror.Append(merr, errors.New("deployment resource type cannot be empty"))
-	}
-
-	return merr.ErrorOrNil()
 }
 
 // Restore upgrades a stateless deployment resource like APM, Kibana

--- a/pkg/deployment/depresource/restore.go
+++ b/pkg/deployment/depresource/restore.go
@@ -1,0 +1,81 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package depresource
+
+import (
+	"errors"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/client/deployments"
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/elastic/ecctl/pkg/deployment/deputil"
+	"github.com/elastic/ecctl/pkg/util"
+)
+
+// RestoreParams is consumed by Restore
+type RestoreParams struct {
+	*api.API
+
+	DeploymentID string
+	Type         string
+	RefID        string
+
+	// Optional
+	RestoreSnapshot bool
+}
+
+// Validate ensures the parameters are usable by the consuming function.
+func (params RestoreParams) Validate() error {
+	var merr = new(multierror.Error)
+
+	if params.API == nil {
+		merr = multierror.Append(merr, util.ErrAPIReq)
+	}
+
+	if len(params.DeploymentID) != 32 {
+		merr = multierror.Append(merr, deputil.NewInvalidDeploymentIDError(params.DeploymentID))
+	}
+
+	if params.RefID == "" {
+		merr = multierror.Append(merr, errors.New("deployment resource ref id cannot be empty"))
+	}
+
+	if params.Type == "" {
+		merr = multierror.Append(merr, errors.New("deployment resource type cannot be empty"))
+	}
+
+	return merr.ErrorOrNil()
+}
+
+// Restore upgrades a stateless deployment resource like APM, Kibana
+// and AppSearch.
+func Restore(params RestoreParams) error {
+	if err := params.Validate(); err != nil {
+		return err
+	}
+
+	return util.ReturnErrOnly(params.V1API.Deployments.RestoreDeploymentResource(
+		deployments.NewRestoreDeploymentResourceParams().
+			WithRestoreSnapshot(&params.RestoreSnapshot).
+			WithResourceKind(params.Type).
+			WithDeploymentID(params.DeploymentID).
+			WithRefID(params.RefID),
+		params.AuthWriter,
+	))
+}

--- a/pkg/deployment/depresource/restore_test.go
+++ b/pkg/deployment/depresource/restore_test.go
@@ -1,0 +1,124 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package depresource
+
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/elastic/ecctl/pkg/deployment/deputil"
+	"github.com/elastic/ecctl/pkg/util"
+)
+
+func TestRestore(t *testing.T) {
+	var internalError = models.BasicFailedReply{
+		Errors: []*models.BasicFailedReplyElement{
+			{},
+		},
+	}
+	internalErrorBytes, _ := json.MarshalIndent(internalError, "", "  ")
+	type args struct {
+		params RestoreParams
+	}
+	tests := []struct {
+		name string
+		args args
+		err  error
+	}{
+		{
+			name: "fails due to param validation",
+			err: &multierror.Error{Errors: []error{
+				util.ErrAPIReq,
+				deputil.NewInvalidDeploymentIDError(""),
+				errors.New("deployment resource ref id cannot be empty"),
+				errors.New("deployment resource type cannot be empty"),
+			}},
+		},
+		{
+			name: "fails due to restore Kibana due to API error",
+			args: args{params: RestoreParams{
+				API:          api.NewMock(mock.New404Response(mock.NewStructBody(internalError))),
+				DeploymentID: util.ValidClusterID,
+				RefID:        "kibana",
+				Type:         "kibana",
+			}},
+			err: errors.New(string(internalErrorBytes)),
+		},
+		{
+			name: "fails to restore APM due to API error",
+			args: args{params: RestoreParams{
+				API:          api.NewMock(mock.New404Response(mock.NewStructBody(internalError))),
+				DeploymentID: util.ValidClusterID,
+				RefID:        "apm",
+				Type:         "apm",
+			}},
+			err: errors.New(string(internalErrorBytes)),
+		},
+		{
+			name: "fails due to restore Elasticsearch due to API error",
+			args: args{params: RestoreParams{
+				API:          api.NewMock(mock.New404Response(mock.NewStructBody(internalError))),
+				DeploymentID: util.ValidClusterID,
+				RefID:        "elasticsearch",
+				Type:         "elasticsearch",
+			}},
+			err: errors.New(string(internalErrorBytes)),
+		},
+		{
+			name: "Succeeds restoring Kibana",
+			args: args{params: RestoreParams{
+				API:          api.NewMock(mock.New200Response(mock.NewStringBody(""))),
+				DeploymentID: util.ValidClusterID,
+				RefID:        "kibana",
+				Type:         "kibana",
+			}},
+		},
+		{
+			name: "Succeeds restoring APM",
+			args: args{params: RestoreParams{
+				API:          api.NewMock(mock.New200Response(mock.NewStringBody(""))),
+				DeploymentID: util.ValidClusterID,
+				RefID:        "apm",
+				Type:         "apm",
+			}},
+		},
+		{
+			name: "Succeeds restoring Elasticsearch",
+			args: args{params: RestoreParams{
+				API:          api.NewMock(mock.New200Response(mock.NewStringBody(""))),
+				DeploymentID: util.ValidClusterID,
+				RefID:        "elasticsearch",
+				Type:         "elasticsearch",
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := Restore(tt.args.params); !reflect.DeepEqual(err, tt.err) {
+				t.Errorf("Restore() error = %v, wantErr %v", err, tt.err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds an `ecctl deployment resource restore` command which restores a
previously shut down individual deployment resource. If ref-id not specified
it's auto-discovered via an API call.

Required flags: `--type`.
Optional flag: `--restore-snapshot` and `--ref-id` 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

