### PR TITLE
cmd: Add deployment resync and --all flag

### DIFF
--- a/cmd/deployment/resync.go
+++ b/cmd/deployment/resync.go
@@ -1,0 +1,59 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmddeployment
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	cmdutil "github.com/elastic/ecctl/cmd/util"
+	"github.com/elastic/ecctl/pkg/deployment"
+	"github.com/elastic/ecctl/pkg/ecctl"
+)
+
+var resyncDeploymentCmd = &cobra.Command{
+	Use:     "resync [<deployment id> | --all]",
+	Short:   "Resynchronizes the search index and cache for the selected deployment",
+	PreRunE: cmdutil.CheckInputHas1ArgsOr0ArgAndAll,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		all, _ := cmd.Flags().GetBool("all")
+
+		if all {
+			res, err := deployment.ResyncAll(deployment.ResyncAllParams{
+				API: ecctl.Get().API,
+			})
+			if err != nil {
+				return err
+			}
+
+			return ecctl.Get().Formatter.Format("", res)
+		}
+
+		fmt.Printf("Resynchronizing deployment: %s\n", args[0])
+		return deployment.Resync(deployment.ResyncParams{
+			API: ecctl.Get().API,
+			ID:  args[0],
+		})
+	},
+}
+
+func init() {
+	Command.AddCommand(resyncDeploymentCmd)
+	resyncDeploymentCmd.Flags().Bool("all", false, "Resynchronizes the search index for all deployments")
+}

--- a/cmd/deployment/resync.go
+++ b/cmd/deployment/resync.go
@@ -28,13 +28,14 @@ import (
 )
 
 var resyncDeploymentCmd = &cobra.Command{
-	Use:     "resync [<deployment id> | --all]",
-	Short:   "Resynchronizes the search index and cache for the selected deployment",
+	Use:     "resync {<deployment id> | --all}",
+	Short:   "Resynchronizes the search index and cache for the selected deployment or all",
 	PreRunE: cmdutil.CheckInputHas1ArgsOr0ArgAndAll,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		all, _ := cmd.Flags().GetBool("all")
 
 		if all {
+			fmt.Println("Resynchronizing all deployments")
 			res, err := deployment.ResyncAll(deployment.ResyncAllParams{
 				API: ecctl.Get().API,
 			})

--- a/docs/ecctl_deployment.md
+++ b/docs/ecctl_deployment.md
@@ -49,6 +49,7 @@ ecctl deployment [flags]
 * [ecctl deployment plan](ecctl_deployment_plan.md)	 - Manages deployment plans
 * [ecctl deployment resource](ecctl_deployment_resource.md)	 - Manages deployment resources
 * [ecctl deployment restore](ecctl_deployment_restore.md)	 - Restores a previously shut down deployment and all of its associated sub-resources
+* [ecctl deployment resync](ecctl_deployment_resync.md)	 - Resynchronizes the search index and cache for the selected deployment
 * [ecctl deployment search](ecctl_deployment_search.md)	 - Performs advanced deployment search using the Elasticsearch Query DSL
 * [ecctl deployment show](ecctl_deployment_show.md)	 - Shows the specified deployment resources
 * [ecctl deployment shutdown](ecctl_deployment_shutdown.md)	 - Shuts down a deployment and all of its associated sub-resources

--- a/docs/ecctl_deployment.md
+++ b/docs/ecctl_deployment.md
@@ -49,7 +49,7 @@ ecctl deployment [flags]
 * [ecctl deployment plan](ecctl_deployment_plan.md)	 - Manages deployment plans
 * [ecctl deployment resource](ecctl_deployment_resource.md)	 - Manages deployment resources
 * [ecctl deployment restore](ecctl_deployment_restore.md)	 - Restores a previously shut down deployment and all of its associated sub-resources
-* [ecctl deployment resync](ecctl_deployment_resync.md)	 - Resynchronizes the search index and cache for the selected deployment
+* [ecctl deployment resync](ecctl_deployment_resync.md)	 - Resynchronizes the search index and cache for the selected deployment or all
 * [ecctl deployment search](ecctl_deployment_search.md)	 - Performs advanced deployment search using the Elasticsearch Query DSL
 * [ecctl deployment show](ecctl_deployment_show.md)	 - Shows the specified deployment resources
 * [ecctl deployment shutdown](ecctl_deployment_shutdown.md)	 - Shuts down a deployment and all of its associated sub-resources

--- a/docs/ecctl_deployment_resync.md
+++ b/docs/ecctl_deployment_resync.md
@@ -1,0 +1,43 @@
+## ecctl deployment resync
+
+Resynchronizes the search index and cache for the selected deployment
+
+### Synopsis
+
+Resynchronizes the search index and cache for the selected deployment
+
+```
+ecctl deployment resync [<deployment id> | --all] [flags]
+```
+
+### Options
+
+```
+      --all    Resynchronizes the search index for all deployments
+  -h, --help   help for resync
+```
+
+### Options inherited from parent commands
+
+```
+      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
+      --force              Do not ask for confirmation
+      --format string      Formats the output using a Go template
+      --host string        Base URL to use
+      --insecure           Skips all TLS validation
+      --message string     A message to set on cluster operation
+      --output string      Output format [text|json] (default "text")
+      --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
+      --pprof              Enables pprofing and saves the profile to pprof-20060102150405
+  -q, --quiet              Suppresses the configuration file used for the run, if any
+      --timeout duration   Timeout to use on all HTTP calls (default 30s)
+      --trace              Enables tracing saves the trace to trace-20060102150405
+      --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)
+      --verbose            Enable verbose mode
+```
+
+### SEE ALSO
+
+* [ecctl deployment](ecctl_deployment.md)	 - Manages deployments
+

--- a/docs/ecctl_deployment_resync.md
+++ b/docs/ecctl_deployment_resync.md
@@ -1,13 +1,13 @@
 ## ecctl deployment resync
 
-Resynchronizes the search index and cache for the selected deployment
+Resynchronizes the search index and cache for the selected deployment or all
 
 ### Synopsis
 
-Resynchronizes the search index and cache for the selected deployment
+Resynchronizes the search index and cache for the selected deployment or all
 
 ```
-ecctl deployment resync [<deployment id> | --all] [flags]
+ecctl deployment resync {<deployment id> | --all} [flags]
 ```
 
 ### Options

--- a/pkg/deployment/resync.go
+++ b/pkg/deployment/resync.go
@@ -1,0 +1,89 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package deployment
+
+import (
+	"github.com/elastic/cloud-sdk-go/pkg/client/deployments"
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	multierror "github.com/hashicorp/go-multierror"
+
+	"github.com/elastic/ecctl/pkg/util"
+	"github.com/elastic/ecctl/pkg/deployment/deputil"
+)
+
+// ResyncParams represents parameters used to resynchronize an APM cluster.
+type ResyncParams struct {
+	*api.API
+	ID string
+}
+
+// Validate ensures that the parameters such as APM cluster ID and
+// the API client object are valid before the API call is made.
+func (params ResyncParams) Validate() error {
+	var err = multierror.Append(new(multierror.Error),
+		deputil.ValidateParams(&params),
+	)
+	return err.ErrorOrNil()
+}
+
+// ResyncAllParams is consumed by ResyncAll
+type ResyncAllParams struct {
+	*api.API
+}
+
+// Validate ensures the parameters are usable by the consuming function.
+func (params ResyncAllParams) Validate() error {
+	if params.API == nil {
+		return util.ErrAPIReq
+	}
+	return nil
+}
+
+// Resync forces indexer to immediately resynchronize the search index
+// and cache for a given Kibana instance.
+func Resync(params ResyncParams) error {
+	if err := params.Validate(); err != nil {
+		return err
+	}
+
+	return util.ReturnErrOnly(
+		params.API.V1API.Deployments.ResyncDeployment(
+			deployments.NewResyncDeploymentParams().
+				WithDeploymentID(params.ID),
+			params.API.AuthWriter,
+		),
+	)
+}
+
+// ResyncAll asynchronously resynchronizes the search index for all Kibana instances.
+func ResyncAll(params ResyncAllParams) (*models.IndexSynchronizationResults, error) {
+	if err := params.Validate(); err != nil {
+		return nil, err
+	}
+
+	res, err := params.API.V1API.Deployments.ResyncDeployments(
+		deployments.NewResyncDeploymentsParams(),
+		params.API.AuthWriter,
+	)
+	if err != nil {
+		return nil, api.UnwrapError(err)
+	}
+
+	return res.Payload, nil
+}

--- a/pkg/deployment/resync.go
+++ b/pkg/deployment/resync.go
@@ -18,23 +18,22 @@
 package deployment
 
 import (
-	"github.com/elastic/cloud-sdk-go/pkg/client/deployments"
 	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/client/deployments"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	multierror "github.com/hashicorp/go-multierror"
 
-	"github.com/elastic/ecctl/pkg/util"
 	"github.com/elastic/ecctl/pkg/deployment/deputil"
+	"github.com/elastic/ecctl/pkg/util"
 )
 
-// ResyncParams represents parameters used to resynchronize an APM cluster.
+// ResyncParams is consumed by Resync
 type ResyncParams struct {
 	*api.API
 	ID string
 }
 
-// Validate ensures that the parameters such as APM cluster ID and
-// the API client object are valid before the API call is made.
+// Validate ensures the parameters are usable by the consuming function.
 func (params ResyncParams) Validate() error {
 	var err = multierror.Append(new(multierror.Error),
 		deputil.ValidateParams(&params),
@@ -56,7 +55,7 @@ func (params ResyncAllParams) Validate() error {
 }
 
 // Resync forces indexer to immediately resynchronize the search index
-// and cache for a given Kibana instance.
+// and cache for a given deployment.
 func Resync(params ResyncParams) error {
 	if err := params.Validate(); err != nil {
 		return err
@@ -71,7 +70,7 @@ func Resync(params ResyncParams) error {
 	)
 }
 
-// ResyncAll asynchronously resynchronizes the search index for all Kibana instances.
+// ResyncAll asynchronously resynchronizes the search index for all deployments.
 func ResyncAll(params ResyncAllParams) (*models.IndexSynchronizationResults, error) {
 	if err := params.Validate(); err != nil {
 		return nil, err

--- a/pkg/deployment/resync_test.go
+++ b/pkg/deployment/resync_test.go
@@ -28,8 +28,6 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	multierror "github.com/hashicorp/go-multierror"
-
-	"github.com/elastic/ecctl/pkg/util"
 )
 
 func TestResync(t *testing.T) {
@@ -45,7 +43,7 @@ func TestResync(t *testing.T) {
 			name: "Fails due to parameter validation (Cluster ID)",
 			args: args{},
 			wantErr: &multierror.Error{Errors: []error{
-				util.ErrAPIReq,
+				errors.New("api reference is required for command"),
 				errors.New(`id "" is invalid`),
 			}},
 		},
@@ -55,7 +53,7 @@ func TestResync(t *testing.T) {
 				ID: "d324608c97154bdba2dff97511d40368",
 			}},
 			wantErr: &multierror.Error{Errors: []error{
-				util.ErrAPIReq,
+				errors.New("api reference is required for command"),
 			}},
 		},
 		{
@@ -84,7 +82,7 @@ func TestResync(t *testing.T) {
 			},
 		},
 		{
-			name: "Succeeds to resynchronize deployment without errors",
+			name: "Succeeds to resynchronize a deployment without errors",
 			args: args{params: ResyncParams{
 				ID: "d324608c97154bdba2dff97511d40368",
 				API: api.NewMock(mock.Response{Response: http.Response{
@@ -143,7 +141,7 @@ func TestResyncAll(t *testing.T) {
 			},
 		},
 		{
-			name: "Succeeds to resynchronize Deployment without errors",
+			name: "Succeeds to resynchronize all deployments without errors",
 			args: args{params: ResyncAllParams{
 				API: api.NewMock(mock.Response{Response: http.Response{
 					StatusCode: http.StatusOK,

--- a/pkg/deployment/resync_test.go
+++ b/pkg/deployment/resync_test.go
@@ -1,0 +1,169 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package deployment
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	multierror "github.com/hashicorp/go-multierror"
+
+	"github.com/elastic/ecctl/pkg/util"
+)
+
+func TestResync(t *testing.T) {
+	type args struct {
+		params ResyncParams
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr error
+	}{
+		{
+			name: "Fails due to parameter validation (Cluster ID)",
+			args: args{},
+			wantErr: &multierror.Error{Errors: []error{
+				util.ErrAPIReq,
+				errors.New(`id "" is invalid`),
+			}},
+		},
+		{
+			name: "Fails due to parameter validation (API)",
+			args: args{params: ResyncParams{
+				ID: "d324608c97154bdba2dff97511d40368",
+			}},
+			wantErr: &multierror.Error{Errors: []error{
+				util.ErrAPIReq,
+			}},
+		},
+		{
+			name: "Fails due to unknown API response",
+			args: args{params: ResyncParams{
+				ID: "2c221bd86b7f48959a59ee3128d5c5e8",
+				API: api.NewMock(mock.Response{Response: http.Response{
+					StatusCode: http.StatusForbidden,
+					Body:       mock.NewStringBody(`{"error": "some forbidden error"}`),
+				}}),
+			}},
+			wantErr: errors.New(`{"error": "some forbidden error"}`),
+		},
+		{
+			name: "Fails due to API error",
+			args: args{params: ResyncParams{
+				ID: "2c221bd86b7f48959a59ee3128d5c5e8",
+				API: api.NewMock(mock.Response{
+					Error: errors.New("error with API"),
+				}),
+			}},
+			wantErr: &url.Error{
+				Op:  "Post",
+				URL: "https://mock-host/mock-path/deployments/2c221bd86b7f48959a59ee3128d5c5e8/_resync",
+				Err: errors.New("error with API"),
+			},
+		},
+		{
+			name: "Succeeds to resynchronize deployment without errors",
+			args: args{params: ResyncParams{
+				ID: "d324608c97154bdba2dff97511d40368",
+				API: api.NewMock(mock.Response{Response: http.Response{
+					StatusCode: http.StatusOK,
+					Body:       mock.NewStringBody(`{}`),
+				}}),
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := Resync(tt.args.params); !reflect.DeepEqual(err, tt.wantErr) {
+				t.Errorf("Resync() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestResyncAll(t *testing.T) {
+	type args struct {
+		params ResyncAllParams
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr error
+		want    *models.IndexSynchronizationResults
+	}{
+		{
+			name:    "Fails due to parameter validation (API)",
+			args:    args{params: ResyncAllParams{}},
+			wantErr: errors.New("api reference is required for command"),
+		},
+		{
+			name: "Fails due to unknown API response",
+			args: args{params: ResyncAllParams{
+				API: api.NewMock(mock.Response{Response: http.Response{
+					StatusCode: http.StatusForbidden,
+					Body:       mock.NewStringBody(`{"error": "some forbidden error"}`),
+				}}),
+			}},
+			wantErr: errors.New(`{"error": "some forbidden error"}`),
+		},
+		{
+			name: "Fails due to API error",
+			args: args{params: ResyncAllParams{
+				API: api.NewMock(mock.Response{
+					Error: errors.New("error with API"),
+				}),
+			}},
+			wantErr: &url.Error{
+				Op:  "Post",
+				URL: "https://mock-host/mock-path/deployments/_resync",
+				Err: errors.New("error with API"),
+			},
+		},
+		{
+			name: "Succeeds to resynchronize Deployment without errors",
+			args: args{params: ResyncAllParams{
+				API: api.NewMock(mock.Response{Response: http.Response{
+					StatusCode: http.StatusOK,
+					Body:       mock.NewStringBody(`{}`),
+				}}),
+			}},
+			want: &models.IndexSynchronizationResults{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResyncAll(tt.args.params)
+			if !reflect.DeepEqual(tt.wantErr, err) {
+				t.Errorf("ResyncAll() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ResyncAll() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description

Implements a new `deployment resync` command which resynchronises a given deployment or all.

```console
$ ecctl deployment resync {<deployment id> | --all}
```

## Related Issues
Closes: https://github.com/elastic/cloud-cli/issues/1018

## How Has This Been Tested?
Manual and Unit tests

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
