### PR TITLE
deployments: Change refID defaults to use 'main-' prefix

### DIFF
--- a/cmd/deployment/apm/create.go
+++ b/cmd/deployment/apm/create.go
@@ -125,7 +125,7 @@ func init() {
 	createApmCmd.Flags().StringP("file", "f", "", "ApmPayload file definition. See help for more information")
 	createApmCmd.Flags().String("deployment-template", "", "Optional deployment template ID, automatically obtained from the current deployment")
 	createApmCmd.Flags().String("version", "", "Optional version to use. If not specified, it will default to the deployment's stack version")
-	createApmCmd.Flags().String("ref-id", "apm", "RefId for the Apm deployment")
+	createApmCmd.Flags().String("ref-id", "main-apm", "RefId for the Apm deployment")
 	createApmCmd.Flags().String("id", "", "Deployment ID where to create the Apm deployment")
 	createApmCmd.MarkFlagRequired("id")
 	createApmCmd.Flags().String("elasticsearch-ref-id", "", "Optional Elasticsearch ref ID where the Apm deployment will connect to")

--- a/cmd/deployment/kibana/create.go
+++ b/cmd/deployment/kibana/create.go
@@ -124,7 +124,7 @@ func init() {
 	createKibanaCmd.Flags().StringP("file", "f", "", "KibanaPayload file definition. See help for more information")
 	createKibanaCmd.Flags().String("deployment-template", "", "Optional deployment template ID, automatically obtained from the current deployment")
 	createKibanaCmd.Flags().String("version", "", "Version to use, if not specified, the deployment's stack version will be used")
-	createKibanaCmd.Flags().String("ref-id", "kibana", "RefId for the Kibana deployment")
+	createKibanaCmd.Flags().String("ref-id", "main-kibana", "RefId for the Kibana deployment")
 	createKibanaCmd.Flags().String("id", "", "Deployment ID where to create the Kibana deployment")
 	createKibanaCmd.MarkFlagRequired("id")
 	createKibanaCmd.Flags().String("elasticsearch-ref-id", "", "Optional Elasticsearch ref ID where the Kibana deployment will connect to")

--- a/docs/ecctl_deployment_apm_create.md
+++ b/docs/ecctl_deployment_apm_create.md
@@ -79,7 +79,7 @@ $ cat apm_create_example.json | dev-cli deployment apm create --track --id a57f8
   -h, --help                          help for create
       --id string                     Deployment ID where to create the Apm deployment
       --name string                   Optional name to set for the Apm deployment (Overrides name if present)
-      --ref-id string                 RefId for the Apm deployment (default "apm")
+      --ref-id string                 RefId for the Apm deployment (default "main-apm")
       --size int32                    Memory (RAM) in MB that each of the deployment nodes will have (default 512)
   -t, --track                         Tracks the progress of the performed task
       --version string                Optional version to use. If not specified, it will default to the deployment's stack version

--- a/docs/ecctl_deployment_kibana_create.md
+++ b/docs/ecctl_deployment_kibana_create.md
@@ -71,7 +71,7 @@ $ cat kibana_create_example.json | dev-cli deployment kibana create --track --id
   -h, --help                          help for create
       --id string                     Deployment ID where to create the Kibana deployment
       --name string                   Optional name to set for the Kibana deployment (Overrides name if present)
-      --ref-id string                 RefId for the Kibana deployment (default "kibana")
+      --ref-id string                 RefId for the Kibana deployment (default "main-kibana")
       --size int32                    Memory (RAM) in MB that each of the deployment nodes will have (default 1024)
   -t, --track                         Tracks the progress of the performed task
       --version string                Version to use, if not specified, the deployment's stack version will be used

--- a/pkg/deployment/depresource/apm.go
+++ b/pkg/deployment/depresource/apm.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	// DefaultApmRefID is used when the RefID is not specified.
-	DefaultApmRefID = "apm"
+	DefaultApmRefID = "main-apm"
 )
 
 // NewApm creates a *models.ApmPayload from the parameters.

--- a/pkg/deployment/depresource/apm_test.go
+++ b/pkg/deployment/depresource/apm_test.go
@@ -65,7 +65,7 @@ func TestNewApm(t *testing.T) {
 	var getResponse = models.DeploymentGetResponse{
 		Resources: &models.DeploymentResources{
 			Elasticsearch: []*models.ElasticsearchResourceInfo{{
-				RefID: ec.String("elasticsearch"),
+				RefID: ec.String("main-elasticsearch"),
 				Info: &models.ElasticsearchClusterInfo{
 					PlanInfo: &models.ElasticsearchClusterPlansInfo{
 						Current: &models.ElasticsearchClusterPlanInfo{
@@ -150,9 +150,9 @@ func TestNewApm(t *testing.T) {
 				Region: "ece-region",
 			}},
 			want: &models.ApmPayload{
-				ElasticsearchClusterRefID: ec.String("elasticsearch"),
+				ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
 				Region:                    ec.String("ece-region"),
-				RefID:                     ec.String("apm"),
+				RefID:                     ec.String("main-apm"),
 				Plan: &models.ApmPlan{
 					Apm: &models.ApmConfiguration{},
 					ClusterTopology: []*models.ApmTopologyElement{
@@ -180,9 +180,9 @@ func TestNewApm(t *testing.T) {
 				Region: "ece-region",
 			}},
 			want: &models.ApmPayload{
-				ElasticsearchClusterRefID: ec.String("elasticsearch"),
+				ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
 				Region:                    ec.String("ece-region"),
-				RefID:                     ec.String("apm"),
+				RefID:                     ec.String("main-apm"),
 				Plan: &models.ApmPlan{
 					Apm: &models.ApmConfiguration{},
 					ClusterTopology: []*models.ApmTopologyElement{

--- a/pkg/deployment/depresource/elasticsearch.go
+++ b/pkg/deployment/depresource/elasticsearch.go
@@ -44,7 +44,7 @@ const (
 	DefaultDataZoneCount = 1
 
 	// DefaultElasticsearchRefID is used when the RefID is not specified.
-	DefaultElasticsearchRefID = "elasticsearch"
+	DefaultElasticsearchRefID = "main-elasticsearch"
 )
 
 // NewElasticsearchParams is consumed by NewElasticsearch.

--- a/pkg/deployment/depresource/kibana.go
+++ b/pkg/deployment/depresource/kibana.go
@@ -25,15 +25,15 @@ import (
 )
 
 const (
-	// DefaultKibanahRefID is used when the RefID is not specified.
-	DefaultKibanahRefID = "kibana"
+	// DefaultKibanaRefID is used when the RefID is not specified.
+	DefaultKibanaRefID = "main-kibana"
 )
 
 // NewKibana creates a *models.KibanaPayload from the parameters.
 // It relies on a simplified single dimension memory size and zone count to
 // construct the Kibana's topology.
 func NewKibana(params NewStateless) (*models.KibanaPayload, error) {
-	params.fillDefaults(DefaultKibanahRefID)
+	params.fillDefaults(DefaultKibanaRefID)
 	if err := params.Validate(); err != nil {
 		return nil, err
 	}

--- a/pkg/deployment/depresource/kibana_test.go
+++ b/pkg/deployment/depresource/kibana_test.go
@@ -65,7 +65,7 @@ func TestNewKibana(t *testing.T) {
 	var getResponse = models.DeploymentGetResponse{
 		Resources: &models.DeploymentResources{
 			Elasticsearch: []*models.ElasticsearchResourceInfo{{
-				RefID: ec.String("elasticsearch"),
+				RefID: ec.String("main-elasticsearch"),
 				Info: &models.ElasticsearchClusterInfo{
 					PlanInfo: &models.ElasticsearchClusterPlansInfo{
 						Current: &models.ElasticsearchClusterPlanInfo{
@@ -150,9 +150,9 @@ func TestNewKibana(t *testing.T) {
 				Region: "ece-region",
 			}},
 			want: &models.KibanaPayload{
-				ElasticsearchClusterRefID: ec.String("elasticsearch"),
+				ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
 				Region:                    ec.String("ece-region"),
-				RefID:                     ec.String("kibana"),
+				RefID:                     ec.String("main-kibana"),
 				Plan: &models.KibanaClusterPlan{
 					Kibana: &models.KibanaConfiguration{},
 					ClusterTopology: []*models.KibanaClusterTopologyElement{
@@ -180,9 +180,9 @@ func TestNewKibana(t *testing.T) {
 				Region: "ece-region",
 			}},
 			want: &models.KibanaPayload{
-				ElasticsearchClusterRefID: ec.String("elasticsearch"),
+				ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
 				Region:                    ec.String("ece-region"),
-				RefID:                     ec.String("kibana"),
+				RefID:                     ec.String("main-kibana"),
 				Plan: &models.KibanaClusterPlan{
 					Kibana: &models.KibanaConfiguration{},
 					ClusterTopology: []*models.KibanaClusterTopologyElement{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Changes the default `refID` values to use a "main-" prefix in order to achieve parity with the UI.

## Related Issues
Closes: https://github.com/elastic/cloud-cli/issues/1054

## How Has This Been Tested?
Manually and integration test run

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
