### PR TITLE
build: Add Go module cache for GitHub actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,6 +16,14 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
 
+    - name: Cache Go Modules
+      uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
     - name: Get dependencies
       run: make vendor
       id: modules

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,14 @@ jobs:
           go-version: 1.13
         id: go
 
+      - name: Cache Go Modules
+        uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
       - name: Install hub
         uses: geertvdc/setup-hub@master
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds the cache action to all workflows so that the Go modules can be
pre-cached

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Cached dependencies so builds go faster

