### PR TITLE
cmd: add --all flag to kibana resync command

### DIFF
--- a/cmd/deployment/kibana/resync.go
+++ b/cmd/deployment/kibana/resync.go
@@ -28,7 +28,7 @@ import (
 )
 
 var resyncKibanaCmd = &cobra.Command{
-	Use:     "resync [<deployment id> | --all",
+	Use:     "resync [<deployment id> | --all]",
 	Short:   "Resynchronizes the search index and cache for the selected Kibana instance",
 	PreRunE: cmdutil.CheckInputHas1ArgsOr0ArgAndAll,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/deployment/kibana/resync.go
+++ b/cmd/deployment/kibana/resync.go
@@ -30,12 +30,29 @@ import (
 var resyncKibanaCmd = &cobra.Command{
 	Use:     "resync <cluster id>",
 	Short:   "Resynchronizes the search index and cache for the selected Kibana instance",
-	PreRunE: cmdutil.MinimumNArgsAndUUID(1),
+	PreRunE: cmdutil.CheckInputHas1ArgsOr0ArgAndAll,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		all, _ := cmd.Flags().GetBool("all")
+
+		if all {
+			res, err := kibana.ResyncAll(kibana.ResyncAllParams{
+				API: ecctl.Get().API,
+			})
+			if err != nil {
+				return err
+			}
+
+			return ecctl.Get().Formatter.Format("", res)
+		}
+
 		fmt.Printf("Resynchronizing Kibana instance: %s\n", args[0])
 		return kibana.Resync(kibana.DeploymentParams{
 			API: ecctl.Get().API,
 			ID:  args[0],
 		})
 	},
+}
+
+func init() {
+	resyncKibanaCmd.Flags().Bool("all", false, "Resynchronizes the search index for all Kibana instances")
 }

--- a/cmd/deployment/kibana/resync.go
+++ b/cmd/deployment/kibana/resync.go
@@ -28,7 +28,7 @@ import (
 )
 
 var resyncKibanaCmd = &cobra.Command{
-	Use:     "resync <cluster id>",
+	Use:     "resync [<deployment id> | --all",
 	Short:   "Resynchronizes the search index and cache for the selected Kibana instance",
 	PreRunE: cmdutil.CheckInputHas1ArgsOr0ArgAndAll,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/deployment/kibana/resync.go
+++ b/cmd/deployment/kibana/resync.go
@@ -28,13 +28,14 @@ import (
 )
 
 var resyncKibanaCmd = &cobra.Command{
-	Use:     "resync [<deployment id> | --all]",
-	Short:   "Resynchronizes the search index and cache for the selected Kibana instance",
+	Use:     "resync {<deployment id> | --all}",
+	Short:   "Resynchronizes the search index and cache for the selected Kibana instance or all instances",
 	PreRunE: cmdutil.CheckInputHas1ArgsOr0ArgAndAll,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		all, _ := cmd.Flags().GetBool("all")
 
 		if all {
+			fmt.Println("Resynchronizing all Kibana instances")
 			res, err := kibana.ResyncAll(kibana.ResyncAllParams{
 				API: ecctl.Get().API,
 			})

--- a/docs/ecctl_deployment_kibana.md
+++ b/docs/ecctl_deployment_kibana.md
@@ -45,7 +45,7 @@ ecctl deployment kibana [flags]
 * [ecctl deployment kibana plan](ecctl_deployment_kibana_plan.md)	 - Manages Kibana plans
 * [ecctl deployment kibana reallocate](ecctl_deployment_kibana_reallocate.md)	 - Reallocates Kibana instances
 * [ecctl deployment kibana restart](ecctl_deployment_kibana_restart.md)	 - Restarts a Kibana instance
-* [ecctl deployment kibana resync](ecctl_deployment_kibana_resync.md)	 - Resynchronizes the search index and cache for the selected Kibana instance
+* [ecctl deployment kibana resync](ecctl_deployment_kibana_resync.md)	 - Resynchronizes the search index and cache for the selected Kibana instance or all instances
 * [ecctl deployment kibana show](ecctl_deployment_kibana_show.md)	 - Returns the cluster information
 * [ecctl deployment kibana start](ecctl_deployment_kibana_start.md)	 - Starts a Kibana instance
 * [ecctl deployment kibana stop](ecctl_deployment_kibana_stop.md)	 - Downscales a Kibana instance

--- a/docs/ecctl_deployment_kibana_resync.md
+++ b/docs/ecctl_deployment_kibana_resync.md
@@ -1,13 +1,13 @@
 ## ecctl deployment kibana resync
 
-Resynchronizes the search index and cache for the selected Kibana instance
+Resynchronizes the search index and cache for the selected Kibana instance or all instances
 
 ### Synopsis
 
-Resynchronizes the search index and cache for the selected Kibana instance
+Resynchronizes the search index and cache for the selected Kibana instance or all instances
 
 ```
-ecctl deployment kibana resync [<deployment id> | --all] [flags]
+ecctl deployment kibana resync {<deployment id> | --all} [flags]
 ```
 
 ### Options

--- a/docs/ecctl_deployment_kibana_resync.md
+++ b/docs/ecctl_deployment_kibana_resync.md
@@ -13,6 +13,7 @@ ecctl deployment kibana resync <cluster id> [flags]
 ### Options
 
 ```
+      --all    Resynchronizes the search index for all Kibana instances
   -h, --help   help for resync
 ```
 

--- a/docs/ecctl_deployment_kibana_resync.md
+++ b/docs/ecctl_deployment_kibana_resync.md
@@ -7,7 +7,7 @@ Resynchronizes the search index and cache for the selected Kibana instance
 Resynchronizes the search index and cache for the selected Kibana instance
 
 ```
-ecctl deployment kibana resync [<deployment id> | --all [flags]
+ecctl deployment kibana resync [<deployment id> | --all] [flags]
 ```
 
 ### Options

--- a/docs/ecctl_deployment_kibana_resync.md
+++ b/docs/ecctl_deployment_kibana_resync.md
@@ -7,7 +7,7 @@ Resynchronizes the search index and cache for the selected Kibana instance
 Resynchronizes the search index and cache for the selected Kibana instance
 
 ```
-ecctl deployment kibana resync <cluster id> [flags]
+ecctl deployment kibana resync [<deployment id> | --all [flags]
 ```
 
 ### Options

--- a/pkg/deployment/kibana/resync.go
+++ b/pkg/deployment/kibana/resync.go
@@ -69,5 +69,4 @@ func ResyncAll(params ResyncAllParams) (*models.ModelVersionIndexSynchronization
 	}
 
 	return res.Payload, nil
-
 }

--- a/pkg/deployment/kibana/resync.go
+++ b/pkg/deployment/kibana/resync.go
@@ -18,10 +18,25 @@
 package kibana
 
 import (
+	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/client/clusters_kibana"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
 
 	"github.com/elastic/ecctl/pkg/util"
 )
+
+// ResyncAllParams is consumed by ResyncAll
+type ResyncAllParams struct {
+	*api.API
+}
+
+// Validate ensures the parameters are usable by the consuming function.
+func (params ResyncAllParams) Validate() error {
+	if params.API == nil {
+		return util.ErrAPIReq
+	}
+	return nil
+}
 
 // Resync forces indexer to immediately resynchronize the search index
 // and cache for a given Kibana instance.
@@ -37,4 +52,22 @@ func Resync(params DeploymentParams) error {
 			params.API.AuthWriter,
 		),
 	)
+}
+
+// ResyncAll asynchronously resynchronizes the search index for all Kibana instances.
+func ResyncAll(params ResyncAllParams) (*models.ModelVersionIndexSynchronizationResults, error) {
+	if err := params.Validate(); err != nil {
+		return nil, err
+	}
+
+	res, err := params.API.V1API.ClustersKibana.ResyncKibanaClusters(
+		clusters_kibana.NewResyncKibanaClustersParams(),
+		params.API.AuthWriter,
+	)
+	if err != nil {
+		return nil, api.UnwrapError(err)
+	}
+
+	return res.Payload, nil
+
 }

--- a/pkg/deployment/kibana/resync_test.go
+++ b/pkg/deployment/kibana/resync_test.go
@@ -143,7 +143,7 @@ func TestResyncAll(t *testing.T) {
 			},
 		},
 		{
-			name: "Succeeds to resynchronize Kibana instance without errors",
+			name: "Succeeds to re-synchronize all Kibana instances without errors",
 			args: args{params: ResyncAllParams{
 				API: api.NewMock(mock.Response{Response: http.Response{
 					StatusCode: http.StatusAccepted,

--- a/pkg/deployment/kibana/resync_test.go
+++ b/pkg/deployment/kibana/resync_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
 	multierror "github.com/hashicorp/go-multierror"
 
 	"github.com/elastic/ecctl/pkg/util"
@@ -98,6 +99,70 @@ func TestResync(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := Resync(tt.args.params); !reflect.DeepEqual(err, tt.wantErr) {
 				t.Errorf("Resync() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestResyncAll(t *testing.T) {
+	type args struct {
+		params ResyncAllParams
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr error
+		want    *models.ModelVersionIndexSynchronizationResults
+	}{
+		{
+			name:    "Fails due to parameter validation (API)",
+			args:    args{params: ResyncAllParams{}},
+			wantErr: errors.New("api reference is required for command"),
+		},
+		{
+			name: "Fails due to unknown API response",
+			args: args{params: ResyncAllParams{
+				API: api.NewMock(mock.Response{Response: http.Response{
+					StatusCode: http.StatusForbidden,
+					Body:       mock.NewStringBody(`{"error": "some forbidden error"}`),
+				}}),
+			}},
+			wantErr: errors.New(`{"error": "some forbidden error"}`),
+		},
+		{
+			name: "Fails due to API error",
+			args: args{params: ResyncAllParams{
+				API: api.NewMock(mock.Response{
+					Error: errors.New("error with API"),
+				}),
+			}},
+			wantErr: &url.Error{
+				Op:  "Post",
+				URL: "https://mock-host/mock-path/clusters/kibana/_resync?skip_matching_version=true",
+				Err: errors.New("error with API"),
+			},
+		},
+		{
+			name: "Succeeds to resynchronize Kibana instance without errors",
+			args: args{params: ResyncAllParams{
+				API: api.NewMock(mock.Response{Response: http.Response{
+					StatusCode: http.StatusAccepted,
+					Body:       mock.NewStringBody(`{}`),
+				}}),
+			}},
+			want: &models.ModelVersionIndexSynchronizationResults{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResyncAll(tt.args.params)
+			if !reflect.DeepEqual(tt.wantErr, err) {
+				t.Errorf("ResyncAll() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ResyncAll() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Implements a new  `--all` flag for kibana resync:

```console
$ ecctl deployment kibana resync --all
```

## Related Issues
Closes: https://github.com/elastic/cloud-cli/issues/1017

## How Has This Been Tested?
Manual and Unit tests

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
