### PR TITLE
cmd: Add deployment resource delete command

### DIFF
--- a/cmd/deployment/resource/delete.go
+++ b/cmd/deployment/resource/delete.go
@@ -1,0 +1,52 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmddeploymentresource
+
+import (
+	"github.com/spf13/cobra"
+
+	cmdutil "github.com/elastic/ecctl/cmd/util"
+	"github.com/elastic/ecctl/pkg/deployment/depresource"
+	"github.com/elastic/ecctl/pkg/ecctl"
+)
+
+// deleteCmd is the deployment subcommand
+var deleteCmd = &cobra.Command{
+	Use:     "delete <deployment id> --type <type> --ref-id <ref-id>",
+	Short:   "Deletes a previously shut down deployment resource",
+	PreRunE: cmdutil.MinimumNArgsAndUUID(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		resType, _ := cmd.Flags().GetString("type")
+		refID, _ := cmd.Flags().GetString("ref-id")
+
+		return depresource.DeleteStateless(depresource.DeleteStatelessParams{
+			API:          ecctl.Get().API,
+			DeploymentID: args[0],
+			Type:         resType,
+			RefID:        refID,
+		})
+	},
+}
+
+func init() {
+	Command.AddCommand(deleteCmd)
+	deleteCmd.Flags().String("type", "", "Required stateless deployment type to upgrade (kibana, apm, or appsearch)")
+	deleteCmd.MarkFlagRequired("type")
+	deleteCmd.Flags().String("ref-id", "", "Required deployment RefId")
+	deleteCmd.MarkFlagRequired("ref-id")
+}

--- a/cmd/deployment/resource/delete.go
+++ b/cmd/deployment/resource/delete.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 
 	cmdutil "github.com/elastic/ecctl/cmd/util"
+	"github.com/elastic/ecctl/pkg/deployment"
 	"github.com/elastic/ecctl/pkg/deployment/depresource"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
@@ -35,10 +36,12 @@ var deleteCmd = &cobra.Command{
 		refID, _ := cmd.Flags().GetString("ref-id")
 
 		return depresource.DeleteStateless(depresource.DeleteStatelessParams{
-			API:          ecctl.Get().API,
-			DeploymentID: args[0],
-			Type:         resType,
-			RefID:        refID,
+			ResourceParams: deployment.ResourceParams{
+				API:          ecctl.Get().API,
+				DeploymentID: args[0],
+				Type:         resType,
+				RefID:        refID,
+			},
 		})
 	},
 }
@@ -47,6 +50,5 @@ func init() {
 	Command.AddCommand(deleteCmd)
 	deleteCmd.Flags().String("type", "", "Required stateless deployment type to upgrade (kibana, apm, or appsearch)")
 	deleteCmd.MarkFlagRequired("type")
-	deleteCmd.Flags().String("ref-id", "", "Required deployment RefId")
-	deleteCmd.MarkFlagRequired("ref-id")
+	deleteCmd.Flags().String("ref-id", "", "Optional deployment RefId, auto-discovered if not specified")
 }

--- a/docs/ecctl_deployment_resource_delete.md
+++ b/docs/ecctl_deployment_resource_delete.md
@@ -1,19 +1,21 @@
-## ecctl deployment resource
+## ecctl deployment resource delete
 
-Manages deployment resources
+Deletes a previously shut down deployment resource
 
 ### Synopsis
 
-Manages deployment resources
+Deletes a previously shut down deployment resource
 
 ```
-ecctl deployment resource [flags]
+ecctl deployment resource delete <deployment id> --type <type> --ref-id <ref-id> [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for resource
+  -h, --help            help for delete
+      --ref-id string   Required deployment RefId
+      --type string     Required stateless deployment type to upgrade (kibana, apm, or appsearch)
 ```
 
 ### Options inherited from parent commands
@@ -38,13 +40,5 @@ ecctl deployment resource [flags]
 
 ### SEE ALSO
 
-* [ecctl deployment](ecctl_deployment.md)	 - Manages deployments
-* [ecctl deployment resource delete](ecctl_deployment_resource_delete.md)	 - Deletes a previously shut down deployment resource
-* [ecctl deployment resource restore](ecctl_deployment_resource_restore.md)	 - Restores a previously shut down deployment resource
-* [ecctl deployment resource shutdown](ecctl_deployment_resource_shutdown.md)	 - Shuts down a deployment resource by its type and ref-id
-* [ecctl deployment resource start](ecctl_deployment_resource_start.md)	 - Starts a previously stopped deployment resource
-* [ecctl deployment resource start-maintenance](ecctl_deployment_resource_start-maintenance.md)	 - Starts maintenance mode on a deployment resource
-* [ecctl deployment resource stop](ecctl_deployment_resource_stop.md)	 - Stops a deployment resource
-* [ecctl deployment resource stop-maintenance](ecctl_deployment_resource_stop-maintenance.md)	 - Stops maintenance mode on a deployment resource
-* [ecctl deployment resource upgrade](ecctl_deployment_resource_upgrade.md)	 - Upgrades a deployment resource
+* [ecctl deployment resource](ecctl_deployment_resource.md)	 - Manages deployment resources
 

--- a/docs/ecctl_deployment_resource_delete.md
+++ b/docs/ecctl_deployment_resource_delete.md
@@ -14,7 +14,7 @@ ecctl deployment resource delete <deployment id> --type <type> --ref-id <ref-id>
 
 ```
   -h, --help            help for delete
-      --ref-id string   Required deployment RefId
+      --ref-id string   Optional deployment RefId, auto-discovered if not specified
       --type string     Required stateless deployment type to upgrade (kibana, apm, or appsearch)
 ```
 

--- a/pkg/deployment/depresource/delete_stateless.go
+++ b/pkg/deployment/depresource/delete_stateless.go
@@ -1,0 +1,83 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package depresource
+
+import (
+	"errors"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/client/deployments"
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/elastic/ecctl/pkg/deployment/deputil"
+	"github.com/elastic/ecctl/pkg/util"
+)
+
+// DeleteStatelessParams is consumed by Delete
+type DeleteStatelessParams struct {
+	*api.API
+
+	DeploymentID string
+	Type         string
+	RefID        string
+}
+
+// Validate ensures the parameters are usable by the consuming function.
+func (params DeleteStatelessParams) Validate() error {
+	var merr = new(multierror.Error)
+
+	if params.API == nil {
+		merr = multierror.Append(merr, util.ErrAPIReq)
+	}
+
+	if len(params.DeploymentID) != 32 {
+		merr = multierror.Append(merr, deputil.NewInvalidDeploymentIDError(params.DeploymentID))
+	}
+
+	if params.RefID == "" {
+		merr = multierror.Append(merr, errors.New("deployment resource ref id cannot be empty"))
+	}
+
+	if params.Type == "" {
+		merr = multierror.Append(merr, errors.New("deployment resource type cannot be empty"))
+	}
+
+	if params.Type == "elasticsearch" {
+		merr = multierror.Append(merr, errors.New("deployment resource type \"elasticsearch\" is not supported"))
+	}
+
+	return merr.ErrorOrNil()
+}
+
+// DeleteStateless upgrades a stateless deployment resource like APM, Kibana
+// and AppSearch.
+func DeleteStateless(params DeleteStatelessParams) error {
+	if err := params.Validate(); err != nil {
+		return err
+	}
+
+	return util.ReturnErrOnly(
+		params.V1API.Deployments.DeleteDeploymentStatelessResource(
+			deployments.NewDeleteDeploymentStatelessResourceParams().
+				WithStatelessResourceKind(params.Type).
+				WithDeploymentID(params.DeploymentID).
+				WithRefID(params.RefID),
+			params.AuthWriter,
+		),
+	)
+}

--- a/pkg/deployment/depresource/delete_stateless.go
+++ b/pkg/deployment/depresource/delete_stateless.go
@@ -20,42 +20,23 @@ package depresource
 import (
 	"errors"
 
-	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/client/deployments"
 	"github.com/hashicorp/go-multierror"
 
-	"github.com/elastic/ecctl/pkg/deployment/deputil"
+	"github.com/elastic/ecctl/pkg/deployment"
 	"github.com/elastic/ecctl/pkg/util"
 )
 
 // DeleteStatelessParams is consumed by Delete
 type DeleteStatelessParams struct {
-	*api.API
-
-	DeploymentID string
-	Type         string
-	RefID        string
+	deployment.ResourceParams
 }
 
 // Validate ensures the parameters are usable by the consuming function.
 func (params DeleteStatelessParams) Validate() error {
 	var merr = new(multierror.Error)
 
-	if params.API == nil {
-		merr = multierror.Append(merr, util.ErrAPIReq)
-	}
-
-	if len(params.DeploymentID) != 32 {
-		merr = multierror.Append(merr, deputil.NewInvalidDeploymentIDError(params.DeploymentID))
-	}
-
-	if params.RefID == "" {
-		merr = multierror.Append(merr, errors.New("deployment resource ref id cannot be empty"))
-	}
-
-	if params.Type == "" {
-		merr = multierror.Append(merr, errors.New("deployment resource type cannot be empty"))
-	}
+	merr = multierror.Append(merr, params.ResourceParams.Validate())
 
 	if params.Type == "elasticsearch" {
 		merr = multierror.Append(merr, errors.New("deployment resource type \"elasticsearch\" is not supported"))

--- a/pkg/deployment/depresource/delete_stateless_test.go
+++ b/pkg/deployment/depresource/delete_stateless_test.go
@@ -1,0 +1,120 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package depresource
+
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/elastic/ecctl/pkg/util"
+)
+
+func TestDeleteStateless(t *testing.T) {
+	var internalError = models.BasicFailedReply{
+		Errors: []*models.BasicFailedReplyElement{
+			{},
+		},
+	}
+	internalErrorBytes, _ := json.MarshalIndent(internalError, "", "  ")
+	type args struct {
+		params DeleteStatelessParams
+	}
+	tests := []struct {
+		name string
+		args args
+		want *models.DeploymentResourceUpgradeResponse
+		err  error
+	}{
+		{
+			name: "fails due to parameter validation",
+			args: args{},
+			err: &multierror.Error{Errors: []error{
+				util.ErrAPIReq,
+				errors.New("id \"\" is invalid"),
+				errors.New("deployment resource ref id cannot be empty"),
+				errors.New("deployment resource type cannot be empty"),
+			}},
+		},
+		{
+			name: "fails due to parameter validation on invalid type",
+			args: args{params: DeleteStatelessParams{
+				Type: "elasticsearch",
+			}},
+			err: &multierror.Error{Errors: []error{
+				util.ErrAPIReq,
+				errors.New("id \"\" is invalid"),
+				errors.New("deployment resource ref id cannot be empty"),
+				errors.New("deployment resource type \"elasticsearch\" is not supported"),
+			}},
+		},
+		{
+			name: "fails due to API error",
+			args: args{params: DeleteStatelessParams{
+				API:          api.NewMock(mock.New404Response(mock.NewStructBody(internalError))),
+				DeploymentID: util.ValidClusterID,
+				RefID:        "kibana",
+				Type:         "kibana",
+			}},
+			err: errors.New(string(internalErrorBytes)),
+		},
+		{
+			name: "succeeds on APM resource",
+			args: args{params: DeleteStatelessParams{
+				API:          api.NewMock(mock.New200Response(mock.NewStringBody(""))),
+				DeploymentID: util.ValidClusterID,
+				RefID:        "kibana",
+				Type:         "kibana",
+			}},
+		},
+		{
+			name: "fails due to API error on APM resource",
+			args: args{params: DeleteStatelessParams{
+				API:          api.NewMock(mock.New404Response(mock.NewStructBody(internalError))),
+				DeploymentID: util.ValidClusterID,
+				RefID:        "apm",
+				Type:         "apm",
+			}},
+			err: errors.New(string(internalErrorBytes)),
+		},
+		{
+			name: "succeeds",
+			args: args{params: DeleteStatelessParams{
+				API:          api.NewMock(mock.New200Response(mock.NewStringBody(""))),
+				DeploymentID: util.ValidClusterID,
+				RefID:        "apm",
+				Type:         "apm",
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := DeleteStateless(tt.args.params)
+			if !reflect.DeepEqual(err, tt.err) {
+				t.Errorf("DeleteStateless() error = %v, wantErr %v", err, tt.err)
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds an `ecctl deployment resource delete` command which deletes a
previously shut down deployment resource. If ref-id not specified
it's auto-discovered via an API call.

Required flags: `--type`
Optional flags: `--ref-id`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

