### PR TITLE
elasticsearch: Fix broken diagnostics command

### DIFF
--- a/cmd/deployment/elasticsearch/diagnose.go
+++ b/cmd/deployment/elasticsearch/diagnose.go
@@ -33,13 +33,14 @@ import (
 var generateElasticsearchDiagnosticsCmd = &cobra.Command{
 	Use:     "diagnose <cluster id>",
 	Short:   "Generates a diagnostics bundle for the cluster",
+	Long:    "Generates a diagnostics bundle for the cluster, a timeout increase might be necessary",
 	PreRunE: cmdutil.MinimumNArgsAndUUID(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		location := cmd.Flag("location").Value.String()
 		filename := fmt.Sprint("diagnostic-", args[0], ".zip")
 		path := filepath.Join(location, filename)
 
-		f, err := os.Open(path)
+		f, err := os.Create(path)
 		if err != nil {
 			return err
 		}

--- a/docs/ecctl_deployment_elasticsearch_diagnose.md
+++ b/docs/ecctl_deployment_elasticsearch_diagnose.md
@@ -4,7 +4,7 @@ Generates a diagnostics bundle for the cluster
 
 ### Synopsis
 
-Generates a diagnostics bundle for the cluster
+Generates a diagnostics bundle for the cluster, a timeout increase might be necessary
 
 ```
 ecctl deployment elasticsearch diagnose <cluster id> [flags]


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Fixes the broken diagnostics command by using `os.Create` rather than
`os.Open` for the .zip bundled file. Additionally adds a notee about a
potentially necessary timeout increase in order to complete the
operation.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
#99 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
