### PR TITLE
Updating ecctl init sample command to run after init

### DIFF
--- a/docs/ecctl-getting-started.asciidoc
+++ b/docs/ecctl-getting-started.asciidoc
@@ -132,9 +132,8 @@ Paste your API Key and press enter: xxxxx
 
 Your credentials seem to be valid, and show you're authenticated as "user".
 
-You're all set! Here are some commands to try:
-  $ ecctl auth user key list
-  $ ecctl deployment elasticsearch list
+You're all set! Here is a command to try:
+  $ ecctl deployment list
 ----
 
 [id="{p}-authentication"]


### PR DESCRIPTION
Removed `$ ecctl auth user key list` command that doesn't work in ESS and updated `ecctl deployment elasticsearch list` command to `ecctl deployment list` to list all active deployments.