### PR TITLE
release: Automate release in GitHub action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - v*.*.*
+
+jobs:
+  name: Release a new version
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13
+        id: go
+
+      - name: Install hub
+        uses: geertvdc/setup-hub@master
+
+      - name: Update AWS cli
+        uses: chrislennon/action-aws-cli@v1.1
+
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+
+      - name: Get the builtvar
+        id: get_built
+        run: echo ::set-output name=BUILT::$(date -u +%a_%d_%b_%H:%M:%S_%Y)
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_EXTRA }}
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
+          BUILT: ${{ steps.get_built.outputs.BUILT }}
+          OWNER: elastic
+          REPO: ecctl
+        with:
+          version: latest
+          args: release --rm-dist
+
+      - name: Run release post actions
+        run: ./scripts/goreleaser-post-actions.sh $VERSION
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_EXTRA }}
+          GITHUB_USER: marclop
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: goreleaser
 on:
   push:
     tags:
-      - v*.*.*
+      - '*.*.*'
 
 jobs:
   name: Release a new version

--- a/developer_docs/RELEASE.md
+++ b/developer_docs/RELEASE.md
@@ -14,14 +14,14 @@ The version is currently defined in the [Makefile](./Makefile) as an exported en
 
 ```Makefile
 SHELL := /bin/bash
-export VERSION ?= 1.0.0
+export VERSION ?= v1.0.0
 ```
 
 Say we want to perform a minor version release (i.e. no breaking changes and only new features and bug fixes are being included); in which case we'll update the _MINOR_ part of the version:
 
 ```Makefile
 SHELL := /bin/bash
-export VERSION ?= 1.1.0
+export VERSION ?= v1.1.0
 ```
 
 ### Generating a changelog for the new version
@@ -32,4 +32,4 @@ After a changelog has been manually curated, a new pull request can be opened wi
 
 ## Executing the release
 
-After the new changelog and version have been merged to master, the only thing remaining is to run `make release`. This is the makefile target which will do the release.
+After the new changelog and version have been merged to master, the only thing remaining is to run `make tag`. This is the makefile target which will push the GitHub tag and will trigger the corresponding [GitHub action](.github/workflows/release.yml) which will release ecctl.

--- a/scripts/goreleaser
+++ b/scripts/goreleaser
@@ -28,13 +28,5 @@ docker run --rm -ti --privileged \
     -v "$(pwd):/go/src/github.com/${OWNER}/${REPO}" \
     -w "/go/src/github.com/${OWNER}/${REPO}" ecctl:goreleaser ${*}
 
-# Upload the binaries and the checksums.
-for f in dist/*.{tar.gz,deb,rpm,txt}; do
-    aws --profile ecsecurity s3 cp --acl bucket-owner-full-control \
-    ${f} s3://download.elasticsearch.org/downloads/ecctl/${VERSION}/
-done
-
-# Create the actual Github Release.
-hub release create -F notes/${VERSION}.md -m ${VERSION}
-
-echo "-> Please update the brew formula https://github.com/elastic/homebrew-ecctl with the new version and checksums"
+# Run post actions
+./goreleaser-post-actions.sh ${VERSION}

--- a/scripts/goreleaser-post-actions.sh
+++ b/scripts/goreleaser-post-actions.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Parameters
+VERSION=${1}
+
+# Upload the binaries and the checksums.
+for f in dist/*.{tar.gz,deb,rpm,txt}; do
+    aws --profile ecsecurity s3 cp --acl bucket-owner-full-control \
+    ${f} s3://download.elasticsearch.org/downloads/ecctl/${VERSION}/
+done
+
+# Create the actual Github Release.
+hub release create -F notes/${VERSION}.md -m ${VERSION}
+
+# Update the brew tap formula
+./scripts/update-brew-tap.sh ${VERSION}

--- a/scripts/update-brew-tap.sh
+++ b/scripts/update-brew-tap.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Parameters
+VERSION=$(echo ${1}| sed 's/^v//')
+
+# Globals
+FORMULA_FILE=/tmp/homebrew-tap/Formula/ecctl.rb
+GITHUB_USER=marclop
+
+# Execution
+
+if [[ -d /tmp/homebrew-tap ]]; then rm -rf /tmp/homebrew-tap; fi
+hub clone https://github.com/elastic/homebrew-tap /tmp/homebrew-tap
+
+DARWIN_CHECKSUM=$(grep darwin_amd64 dist/*checksums.txt | awk '{print $1}' | tr -d '\n')
+LINUX_CHECKSUM=$(grep linux_amd64.tar.gz dist/*checksums.txt | awk '{print $1}' | tr -d '\n')
+OLD_DARWIN_CHECKSUM=$(grep sha256 ${FORMULA_FILE}|head -1| awk '{print $2}' | tr -d '\n' | tr -d '"')
+OLD_LINUX_CHECKSUM=$(grep sha256 ${FORMULA_FILE}|tail -1| awk '{print $2}' | tr -d '\n' | tr -d '"')
+OLD_VERSION=$(grep 'version \"' ${FORMULA_FILE} | awk '{print $2}' | tr -d '"' | tr -d '\n')
+
+sed "s/${OLD_VERSION}/${VERSION}/g" ${FORMULA_FILE} | sed "s/${OLD_DARWIN_CHECKSUM}/${DARWIN_CHECKSUM}/" | sed "s/${OLD_LINUX_CHECKSUM}/${LINUX_CHECKSUM}/" > /tmp/ecctl.rb
+mv /tmp/ecctl.rb ${FORMULA_FILE}
+
+cd /tmp/homebrew-tap
+hub fork --no-remote
+hub remote add fork https://github.com/${GITHUB_USER}/homebrew-tap
+hub add Formula/ecctl.rb
+hub checkout -b f/update-ecctl-formula-to-${VERSION}
+hub commit -m "(TEST) Update ecctl version to ${VERSION}"
+hub push fork f/update-ecctl-formula-to-${VERSION}
+hub pull-request -m "Update ecctl version to ${VERSION}" -m "Created through automation by update-brew-tap.sh"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Automates the release process for ecctl binaries in a GitHub action. As
part of automating the release, it has been split into two parts;
running goreleaser and running goreleaser post actions.

Since goreleaser no longer automates the homebrew formula creation or
the upload of binaries to an artifact repository, those actions have
been moved to `scripts/goreleaser-post-actions.sh`, which uploads the
binaries to S3, Creates GitHub release, and updates elastic/homebrew-tap
with the latest ecctl version, binary links and checksums.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fully automated release process. No more user-tied releases.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually
