### PR TITLE
release: Remove v prefix from binaries and path

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,7 +27,7 @@ builds:
   binary: ecctl
   lang: go
 archives:
-  - name_template: '{{ .ProjectName }}_{{ .Env.VERSION }}_{{ .Os }}_{{ .Arch }}{{ if .Arm}}v{{ .Arm }}{{ end }}'
+  - name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm}}v{{ .Arm }}{{ end }}'
     format: tar.gz
     files:
     - LICENSE*
@@ -36,7 +36,7 @@ archives:
 snapshot:
   name_template: SNAPSHOT-{{ .Commit }}
 nfpms:
-  - file_name_template: "{{ .ProjectName }}_{{ .Env.VERSION }}_{{ .Os }}_{{ .Arch }}"
+  - file_name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     license: Apache 2.0
     replacements:
       amd64: 64-bit
@@ -45,5 +45,5 @@ nfpms:
       - deb
       - rpm
 checksum:
-  name_template: '{{ .ProjectName }}_{{ .Env.VERSION }}_checksums.txt'
+  name_template: '{{ .ProjectName }}_{{ .Version }}_checksums.txt'
 dist: dist

--- a/scripts/goreleaser
+++ b/scripts/goreleaser
@@ -29,4 +29,6 @@ docker run --rm -ti --privileged \
     -w "/go/src/github.com/${OWNER}/${REPO}" ecctl:goreleaser ${*}
 
 # Run post actions
-./goreleaser-post-actions.sh ${VERSION}
+if [[ ${1} != "snapshot" ]]; then
+    ./scripts/goreleaser-post-actions.sh ${VERSION}
+fi

--- a/scripts/goreleaser-post-actions.sh
+++ b/scripts/goreleaser-post-actions.sh
@@ -8,7 +8,7 @@ VERSION=${1}
 # Upload the binaries and the checksums.
 for f in dist/*.{tar.gz,deb,rpm,txt}; do
     aws --profile ecsecurity s3 cp --acl bucket-owner-full-control \
-    ${f} s3://download.elasticsearch.org/downloads/ecctl/${VERSION}/
+    ${f} s3://download.elasticsearch.org/downloads/ecctl/$(echo ${VERSION}| sed 's/^v//')/
 done
 
 # Create the actual Github Release.


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
This change removes the v prefix for all of the artifacts created from
goreleaser and also from the path where the artifacts are then uploaded
to.

Additionally fixes a bug which was calling the release post actions on
goreleaser's snapshot command and an erroneous path since the script is
called by the root Makefile

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Resolves #149 

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
