### PR TITLE
cmd: add runner show <runner id> command

### DIFF
--- a/cmd/platform/runner/show.go
+++ b/cmd/platform/runner/show.go
@@ -1,0 +1,48 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmdrunner
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/elastic/ecctl/pkg/ecctl"
+	"github.com/elastic/ecctl/pkg/platform/runner"
+)
+
+var showCmd = &cobra.Command{
+	Use:     "show <runner id>",
+	Short:   "Shows information about the specified runner",
+	PreRunE: cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := runner.Show(runner.ShowParams{
+			Params: runner.Params{
+				API: ecctl.Get().API,
+			},
+			ID: args[0],
+		})
+		if err != nil {
+			return err
+		}
+
+		return ecctl.Get().Formatter.Format("", res)
+	},
+}
+
+func init() {
+	Command.AddCommand(showCmd)
+}

--- a/docs/ecctl_platform_runner_show.md
+++ b/docs/ecctl_platform_runner_show.md
@@ -1,19 +1,19 @@
-## ecctl platform runner
+## ecctl platform runner show
 
-Manages platform runners (for ECE installations only)
+Shows information about the specified runner
 
 ### Synopsis
 
-Manages platform runners (for ECE installations only)
+Shows information about the specified runner
 
 ```
-ecctl platform runner [flags]
+ecctl platform runner show <runner id> [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for runner
+  -h, --help   help for show
 ```
 
 ### Options inherited from parent commands
@@ -38,7 +38,5 @@ ecctl platform runner [flags]
 
 ### SEE ALSO
 
-* [ecctl platform](ecctl_platform.md)	 - Manages the platform
-* [ecctl platform runner list](ecctl_platform_runner_list.md)	 - Lists the existing platform runners
-* [ecctl platform runner show](ecctl_platform_runner_show.md)	 - Shows information about the specified runner
+* [ecctl platform runner](ecctl_platform_runner.md)	 - Manages platform runners (for ECE installations only)
 

--- a/pkg/platform/runner/show.go
+++ b/pkg/platform/runner/show.go
@@ -1,0 +1,63 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package runner
+
+import (
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/client/platform_infrastructure"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	multierror "github.com/hashicorp/go-multierror"
+
+	"github.com/elastic/ecctl/pkg/util"
+)
+
+// ShowParams is the set of parameters required for
+type ShowParams struct {
+	Params
+	ID string
+}
+
+// Validate checks the parameters
+func (params ShowParams) Validate() error {
+	var merr = new(multierror.Error)
+
+	if params.ID == "" {
+		merr = multierror.Append(merr, util.ErrIDCannotBeEmpty)
+	}
+
+	merr = multierror.Append(merr, params.Params.Validate())
+
+	return merr.ErrorOrNil()
+}
+
+// Show returns information about a specific runner
+func Show(params ShowParams) (*models.RunnerInfo, error) {
+	if err := params.Validate(); err != nil {
+		return nil, err
+	}
+
+	res, err := params.API.V1API.PlatformInfrastructure.GetRunner(
+		platform_infrastructure.NewGetRunnerParams().WithRunnerID(params.ID),
+		params.AuthWriter,
+	)
+	if err != nil {
+		return nil, api.UnwrapError(err)
+	}
+
+	return res.Payload, nil
+}

--- a/pkg/platform/runner/show.go
+++ b/pkg/platform/runner/show.go
@@ -52,7 +52,8 @@ func Show(params ShowParams) (*models.RunnerInfo, error) {
 	}
 
 	res, err := params.API.V1API.PlatformInfrastructure.GetRunner(
-		platform_infrastructure.NewGetRunnerParams().WithRunnerID(params.ID),
+		platform_infrastructure.NewGetRunnerParams().
+			WithRunnerID(params.ID),
 		params.AuthWriter,
 	)
 	if err != nil {

--- a/pkg/platform/runner/show_test.go
+++ b/pkg/platform/runner/show_test.go
@@ -1,0 +1,111 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package runner
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+	multierror "github.com/hashicorp/go-multierror"
+)
+
+func TestShow(t *testing.T) {
+	var runnerShow = `
+{
+  "connected": true,
+  "runner_id": "192.168.44.10"
+}`
+
+	type args struct {
+		params ShowParams
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *models.RunnerInfo
+		wantErr error
+	}{
+		{
+			name: "Show runner succeeds",
+			args: args{
+				params: ShowParams{
+					ID: "192.168.44.10",
+					Params: Params{
+						API: api.NewMock(mock.Response{Response: http.Response{
+							Body:       mock.NewStringBody(runnerShow),
+							StatusCode: 200,
+						}}),
+					},
+				},
+			},
+			want: &models.RunnerInfo{
+				RunnerID:  ec.String("192.168.44.10"),
+				Connected: ec.Bool(true),
+			},
+		},
+		{
+			name: "Show runner fails",
+			args: args{
+				params: ShowParams{
+					ID: "192.168.44.10",
+					Params: Params{
+						API: api.NewMock(mock.Response{Error: errors.New("error")}),
+					},
+				},
+			},
+			want: nil,
+			wantErr: &url.Error{
+				Op:  "Get",
+				URL: "https://mock-host/mock-path/platform/infrastructure/runners/192.168.44.10",
+				Err: errors.New("error"),
+			},
+		},
+		{
+			name: "Show runner fails due to validation",
+			args: args{
+				params: ShowParams{},
+			},
+			want: nil,
+			wantErr: &multierror.Error{
+				Errors: []error{
+					errors.New("id field cannot be empty"),
+					errors.New("api reference is required for command"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Show(tt.args.params)
+			if !reflect.DeepEqual(err, tt.wantErr) {
+				t.Errorf("List() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Show() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/util/helper.go
+++ b/pkg/util/helper.go
@@ -39,6 +39,8 @@ var (
 	ErrClusterLength = errors.New("cluster id should have a length of 32 characters")
 	// ErrDeploymentID is the message returned when a provided cluster id is not of the expected length (32 chars)
 	ErrDeploymentID = errors.New("deployment id should have a length of 32 characters")
+	// ErrIDCannotBeEmpty is the message returned when an ID field is empty
+	ErrIDCannotBeEmpty = errors.New("id field cannot be empty")
 
 	// SkipMaintenanceHeaders tells the EC proxy layer to still send requests to the
 	// underlying cluster instances even if they are in maintenance mode


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Creates an `ecctl runner show <runner-id>` command, which shows information about the specified runner.

## Related Issues
Closes: https://github.com/elastic/ecctl/issues/170

## How Has This Been Tested?
Unit tests and by running `go run main.go platform runner show 192.168.44.12` against an ece environment.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
