### PR TITLE
deployment: Add --type flag autocompletion

### DIFF
--- a/cmd/deployment/plan/cancel.go
+++ b/cmd/deployment/plan/cancel.go
@@ -52,7 +52,7 @@ var cancelPlan = &cobra.Command{
 
 func init() {
 	Command.AddCommand(cancelPlan)
-	cancelPlan.Flags().String("type", "", "Optional deployment type to show resource information (elasticsearch, kibana, apm, or appsearch)")
+	cmdutil.AddTypeFlag(cancelPlan, "Optional", true)
 	cancelPlan.MarkFlagRequired("type")
 	cancelPlan.Flags().String("ref-id", "", "Optional deployment type RefId, if not set, the RefId will be auto-discovered")
 }

--- a/cmd/deployment/resource/delete.go
+++ b/cmd/deployment/resource/delete.go
@@ -56,7 +56,7 @@ var deleteCmd = &cobra.Command{
 
 func init() {
 	Command.AddCommand(deleteCmd)
-	deleteCmd.Flags().String("type", "", "Required stateless deployment type to upgrade (kibana, apm, or appsearch)")
+	cmdutil.AddTypeFlag(deleteCmd, "Required stateless", false)
 	deleteCmd.MarkFlagRequired("type")
 	deleteCmd.Flags().String("ref-id", "", "Optional deployment RefId, auto-discovered if not specified")
 }

--- a/cmd/deployment/resource/restore.go
+++ b/cmd/deployment/resource/restore.go
@@ -67,7 +67,7 @@ var restoreCmd = &cobra.Command{
 
 func init() {
 	Command.AddCommand(restoreCmd)
-	restoreCmd.Flags().String("type", "", "Required deployment type to restore (elasticsearch, kibana, apm, or appsearch)")
+	cmdutil.AddTypeFlag(restoreCmd, "Required", true)
 	restoreCmd.MarkFlagRequired("type")
 	restoreCmd.Flags().String("ref-id", "", "Optional deployment RefId, auto-discovered if not specified")
 	restoreCmd.Flags().Bool("restore-snapshot", false, "Optional flag to toggle restoring a snapshot for an Elasticsearch resource. It has no effect for other resources")

--- a/cmd/deployment/resource/shutdown.go
+++ b/cmd/deployment/resource/shutdown.go
@@ -62,7 +62,7 @@ var shutdownCmd = &cobra.Command{
 
 func init() {
 	Command.AddCommand(shutdownCmd)
-	shutdownCmd.Flags().String("type", "", "Required deployment type to shutdown (elasticsearch, kibana, apm, or appsearch)")
+	cmdutil.AddTypeFlag(shutdownCmd, "Required", true)
 	shutdownCmd.MarkFlagRequired("type")
 	shutdownCmd.Flags().String("ref-id", "", "Optional deployment RefId, auto-discovered if not specified")
 	shutdownCmd.Flags().Bool("skip-snapshot", false, "Optional flag to toggle skipping the resource snapshot before shutting it down")

--- a/cmd/deployment/resource/start-maintenance.go
+++ b/cmd/deployment/resource/start-maintenance.go
@@ -77,7 +77,7 @@ func init() {
 	Command.AddCommand(startMaintCmd)
 	startMaintCmd.Flags().Bool("all", false, "Starts maintenance mode on all instances of a defined resource type")
 	startMaintCmd.Flags().Bool("ignore-missing", false, "If set and the specified instance does not exist, then quietly proceed to the next instance")
-	startMaintCmd.Flags().String("type", "", "Deployment resource type to use (elasticsearch, kibana, apm, or appsearch)")
+	cmdutil.AddTypeFlag(startMaintCmd, "Required", true)
 	startMaintCmd.MarkFlagRequired("type")
 	startMaintCmd.Flags().String("ref-id", "", "Optional deployment RefId, if not set, the RefId will be auto-discovered")
 	startMaintCmd.Flags().StringSliceP("instance-id", "i", nil, "Deployment instance IDs to use (e.g. instance-0000000001)")

--- a/cmd/deployment/resource/start.go
+++ b/cmd/deployment/resource/start.go
@@ -70,7 +70,7 @@ func init() {
 	Command.AddCommand(startCmd)
 	startCmd.Flags().Bool("all", false, "Starts all instances of a defined resource type")
 	startCmd.Flags().Bool("ignore-missing", false, "If set and the specified instance does not exist, then quietly proceed to the next instance")
-	startCmd.Flags().String("type", "", "Deployment resource type to start (elasticsearch, kibana, apm, or appsearch)")
+	cmdutil.AddTypeFlag(startCmd, "Required", true)
 	startCmd.MarkFlagRequired("type")
 	startCmd.Flags().String("ref-id", "", "Optional deployment RefId, if not set, the RefId will be auto-discovered")
 	startCmd.Flags().StringSliceP("instance-id", "i", nil, "Deployment instance IDs to start (e.g. instance-0000000001)")

--- a/cmd/deployment/resource/stop-maintenance.go
+++ b/cmd/deployment/resource/stop-maintenance.go
@@ -70,7 +70,7 @@ func init() {
 	Command.AddCommand(stopMaintCmd)
 	stopMaintCmd.Flags().Bool("all", false, "Stops maintenance mode on all instances of a defined resource type")
 	stopMaintCmd.Flags().Bool("ignore-missing", false, "If set and the specified instance does not exist, then quietly proceed to the next instance")
-	stopMaintCmd.Flags().String("type", "", "Deployment resource type to use (elasticsearch, kibana, apm, or appsearch)")
+	cmdutil.AddTypeFlag(stopMaintCmd, "Required", true)
 	stopMaintCmd.MarkFlagRequired("type")
 	stopMaintCmd.Flags().String("ref-id", "", "Optional deployment RefId, if not set, the RefId will be auto-discovered")
 	stopMaintCmd.Flags().StringSliceP("instance-id", "i", nil, "Deployment instance IDs to use (e.g. instance-0000000001)")

--- a/cmd/deployment/resource/stop.go
+++ b/cmd/deployment/resource/stop.go
@@ -77,7 +77,7 @@ func init() {
 	Command.AddCommand(stopCmd)
 	stopCmd.Flags().Bool("all", false, "Stops all instances of a defined resource type")
 	stopCmd.Flags().Bool("ignore-missing", false, "If set and the specified instance does not exist, then quietly proceed to the next instance")
-	stopCmd.Flags().String("type", "", "Deployment resource type to stop (elasticsearch, kibana, apm, or appsearch)")
+	cmdutil.AddTypeFlag(stopCmd, "Required", true)
 	stopCmd.MarkFlagRequired("type")
 	stopCmd.Flags().String("ref-id", "", "Optional deployment RefId, if not set, the RefId will be auto-discovered")
 	stopCmd.Flags().StringSliceP("instance-id", "i", nil, "Deployment instance IDs to stop (e.g. instance-0000000001)")

--- a/cmd/deployment/resource/upgrade.go
+++ b/cmd/deployment/resource/upgrade.go
@@ -68,7 +68,7 @@ var upgradeCmd = &cobra.Command{
 func init() {
 	Command.AddCommand(upgradeCmd)
 	upgradeCmd.Flags().BoolP("track", "t", false, cmdutil.TrackFlagMessage)
-	upgradeCmd.Flags().String("type", "", "Optional stateless deployment type to upgrade (kibana, apm, or appsearch)")
+	cmdutil.AddTypeFlag(upgradeCmd, "Required", true)
 	upgradeCmd.MarkFlagRequired("type")
 	upgradeCmd.Flags().String("ref-id", "", "Optional deployment RefId, if not set, the RefId will be auto-discovered")
 }

--- a/cmd/deployment/show.go
+++ b/cmd/deployment/show.go
@@ -83,7 +83,7 @@ var showCmd = &cobra.Command{
 
 func init() {
 	Command.AddCommand(showCmd)
-	showCmd.Flags().String("type", "", "Optional deployment type to show resource information (elasticsearch, kibana, apm, or appsearch)")
+	cmdutil.AddTypeFlag(showCmd, "Optional", true)
 	showCmd.Flags().String("ref-id", "", "Optional deployment type RefId, if not set, the RefId will be auto-discovered")
 	showCmd.Flags().Bool("plans", false, "Shows the deployment plans")
 	showCmd.Flags().Bool("plan-logs", false, "Shows the deployment plan logs")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,17 +30,13 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 	"github.com/elastic/ecctl/pkg/util"
 )
 
 const (
-	homePrefix         = "$HOME"
-	bashCompletionFunc = `__ecctl_valid_regions()
-{
-   COMPREPLY=($(echo ${EC_REGIONS}))
-}
-`
+	homePrefix = "$HOME"
 )
 
 var (
@@ -51,6 +47,13 @@ var (
 	defaultViper  = viper.New()
 
 	ecctlHomePath = filepath.Join(homePrefix, ".ecctl")
+
+	bashCompletionFunc = `__ecctl_valid_regions()
+{
+   COMPREPLY=($(echo ${EC_REGIONS}))
+}
+` + cmdutil.StatelessTypesCompFunc + "\n" +
+		cmdutil.AllTypesCompFunc
 )
 
 var (

--- a/docs/ecctl_deployment_plan_cancel.md
+++ b/docs/ecctl_deployment_plan_cancel.md
@@ -15,7 +15,7 @@ ecctl deployment plan cancel <deployment id> --type <type> --ref-id <ref-id> [fl
 ```
   -h, --help            help for cancel
       --ref-id string   Optional deployment type RefId, if not set, the RefId will be auto-discovered
-      --type string     Optional deployment type to show resource information (elasticsearch, kibana, apm, or appsearch)
+      --type string     Optional deployment resource type (apm, appsearch, kibana, elasticsearch)
 ```
 
 ### Options inherited from parent commands

--- a/docs/ecctl_deployment_resource_delete.md
+++ b/docs/ecctl_deployment_resource_delete.md
@@ -15,7 +15,7 @@ ecctl deployment resource delete <deployment id> --type <type> --ref-id <ref-id>
 ```
   -h, --help            help for delete
       --ref-id string   Optional deployment RefId, auto-discovered if not specified
-      --type string     Required stateless deployment type to upgrade (kibana, apm, or appsearch)
+      --type string     Required stateless deployment resource type (apm, appsearch, kibana)
 ```
 
 ### Options inherited from parent commands

--- a/docs/ecctl_deployment_resource_restore.md
+++ b/docs/ecctl_deployment_resource_restore.md
@@ -16,7 +16,7 @@ ecctl deployment resource restore <deployment id> --type <type> --ref-id <ref-id
   -h, --help               help for restore
       --ref-id string      Optional deployment RefId, auto-discovered if not specified
       --restore-snapshot   Optional flag to toggle restoring a snapshot for an Elasticsearch resource. It has no effect for other resources
-      --type string        Required deployment type to restore (elasticsearch, kibana, apm, or appsearch)
+      --type string        Required deployment resource type (apm, appsearch, kibana, elasticsearch)
 ```
 
 ### Options inherited from parent commands

--- a/docs/ecctl_deployment_resource_shutdown.md
+++ b/docs/ecctl_deployment_resource_shutdown.md
@@ -18,7 +18,7 @@ ecctl deployment resource shutdown <deployment id> --type <type> --ref-id <ref-i
       --hide            Optionally hides the deployment resource from being listed by default
       --ref-id string   Optional deployment RefId, auto-discovered if not specified
       --skip-snapshot   Optional flag to toggle skipping the resource snapshot before shutting it down
-      --type string     Required deployment type to shutdown (elasticsearch, kibana, apm, or appsearch)
+      --type string     Required deployment resource type (apm, appsearch, kibana, elasticsearch)
 ```
 
 ### Options inherited from parent commands

--- a/docs/ecctl_deployment_resource_start-maintenance.md
+++ b/docs/ecctl_deployment_resource_start-maintenance.md
@@ -18,7 +18,7 @@ ecctl deployment resource start-maintenance <deployment id> --type <type> [--all
       --ignore-missing        If set and the specified instance does not exist, then quietly proceed to the next instance
   -i, --instance-id strings   Deployment instance IDs to use (e.g. instance-0000000001)
       --ref-id string         Optional deployment RefId, if not set, the RefId will be auto-discovered
-      --type string           Deployment resource type to use (elasticsearch, kibana, apm, or appsearch)
+      --type string           Required deployment resource type (apm, appsearch, kibana, elasticsearch)
 ```
 
 ### Options inherited from parent commands

--- a/docs/ecctl_deployment_resource_start.md
+++ b/docs/ecctl_deployment_resource_start.md
@@ -18,7 +18,7 @@ ecctl deployment resource start <deployment id> --type <type> [--all|--i <instan
       --ignore-missing        If set and the specified instance does not exist, then quietly proceed to the next instance
   -i, --instance-id strings   Deployment instance IDs to start (e.g. instance-0000000001)
       --ref-id string         Optional deployment RefId, if not set, the RefId will be auto-discovered
-      --type string           Deployment resource type to start (elasticsearch, kibana, apm, or appsearch)
+      --type string           Required deployment resource type (apm, appsearch, kibana, elasticsearch)
 ```
 
 ### Options inherited from parent commands

--- a/docs/ecctl_deployment_resource_stop-maintenance.md
+++ b/docs/ecctl_deployment_resource_stop-maintenance.md
@@ -18,7 +18,7 @@ ecctl deployment resource stop-maintenance <deployment id> --type <type> [--all|
       --ignore-missing        If set and the specified instance does not exist, then quietly proceed to the next instance
   -i, --instance-id strings   Deployment instance IDs to use (e.g. instance-0000000001)
       --ref-id string         Optional deployment RefId, if not set, the RefId will be auto-discovered
-      --type string           Deployment resource type to use (elasticsearch, kibana, apm, or appsearch)
+      --type string           Required deployment resource type (apm, appsearch, kibana, elasticsearch)
 ```
 
 ### Options inherited from parent commands

--- a/docs/ecctl_deployment_resource_stop.md
+++ b/docs/ecctl_deployment_resource_stop.md
@@ -18,7 +18,7 @@ ecctl deployment resource stop <deployment id> --type <type> [--all|--i <instanc
       --ignore-missing        If set and the specified instance does not exist, then quietly proceed to the next instance
   -i, --instance-id strings   Deployment instance IDs to stop (e.g. instance-0000000001)
       --ref-id string         Optional deployment RefId, if not set, the RefId will be auto-discovered
-      --type string           Deployment resource type to stop (elasticsearch, kibana, apm, or appsearch)
+      --type string           Required deployment resource type (apm, appsearch, kibana, elasticsearch)
 ```
 
 ### Options inherited from parent commands

--- a/docs/ecctl_deployment_resource_upgrade.md
+++ b/docs/ecctl_deployment_resource_upgrade.md
@@ -17,7 +17,7 @@ ecctl deployment resource upgrade <deployment id> --type <type> --ref-id <ref-id
   -h, --help            help for upgrade
       --ref-id string   Optional deployment RefId, if not set, the RefId will be auto-discovered
   -t, --track           Tracks the progress of the performed task
-      --type string     Optional stateless deployment type to upgrade (kibana, apm, or appsearch)
+      --type string     Required deployment resource type (apm, appsearch, kibana, elasticsearch)
 ```
 
 ### Options inherited from parent commands

--- a/docs/ecctl_deployment_show.md
+++ b/docs/ecctl_deployment_show.md
@@ -31,7 +31,7 @@ ecctl deployment show <deployment-id> [flags]
       --plans           Shows the deployment plans
       --ref-id string   Optional deployment type RefId, if not set, the RefId will be auto-discovered
   -s, --settings        Shows the deployment settings
-      --type string     Optional deployment type to show resource information (elasticsearch, kibana, apm, or appsearch)
+      --type string     Optional deployment resource type (apm, appsearch, kibana, elasticsearch)
 ```
 
 ### Options inherited from parent commands

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/spf13/cobra v0.0.5
+	github.com/spf13/pflag v1.0.3
 	github.com/spf13/viper v1.6.1
 	golang.org/x/crypto v0.0.0-20190829043050-9756ffdc2472
 )


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds autocompletion for all of the `--type` flags specified under
deployment or deployment resource commands. It splits the potential
types into 2 groups, Stateless and Stateful.

It also corrects some of the docs where the flags were marked as
Optional and are actually required.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Resolves #74 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation
