### PR TITLE
Updated tap repo to point to elastic/tap

### DIFF
--- a/docs/ecctl-getting-started.asciidoc
+++ b/docs/ecctl-getting-started.asciidoc
@@ -37,8 +37,8 @@ link:https://brew.sh/[Homebrew]:
 
 [source]
 ----
-$ brew tap elastic/ecctl
-$ brew install elastic/ecctl/ecctl
+$ brew tap elastic/tap
+$ brew install elastic/tap/ecctl
 Updating Homebrew...
 => Installing ecctl from elastic/ecctl
 ...


### PR DESCRIPTION
To align with other elastic product which are served from a single elastic tap we should consider adding ecctl to [elastic/homebrew-tap](https://github.com/elastic/homebrew-tap) as well.