### PR TITLE
cmd: fix command wording

### DIFF
--- a/cmd/deployment/apm/create.go
+++ b/cmd/deployment/apm/create.go
@@ -29,7 +29,7 @@ import (
 )
 
 var createApmCmd = &cobra.Command{
-	Use:     "create -f <definition.json>",
+	Use:     "create --id <deployment-id>",
 	Short:   "Creates an Apm instance",
 	Long:    apmCreateLong,
 	Example: apmCreateExample,

--- a/cmd/deployment/elasticsearch/upgrade.go
+++ b/cmd/deployment/elasticsearch/upgrade.go
@@ -55,7 +55,7 @@ var upgradeElasticsearchVersionCmd = &cobra.Command{
 func init() {
 	Command.AddCommand(upgradeElasticsearchVersionCmd)
 
-	upgradeElasticsearchVersionCmd.Flags().StringP("version", "v", "", "Filters per version (required)")
+	upgradeElasticsearchVersionCmd.Flags().StringP("version", "v", "", "Version to upgrade to (required)")
 	upgradeElasticsearchVersionCmd.Flags().BoolP("track", "t", false, cmdutil.TrackFlagMessage)
 	cobra.MarkFlagRequired(upgradeElasticsearchVersionCmd.Flags(), "version")
 }

--- a/cmd/deployment/kibana/create.go
+++ b/cmd/deployment/kibana/create.go
@@ -29,7 +29,7 @@ import (
 )
 
 var createKibanaCmd = &cobra.Command{
-	Use:     "create -f <definition.json>",
+	Use:     "create --id <deployment-id>",
 	Short:   "Creates a Kibana instance",
 	Long:    kibanaCreateLong,
 	Example: kibanaCreateExample,

--- a/docs/ecctl_deployment_apm_create.md
+++ b/docs/ecctl_deployment_apm_create.md
@@ -18,7 +18,7 @@ that would be sent as a request, save it, update or extend the topology and crea
 deployment using the saved payload with the "--file" flag.
 
 ```
-ecctl deployment apm create -f <definition.json> [flags]
+ecctl deployment apm create --id <deployment-id> [flags]
 ```
 
 ### Examples

--- a/docs/ecctl_deployment_elasticsearch_upgrade.md
+++ b/docs/ecctl_deployment_elasticsearch_upgrade.md
@@ -15,7 +15,7 @@ ecctl deployment elasticsearch upgrade <cluster id> --version=<version> [flags]
 ```
   -h, --help             help for upgrade
   -t, --track            Tracks the progress of the performed task
-  -v, --version string   Filters per version (required)
+  -v, --version string   Version to upgrade to (required)
 ```
 
 ### Options inherited from parent commands

--- a/docs/ecctl_deployment_kibana_create.md
+++ b/docs/ecctl_deployment_kibana_create.md
@@ -18,7 +18,7 @@ that would be sent as a request, save it, update or extend the topology and crea
 deployment using the saved payload with the "--file" flag.
 
 ```
-ecctl deployment kibana create -f <definition.json> [flags]
+ecctl deployment kibana create --id <deployment-id> [flags]
 ```
 
 ### Examples


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Fixes wording for the `--version` flag, and changes the command description to reflect mandatory arguments.

## Related Issues
Related: https://github.com/elastic/ecctl/issues/99

## Motivation and Context
UX

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
