### PR TITLE
user: Fix key show command

### DIFF
--- a/cmd/user/key/show.go
+++ b/cmd/user/key/show.go
@@ -27,12 +27,13 @@ import (
 var showCmd = &cobra.Command{
 	Use:     "show --user=<user id> <key id>",
 	Short:   "Shows the API key details for the specified user",
-	PreRunE: cobra.MinimumNArgs(2),
+	PreRunE: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		user, _ := cmd.Flags().GetString("user")
 		res, err := userauthadmin.GetKey(userauthadmin.GetKeyParams{
-			UserID: args[0],
+			UserID: user,
 			API:    ecctl.Get().API,
-			ID:     args[1],
+			ID:     args[0],
 		})
 		if err != nil {
 			return err

--- a/pkg/user/auth/admin/getkey.go
+++ b/pkg/user/auth/admin/getkey.go
@@ -63,7 +63,7 @@ func GetKey(params GetKeyParams) (*models.APIKeyResponse, error) {
 	res, err := params.V1API.Authentication.GetUserAPIKey(
 		authentication.NewGetUserAPIKeyParams().
 			WithAPIKeyID(params.ID).
-			WithUserID(params.ID),
+			WithUserID(params.UserID),
 		params.AuthWriter,
 	)
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Fixes `ecctl user key show` command where the required number of
arguments was invalid and the UserID used in the pkg layer was the key
ID instead of the UserID.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
#99

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

