### PR TITLE
cmd: add --all flag to apm resync command

### DIFF
--- a/cmd/deployment/apm/resync.go
+++ b/cmd/deployment/apm/resync.go
@@ -28,14 +28,31 @@ import (
 )
 
 var resyncApmCmd = &cobra.Command{
-	Use:     "resync <deployment id>",
+	Use:     "resync [<deployment id> | --all]",
 	Short:   "Resynchronizes the search index and cache for the selected APM deployment",
-	PreRunE: cmdutil.MinimumNArgsAndUUID(1),
+	PreRunE: cmdutil.CheckInputHas1ArgsOr0ArgAndAll,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		all, _ := cmd.Flags().GetBool("all")
+
+		if all {
+			res, err := apm.ResyncAll(apm.ResyncAllParams{
+				API: ecctl.Get().API,
+			})
+			if err != nil {
+				return err
+			}
+
+			return ecctl.Get().Formatter.Format("", res)
+		}
+
 		fmt.Printf("Resynchronizing APM deployment: %s\n", args[0])
 		return apm.Resync(apm.ResyncParams{
 			API:       ecctl.Get().API,
 			ClusterID: args[0],
 		})
 	},
+}
+
+func init() {
+	resyncApmCmd.Flags().Bool("all", false, "Resynchronizes the search index for all APM instances")
 }

--- a/cmd/deployment/apm/resync.go
+++ b/cmd/deployment/apm/resync.go
@@ -28,13 +28,14 @@ import (
 )
 
 var resyncApmCmd = &cobra.Command{
-	Use:     "resync [<deployment id> | --all]",
-	Short:   "Resynchronizes the search index and cache for the selected APM deployment",
+	Use:     "resync {<deployment id> | --all}",
+	Short:   "Resynchronizes the search index and cache for the selected APM deployment or all APM deployments",
 	PreRunE: cmdutil.CheckInputHas1ArgsOr0ArgAndAll,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		all, _ := cmd.Flags().GetBool("all")
 
 		if all {
+			fmt.Println("Resynchronizing all APM deployments")
 			res, err := apm.ResyncAll(apm.ResyncAllParams{
 				API: ecctl.Get().API,
 			})

--- a/docs/ecctl_deployment_apm.md
+++ b/docs/ecctl_deployment_apm.md
@@ -44,7 +44,7 @@ ecctl deployment apm [flags]
 * [ecctl deployment apm list](ecctl_deployment_apm_list.md)	 - Lists the APM deployments
 * [ecctl deployment apm plan](ecctl_deployment_apm_plan.md)	 - Manages APM plans
 * [ecctl deployment apm restart](ecctl_deployment_apm_restart.md)	 - Restarts an APM deployment
-* [ecctl deployment apm resync](ecctl_deployment_apm_resync.md)	 - Resynchronizes the search index and cache for the selected APM deployment
+* [ecctl deployment apm resync](ecctl_deployment_apm_resync.md)	 - Resynchronizes the search index and cache for the selected APM deployment or all APM deployments
 * [ecctl deployment apm show](ecctl_deployment_apm_show.md)	 - Shows the specified APM deployment
 * [ecctl deployment apm stop](ecctl_deployment_apm_stop.md)	 - Stops an APM deployment
 * [ecctl deployment apm upgrade](ecctl_deployment_apm_upgrade.md)	 - Upgrades an APM deployment to the Elasticsearch deployment version

--- a/docs/ecctl_deployment_apm_resync.md
+++ b/docs/ecctl_deployment_apm_resync.md
@@ -1,13 +1,13 @@
 ## ecctl deployment apm resync
 
-Resynchronizes the search index and cache for the selected APM deployment
+Resynchronizes the search index and cache for the selected APM deployment or all APM deployments
 
 ### Synopsis
 
-Resynchronizes the search index and cache for the selected APM deployment
+Resynchronizes the search index and cache for the selected APM deployment or all APM deployments
 
 ```
-ecctl deployment apm resync [<deployment id> | --all] [flags]
+ecctl deployment apm resync {<deployment id> | --all} [flags]
 ```
 
 ### Options

--- a/docs/ecctl_deployment_apm_resync.md
+++ b/docs/ecctl_deployment_apm_resync.md
@@ -7,12 +7,13 @@ Resynchronizes the search index and cache for the selected APM deployment
 Resynchronizes the search index and cache for the selected APM deployment
 
 ```
-ecctl deployment apm resync <deployment id> [flags]
+ecctl deployment apm resync [<deployment id> | --all] [flags]
 ```
 
 ### Options
 
 ```
+      --all    Resynchronizes the search index for all APM instances
   -h, --help   help for resync
 ```
 

--- a/pkg/deployment/apm/resync.go
+++ b/pkg/deployment/apm/resync.go
@@ -20,6 +20,7 @@ package apm
 import (
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/client/clusters_apm"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
 	multierror "github.com/hashicorp/go-multierror"
 
 	"github.com/elastic/ecctl/pkg/deployment/deputil"
@@ -44,6 +45,19 @@ func (params ResyncParams) Validate() error {
 	return err.ErrorOrNil()
 }
 
+// ResyncAllParams is consumed by ResyncAll
+type ResyncAllParams struct {
+	*api.API
+}
+
+// Validate ensures the parameters are usable by the consuming function.
+func (params ResyncAllParams) Validate() error {
+	if params.API == nil {
+		return util.ErrAPIReq
+	}
+	return nil
+}
+
 // Resync forces indexer to immediately resynchronize the search index
 // and cache for a given APM cluster.
 func Resync(params ResyncParams) error {
@@ -58,4 +72,21 @@ func Resync(params ResyncParams) error {
 			params.AuthWriter,
 		),
 	)
+}
+
+// ResyncAll asynchronously resynchronizes the search index for all APM instances.
+func ResyncAll(params ResyncAllParams) (*models.ModelVersionIndexSynchronizationResults, error) {
+	if err := params.Validate(); err != nil {
+		return nil, err
+	}
+
+	res, err := params.API.V1API.ClustersApm.ResyncApmClusters(
+		clusters_apm.NewResyncApmClustersParams(),
+		params.API.AuthWriter,
+	)
+	if err != nil {
+		return nil, api.UnwrapError(err)
+	}
+
+	return res.Payload, nil
 }

--- a/pkg/deployment/apm/resync_test.go
+++ b/pkg/deployment/apm/resync_test.go
@@ -143,7 +143,7 @@ func TestResyncAll(t *testing.T) {
 			},
 		},
 		{
-			name: "Succeeds to resynchronize APM instance without errors",
+			name: "Succeeds to resynchronize all APM instances without errors",
 			args: args{params: ResyncAllParams{
 				API: api.NewMock(mock.Response{Response: http.Response{
 					StatusCode: http.StatusAccepted,

--- a/pkg/deployment/apm/resync_test.go
+++ b/pkg/deployment/apm/resync_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
 	multierror "github.com/hashicorp/go-multierror"
 
 	"github.com/elastic/ecctl/pkg/util"
@@ -98,6 +99,70 @@ func TestResync(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := Resync(tt.args.params); !reflect.DeepEqual(err, tt.wantErr) {
 				t.Errorf("Resync() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestResyncAll(t *testing.T) {
+	type args struct {
+		params ResyncAllParams
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr error
+		want    *models.ModelVersionIndexSynchronizationResults
+	}{
+		{
+			name:    "Fails due to parameter validation (API)",
+			args:    args{params: ResyncAllParams{}},
+			wantErr: errors.New("api reference is required for command"),
+		},
+		{
+			name: "Fails due to unknown API response",
+			args: args{params: ResyncAllParams{
+				API: api.NewMock(mock.Response{Response: http.Response{
+					StatusCode: http.StatusForbidden,
+					Body:       mock.NewStringBody(`{"error": "some forbidden error"}`),
+				}}),
+			}},
+			wantErr: errors.New(`{"error": "some forbidden error"}`),
+		},
+		{
+			name: "Fails due to API error",
+			args: args{params: ResyncAllParams{
+				API: api.NewMock(mock.Response{
+					Error: errors.New("error with API"),
+				}),
+			}},
+			wantErr: &url.Error{
+				Op:  "Post",
+				URL: "https://mock-host/mock-path/clusters/apm/_resync?skip_matching_version=true",
+				Err: errors.New("error with API"),
+			},
+		},
+		{
+			name: "Succeeds to resynchronize APM instance without errors",
+			args: args{params: ResyncAllParams{
+				API: api.NewMock(mock.Response{Response: http.Response{
+					StatusCode: http.StatusAccepted,
+					Body:       mock.NewStringBody(`{}`),
+				}}),
+			}},
+			want: &models.ModelVersionIndexSynchronizationResults{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResyncAll(tt.args.params)
+			if !reflect.DeepEqual(tt.wantErr, err) {
+				t.Errorf("ResyncAll() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ResyncAll() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Implements a new  `--all` flag for APM resync:

```console
$ ecctl deployment apm resync --all
```

## Related Issues
Closes: https://github.com/elastic/cloud-cli/issues/1015

## How Has This Been Tested?
Manual and Unit tests

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
