### PR TITLE
deployment: Fix empty region bug when specified

### DIFF
--- a/cmd/deployment/apm/create.go
+++ b/cmd/deployment/apm/create.go
@@ -44,7 +44,7 @@ var createApmCmd = &cobra.Command{
 		var id, _ = cmd.Flags().GetString("id")
 		var version, _ = cmd.Flags().GetString("version")
 		var dt, _ = cmd.Flags().GetString("deployment-template")
-		var region string
+		var region = ecctl.Get().Config.Region
 		if ecctl.Get().Config.Region == "" {
 			region = cmdutil.DefaultECERegion
 		}

--- a/cmd/deployment/create.go
+++ b/cmd/deployment/create.go
@@ -137,7 +137,7 @@ var createCmd = &cobra.Command{
 			return err
 		}
 
-		var region string
+		var region = ecctl.Get().Config.Region
 		if ecctl.Get().Config.Region == "" {
 			region = cmdutil.DefaultECERegion
 		}

--- a/cmd/deployment/kibana/create.go
+++ b/cmd/deployment/kibana/create.go
@@ -45,7 +45,7 @@ var createKibanaCmd = &cobra.Command{
 		var id, _ = cmd.Flags().GetString("id")
 		var version, _ = cmd.Flags().GetString("version")
 		var dt, _ = cmd.Flags().GetString("deployment-template")
-		var region string
+		var region = ecctl.Get().Config.Region
 		if ecctl.Get().Config.Region == "" {
 			region = cmdutil.DefaultECERegion
 		}

--- a/cmd/deployment/update.go
+++ b/cmd/deployment/update.go
@@ -148,7 +148,7 @@ var updateCmd = &cobra.Command{
 		skipSnapshot, _ := cmd.Flags().GetBool("skip-snapshot")
 		hidePrunedOrphans, _ := cmd.Flags().GetBool("hide-pruned-orphans")
 
-		var region string
+		var region = ecctl.Get().Config.Region
 		if ecctl.Get().Config.Region == "" {
 			region = cmdutil.DefaultECERegion
 		}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Fixes the case where an actual region is specified, either in the
config, flag or environment and it is not populated.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Region not being used when specified in deployments.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
