### PR TITLE
util: Change default tracking poll interval

### DIFF
--- a/pkg/util/track.go
+++ b/pkg/util/track.go
@@ -28,16 +28,16 @@ import (
 const (
 	// DefaultRetries retries for the plan.TrackParams which accounts
 	// for the Pending plan not being present in the backend, it will retry
-	// the request the times specified here. 4 is the default anectdotically
-	// because it provides a maximum sleeping time of (PollFrequency * 2)^4
-	// or math.Exp2(4). Increasing this value will cause the PlanTracker to
+	// the request the times specified here. 2 is the default anectdotically
+	// because it provides a maximum sleeping time of (PollFrequency * 2)^2
+	// or math.Exp2(2). Increasing this value will cause the PlanTracker to
 	// sleep for more time than it's required, thus making ecctl less efficient.
-	DefaultRetries = 4
+	DefaultRetries = 2
 
 	// DefaultPollFrequency is frequency on which the API is polled for updates
 	// on pending plans. This value is also used as the cooldown time when used
 	// with MaxRetries > 0.
-	DefaultPollFrequency = time.Second
+	DefaultPollFrequency = time.Second * 10
 )
 
 // TrackParams are intended to be used as a field in other params structs


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Changes the default poll period from 1s to 10s, meaning a 10x increase
to a slower polling period. Additionally adjusts the number of accepted
API failues (404 or timeouts) to only 2 exponential backoffs since now
the polling interval is higher which yields the same effect on ensuring
that the pending plan has finished without polling the API so many
times.

This should reduce memory the binary's CPU and network usage as well as
reduced API backpressure.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Part or #121 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually
