### PR TITLE
cmd: Add --skip-tracking flag to allocator vacate

### DIFF
--- a/docs/ecctl_platform_allocator_vacate.md
+++ b/docs/ecctl_platform_allocator_vacate.md
@@ -42,6 +42,10 @@ ecctl platform allocator vacate <source> [flags]
   # Override the skip_data_migration setting
   ecctl [globalFlags] allocator vacate --skip-data-migration=true i-05e245252362f7f1d -c f521dedb07194c478fbbc6624f3bbf8f
   
+  # Skips tracking the vacate progress which will cause the command to return almost immediately.
+  # Not recommended since it can lead to failed vacates without the operator knowing about them.
+  ecctl [globalFlags] allocator vacate --skip-tracking i-05e245252362f7f1d
+
 ```
 
 ### Options
@@ -57,6 +61,7 @@ ecctl platform allocator vacate <source> [flags]
       --override-failsafe            If false (the default) then the plan will fail out if it believes the requested sequence of operations can result in data loss - this flag will override some of these restraints. [true|false]
       --skip-data-migration string   Skips the data-migration operation on the specified cluster IDs. ONLY available when the cluster IDs are specified and --move-only is true. [true|false]
       --skip-snapshot string         Skips the snapshot operation on the specified cluster IDs. ONLY available when the cluster IDs are specified. [true|false]
+      --skip-tracking                Skips tracking the vacate progress causing the command to return after the move operation has been executed. Not recommended.
   -t, --target stringArray           Target allocator(s) on which to place the vacated workload
 ```
 

--- a/pkg/platform/allocator/vacate.go
+++ b/pkg/platform/allocator/vacate.go
@@ -237,6 +237,7 @@ func newVacateClusterParams(params addAllocatorMovesToPoolParams, id, kind strin
 		ID:                  params.ID,
 		Kind:                kind,
 		ClusterID:           id,
+		SkipTracking:        params.VacateParams.SkipTracking,
 		ClusterFilter:       params.VacateParams.ClusterFilter,
 		PreferredAllocators: params.VacateParams.PreferredAllocators,
 		MaxPollRetries:      params.VacateParams.MaxPollRetries,
@@ -270,6 +271,10 @@ func VacateCluster(params *VacateClusterParams) error {
 
 	if err := moveClusterByType(params); err != nil {
 		return err
+	}
+
+	if params.SkipTracking {
+		return nil
 	}
 
 	return trackMovedCluster(params)

--- a/pkg/platform/allocator/vacate_params.go
+++ b/pkg/platform/allocator/vacate_params.go
@@ -86,6 +86,13 @@ type VacateParams struct {
 	// bare minimum to move the requested instances across to another allocator.
 	MoveOnly *bool
 
+	// SkipTracking skips displaying and waiting for the individual vacates to complete.
+	// Setting it to true will render the concurrency flag pretty much ineffective since
+	// the vacate action is asynchronous and the only thing keeping the working items in
+	// the pool is the tracking function call which synchronously waits until the vacate
+	// has effectively finished.
+	SkipTracking bool
+
 	// Plan body overrides to place in all of the vacate clusters.
 	PlanOverrides
 }
@@ -132,20 +139,20 @@ func (params VacateParams) Validate() error {
 // VacateClusterParams is used by VacateCluster to move a cluster node
 // from an allocator.
 type VacateClusterParams struct {
-	*api.API
-	ID                  string
-	ClusterID           string
-	Kind                string
 	PreferredAllocators []string
 	ClusterFilter       []string
-	MaxPollRetries      uint8
-	TrackFrequency      time.Duration
-	AllocatorDown       *bool
-	MoveOnly            *bool
-	Output              *output.Device
-
 	// Plan body overrides to place in all of the vacate clusters.
 	PlanOverrides
+	ID        string
+	ClusterID string
+	Kind      string
+	*api.API
+	TrackFrequency time.Duration
+	AllocatorDown  *bool
+	MoveOnly       *bool
+	Output         *output.Device
+	MaxPollRetries uint8
+	SkipTracking   bool
 }
 
 // Validate validates the parameters

--- a/pkg/platform/allocator/vacate_test.go
+++ b/pkg/platform/allocator/vacate_test.go
@@ -750,6 +750,24 @@ func TestVacateCluster(t *testing.T) {
 			),
 		},
 		{
+			name: "Succeeds with an elasticsearch cluster with no tracking",
+			args: args{
+				buf: new(bytes.Buffer),
+				params: &VacateClusterParams{
+					ID:             "someID",
+					ClusterID:      "3ee11eb40eda22cac0cce259625c6734",
+					Kind:           "elasticsearch",
+					Output:         new(output.Device),
+					TrackFrequency: time.Nanosecond,
+					SkipTracking:   true,
+					MaxPollRetries: 1,
+					API: discardResponses(
+						newElasticsearchVacateMove(t, "someID", vacateCaseClusterConfig{}),
+					),
+				},
+			},
+		},
+		{
 			name: "Succeeds with a kibana instance",
 			args: args{
 				buf: new(bytes.Buffer),
@@ -786,6 +804,24 @@ func TestVacateCluster(t *testing.T) {
 				"Cluster [2ee11eb40eda22cac0cce259625c6734][Kibana]: running step \"step3\" (Plan duration )...",
 				"\x1b[92;mCluster [2ee11eb40eda22cac0cce259625c6734][Kibana]: finished running all the plan steps\x1b[0m (Total plan duration )",
 			),
+		},
+		{
+			name: "Succeeds with a kibana instance with no tracking",
+			args: args{
+				buf: new(bytes.Buffer),
+				params: &VacateClusterParams{
+					ID:             "someID",
+					ClusterID:      "2ee11eb40eda22cac0cce259625c6734",
+					Kind:           "kibana",
+					Output:         new(output.Device),
+					TrackFrequency: time.Nanosecond,
+					SkipTracking:   true,
+					MaxPollRetries: 1,
+					API: discardResponses(
+						newKibanaVacateMove(t, "someID", vacateCaseClusterConfig{}),
+					),
+				},
+			},
 		},
 		{
 			name: "Moving kibana instance fails",


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds a --skip-tracking flag which will make the whole operation async
and not wait for the deployments to complete moving nodes. Adds an
interactive warning which can be skipped with the `--force` flag.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Resolves #107 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

```console
$ dev-cli platform allocator list
Showing allocators that have instances or are connected in the platform. Use --all flag or --output json to show all
ZONE         ALLOCATOR ID    HOST IP         CAPACITY   FREE      INSTANCES   CONNECTED   MAINTENANCE
ece-zone-0   192.168.44.10   192.168.44.10   14.19GB    14.19GB   0           true        false
ece-zone-2   192.168.44.12   192.168.44.12   14.19GB    12.19GB   2           true        false
ece-zone-1   192.168.44.11   192.168.44.11   14.19GB    12.19GB   2           true        false

$ dev-cli platform allocator vacate --skip-tracking 192.168.44.11
--skip-tracking flag specified. Are you sure you want to proceed? [y/N]: y

$ dev-cli platform allocator vacate --skip-tracking --force 192.168.44.12

```

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
