### PR TITLE
cmd: Use force flag with instance override

### DIFF
--- a/cmd/deployment/elasticsearch/instances/override.go
+++ b/cmd/deployment/elasticsearch/instances/override.go
@@ -68,13 +68,11 @@ Set the cluster instance to 3x of its current capacity:
 		storageMultiplier, _ := cmd.Flags().GetUint8("storage-multiplier")
 		value, _ := cmd.Flags().GetUint16("value")
 		reset, _ := cmd.Flags().GetBool("reset")
+		force, _ := cmd.Flags().GetBool("force")
 
 		if multiplier > 0 || value > 0 || reset {
-			if !cmdutil.ConfirmAction(
-				"WARNING: changing instance capacity incurs a rolling restart, do you want to continue? [n/y]: ",
-				os.Stdin,
-				os.Stdout,
-			) {
+			msg := "WARNING: changing instance capacity incurs a rolling restart, do you want to continue? [n/y]: "
+			if !force && !cmdutil.ConfirmAction(msg, os.Stdin, os.Stdout) {
 				return nil
 			}
 		}


### PR DESCRIPTION
Signed-off-by: karencfv <karencfv@gmail.com>

<!--- Provide a general summary of your changes in the title above. -->

## Description
Fixes a bug where the usage of a `--force` flag was missing from the `elasticsearch instance override` command

## Motivation and Context
A `--force` flag can be used to avoid the confirm action prompt.

## How Has This Been Tested?
manually and with integration tests!

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
