### PR TITLE
bug: fix resource delete refid discovery and require confirmation

### DIFF
--- a/cmd/deployment/resource/delete.go
+++ b/cmd/deployment/resource/delete.go
@@ -18,6 +18,8 @@
 package cmddeploymentresource
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 
 	cmdutil "github.com/elastic/ecctl/cmd/util"
@@ -34,6 +36,12 @@ var deleteCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		resType, _ := cmd.Flags().GetString("type")
 		refID, _ := cmd.Flags().GetString("ref-id")
+
+		force, _ := cmd.Flags().GetBool("force")
+		var msg = "This action will delete a deployment's resource type and its configuration history. Do you want to continue? [y/n]: "
+		if !force && !cmdutil.ConfirmAction(msg, os.Stderr, os.Stdout) {
+			return nil
+		}
 
 		return depresource.DeleteStateless(depresource.DeleteStatelessParams{
 			ResourceParams: deployment.ResourceParams{

--- a/pkg/deployment/depresource/delete_stateless.go
+++ b/pkg/deployment/depresource/delete_stateless.go
@@ -33,7 +33,7 @@ type DeleteStatelessParams struct {
 }
 
 // Validate ensures the parameters are usable by the consuming function.
-func (params DeleteStatelessParams) Validate() error {
+func (params *DeleteStatelessParams) Validate() error {
 	var merr = new(multierror.Error)
 
 	merr = multierror.Append(merr, params.ResourceParams.Validate())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Fixes a bug where RefID auto-discovery was broken, and adds extra step to confirm the user wishes to perform a destructive action.

## Related Issues
Related: https://github.com/elastic/ecctl/issues/99

## Motivation and Context
Bugfix and destructive actions should ask for confirmation.

## How Has This Been Tested?
Manually

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
