### PR TITLE
cmd: Add default region to APM and Kibana create

### DIFF
--- a/cmd/deployment/apm/create.go
+++ b/cmd/deployment/apm/create.go
@@ -75,6 +75,10 @@ var createApmCmd = &cobra.Command{
 			payload = p
 		}
 
+		if payload.Region == nil || *payload.Region == "" {
+			payload.Region = ec.String(region)
+		}
+
 		// Returns the ApmPayload skipping the creation of the resources.
 		if generatePayload {
 			return ecctl.Get().Formatter.Format("", payload)

--- a/cmd/deployment/kibana/create.go
+++ b/cmd/deployment/kibana/create.go
@@ -76,6 +76,10 @@ var createKibanaCmd = &cobra.Command{
 			payload = p
 		}
 
+		if payload.Region == nil || *payload.Region == "" {
+			payload.Region = ec.String(region)
+		}
+
 		// Returns the KibanaPayload skipping the creation of the resources.
 		if generatePayload {
 			return ecctl.Get().Formatter.Format("", payload)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds the default region to `ecctl kibana create` and `ecctl apm create`
when creating those from a file definition. If the region is not
specified, the default `ece-region` will be used.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
#99 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```console
$ cat deployment_example_esonly.json
{
    "name": "my single deployment",
    "resources": {
        "elasticsearch": [
            {
                "display_name": "my singlee cluster",
                "ref_id": "my-es-cluster",
                "plan": {
                    "deployment_template": {
                        "id": "default"
                    },
                    "elasticsearch": {
                        "version": "7.5.0"
                    },
                    "cluster_topology": [
                        {
                            "instance_configuration_id": "data.default",
                            "memory_per_node": 1024,
                            "node_count_per_zone": 1,
                            "node_type": {
                                "data": true,
                                "ingest": true,
                                "master": true,
                                "ml": false
                            },
                            "zone_count": 1
                        }
                    ]
                }
            }
        ]
    }
}
$ ecctl deployment create -f deployment_example_esonly.json --track
$ cat deployment_example_kibanaonly.json
{
    "display_name": "my kibana instance",
    "ref_id": "my-kibana-instance",
    "elasticsearch_cluster_ref_id": "my-es-cluster",
    "plan": {
        "kibana": {
            "version": "7.5.0"
        },
        "cluster_topology": [
            {
                "instance_configuration_id": "kibana",
                "memory_per_node": 1024,
                "node_count_per_zone": 1,
                "zone_count": 1
            }
        ]
    }
}
$ ecctl deployment kibana create -f deployment_example_kibanaonly.json --track --id f136bedadbb5657b912b25babd755572
$ cat deployment_example_apmonly.json
{
    "display_name": "my apm instance",
    "ref_id": "my-apm-instance",
    "elasticsearch_cluster_ref_id": "my-es-cluster",
    "plan": {
        "apm": {
            "version": "7.5.0"
        },
        "cluster_topology": [{
            "instance_configuration_id": "apm",
            "size": {
                "resource": "memory",
                "value": 512
            },
            "zone_count": 1
        }]
    }
}
$ ecctl deployment apm create -f deployment_example_apmonly.json --track --id f136bedadbb5657b912b25babd755572
```

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
