### PR TITLE
stack: Skip returning an error on packed __MACOSX

### DIFF
--- a/pkg/platform/stack/stack.go
+++ b/pkg/platform/stack/stack.go
@@ -92,6 +92,10 @@ func Upload(params UploadParams) error {
 	var merr = new(multierror.Error)
 	for _, e := range res.Payload.Errors {
 		for _, ee := range e.Errors.Errors {
+			// ECE stack packs seem to have a __MACOSX packed file which is
+			// causing the command to return an error. Error thrown is:
+			// This version cannot be parsed: [__MACOSX] because:
+			// Unknown version string: [__MACOSX]
 			if !strings.Contains(*ee.Message, "__MACOSX") {
 				merr = multierror.Append(merr,
 					fmt.Errorf("%s: %s", *ee.Code, *ee.Message),

--- a/pkg/platform/stack/stack.go
+++ b/pkg/platform/stack/stack.go
@@ -92,9 +92,11 @@ func Upload(params UploadParams) error {
 	var merr = new(multierror.Error)
 	for _, e := range res.Payload.Errors {
 		for _, ee := range e.Errors.Errors {
-			merr = multierror.Append(merr,
-				fmt.Errorf("%s: %s", *ee.Code, *ee.Message),
-			)
+			if !strings.Contains(*ee.Message, "__MACOSX") {
+				merr = multierror.Append(merr,
+					fmt.Errorf("%s: %s", *ee.Code, *ee.Message),
+				)
+			}
 		}
 	}
 	return merr.ErrorOrNil()


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Skips returning an error on stackpacks which have a __MACOSX packed into
the .zip file.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
ECE stack packs seem to have a __MACOSX packed file which is causing the command to return an error.

```console
$ecctl platform stack upload 7.5.1.zip
1 error occurred:
	* stackpack.invalid_configuration_version: This version cannot be parsed: [__MACOSX] because: Unknown version string: [__MACOSX]
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Maually

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

