### PR TITLE
cmd: init ask for type of infrastructure and default to ESS config setup

### DIFF
--- a/pkg/ecctl/init.go
+++ b/pkg/ecctl/init.go
@@ -52,17 +52,21 @@ const (
 	_ = iota
 	essInfraChoice
 	eceInfraChoice
+	esspInfraChoice
 )
 
 const (
-	disclaimer      = "Welcome to the Elastic Cloud CLI! This command will guide you through authenticating and setting some default values.\n\n"
+	disclaimer      = "Welcome to Elastic Cloud Control (ecctl)! This command will guide you through authenticating and setting some default values.\n\n"
 	redacted        = "[REDACTED]"
 	settingsPathMsg = "Found existing settings in %s. Here's a JSON representation of what they look like:\n"
 
 	missingConfigMsg  = `Missing configuration file, would you like to initialise it? [y/n]: `
 	existingConfigMsg = `Would you like to change your current settings? [y/n]: `
 
-	hostMsg = "Enter the URL of your ECE installation: "
+	essHostAddress = "https://api.elastic-cloud.com"
+	eceHostMsg     = "Enter the URL of your ECE installation: "
+	esspHostMsg    = "Enter the URL of your ESSP installation: "
+	essChoiceMsg   = "Using \"%s\" as the API endpoint.\n"
 
 	apiKeyMsg = "Paste your API Key and press enter: "
 	userMsg   = "Type in your username: "
@@ -74,9 +78,10 @@ const (
 
 var (
 	hostChoiceMsg = `
-Select which type of infrastructure this configuration will for:
-  [1] Elastic Cloud (Elasticsearch Service).
+Select which type of Elastic Cloud offering will you be working with:
+  [1] Elasticsearch Service (default).
   [2] Elastic Cloud Enterprise (ECE).
+  [3] Elasticsearch Service Private (ESSP).
 
 Please enter your choice: `
 
@@ -267,13 +272,16 @@ func askInfraSelection(cfg *Config, scanner *input.Scanner, writer, errWriter io
 		return err
 	}
 
-	cfg.Host = "https://api.elastic-cloud.com"
+	cfg.Host = essHostAddress
 	switch infraChoice {
-	case eceInfraChoice:
-		cfg.Host = scanner.Scan(hostMsg)
 	case essInfraChoice:
+		fmt.Fprintf(writer, essChoiceMsg, essHostAddress)
+	case eceInfraChoice:
+		cfg.Host = scanner.Scan(eceHostMsg)
+	case esspInfraChoice:
+		cfg.Host = scanner.Scan(esspHostMsg)
 	default:
-		fmt.Fprintln(errWriter, "invalid choice, defaulting to \"https://api.elastic-cloud.com\"")
+		fmt.Fprintf(errWriter, "invalid choice, defaulting to %s", essHostAddress)
 	}
 
 	return nil

--- a/pkg/ecctl/init_test.go
+++ b/pkg/ecctl/init_test.go
@@ -241,7 +241,7 @@ func TestInitConfig(t *testing.T) {
 				FilePath: filepath.Join(testFiles, "newConfig"),
 				Reader: io.MultiReader(
 					strings.NewReader("y\n"),
-					strings.NewReader("https://ahost\n"),
+					strings.NewReader("1\n"),
 					strings.NewReader("1\n"),
 					strings.NewReader("1\n"),
 					strings.NewReader("anapikey\n"),
@@ -257,11 +257,11 @@ func TestInitConfig(t *testing.T) {
 			}},
 			wantSettings: map[string]interface{}{
 				"apikey":   "somekey",
-				"host":     "https://ahost",
+				"host":     "https://api.elastic-cloud.com",
 				"insecure": true,
 				"output":   "text",
 			},
-			wantOutput: disclaimer + missingConfigMsg + hostMsg +
+			wantOutput: disclaimer + missingConfigMsg + hostChoiceMsg + "\n" +
 				formatChoiceMsg + "\n" + authChoiceMsg + "\n" + apiKeyMsg + "\n" +
 				"\n" + fmt.Sprintf(validCredentialsMsg, "anacleto") + finalMsg + "\n",
 		},
@@ -272,6 +272,7 @@ func TestInitConfig(t *testing.T) {
 				FilePath: filepath.Join(testFiles, "newConfigUserPass"),
 				Reader: io.MultiReader(
 					strings.NewReader("y\n"),
+					strings.NewReader("2\n"),
 					strings.NewReader("https://ahost\n"),
 					strings.NewReader("1\n"),
 					strings.NewReader("2\n"),
@@ -298,7 +299,7 @@ func TestInitConfig(t *testing.T) {
 				"pass":     "apassword",
 				"user":     "auser",
 			},
-			wantOutput: disclaimer + missingConfigMsg + hostMsg +
+			wantOutput: disclaimer + missingConfigMsg + hostChoiceMsg + "\n" + hostMsg +
 				formatChoiceMsg + "\n" + authChoiceMsg + "\n" + userMsg + passMsg +
 				"\n" + "\n" + fmt.Sprintf(validCredentialsMsg, "auser") + finalMsg + "\n",
 		},
@@ -309,6 +310,7 @@ func TestInitConfig(t *testing.T) {
 				FilePath: filepath.Join(testFiles, "doesnt_matter"),
 				Reader: io.MultiReader(
 					strings.NewReader("y\n"),
+					strings.NewReader("2\n"),
 					strings.NewReader("https://ahost\n"),
 					strings.NewReader("1\n"),
 					strings.NewReader("1\n"),
@@ -331,9 +333,9 @@ func TestInitConfig(t *testing.T) {
 			},
 			wantOutput: disclaimer +
 				fmt.Sprintf(settingsPathMsg, "test_files/userpassmodif.yaml") +
-				userPassConfigToModifyContents + "\n" + existingConfigMsg + hostMsg +
-				formatChoiceMsg + "\n" + authChoiceMsg + "\n" + apiKeyMsg + "\n" +
-				"\n" + fmt.Sprintf(validCredentialsMsg, "anacleto") + finalMsg + "\n",
+				userPassConfigToModifyContents + "\n" + existingConfigMsg + hostChoiceMsg +
+				"\n" + hostMsg + formatChoiceMsg + "\n" + authChoiceMsg + "\n" + apiKeyMsg +
+				"\n" + "\n" + fmt.Sprintf(validCredentialsMsg, "anacleto") + finalMsg + "\n",
 		},
 		{
 			name: "finds a config file and user changes the values, from apikey to user/pass",
@@ -342,6 +344,7 @@ func TestInitConfig(t *testing.T) {
 				FilePath: filepath.Join(testFiles, "doesnt_matter"),
 				Reader: io.MultiReader(
 					strings.NewReader("y\n"),
+					strings.NewReader("2\n"),
 					strings.NewReader("https://ahost\n"),
 					strings.NewReader("1\n"),
 					strings.NewReader("2\n"),
@@ -370,9 +373,9 @@ func TestInitConfig(t *testing.T) {
 			},
 			wantOutput: disclaimer +
 				fmt.Sprintf(settingsPathMsg, "test_files/apikeymodif.yaml") +
-				apiKeyConfigToModifyContents + "\n" + existingConfigMsg + hostMsg +
-				formatChoiceMsg + "\n" + authChoiceMsg + "\n" + userMsg + passMsg +
-				"\n" + "\n" + fmt.Sprintf(validCredentialsMsg, "auser") + finalMsg + "\n",
+				apiKeyConfigToModifyContents + "\n" + existingConfigMsg + hostChoiceMsg +
+				"\n" + hostMsg + formatChoiceMsg + "\n" + authChoiceMsg + "\n" + userMsg +
+				passMsg + "\n" + "\n" + fmt.Sprintf(validCredentialsMsg, "auser") + finalMsg + "\n",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/ecctl/init_test.go
+++ b/pkg/ecctl/init_test.go
@@ -262,8 +262,9 @@ func TestInitConfig(t *testing.T) {
 				"output":   "text",
 			},
 			wantOutput: disclaimer + missingConfigMsg + hostChoiceMsg + "\n" +
-				formatChoiceMsg + "\n" + authChoiceMsg + "\n" + apiKeyMsg + "\n" +
-				"\n" + fmt.Sprintf(validCredentialsMsg, "anacleto") + finalMsg + "\n",
+				fmt.Sprintf(essChoiceMsg, essHostAddress) + formatChoiceMsg +
+				"\n" + authChoiceMsg + "\n" + apiKeyMsg + "\n" + "\n" +
+				fmt.Sprintf(validCredentialsMsg, "anacleto") + finalMsg + "\n",
 		},
 		{
 			name: "doesn't find a config file and user creates a new one with user/pass",
@@ -299,7 +300,7 @@ func TestInitConfig(t *testing.T) {
 				"pass":     "apassword",
 				"user":     "auser",
 			},
-			wantOutput: disclaimer + missingConfigMsg + hostChoiceMsg + "\n" + hostMsg +
+			wantOutput: disclaimer + missingConfigMsg + hostChoiceMsg + "\n" + eceHostMsg +
 				formatChoiceMsg + "\n" + authChoiceMsg + "\n" + userMsg + passMsg +
 				"\n" + "\n" + fmt.Sprintf(validCredentialsMsg, "auser") + finalMsg + "\n",
 		},
@@ -310,7 +311,7 @@ func TestInitConfig(t *testing.T) {
 				FilePath: filepath.Join(testFiles, "doesnt_matter"),
 				Reader: io.MultiReader(
 					strings.NewReader("y\n"),
-					strings.NewReader("2\n"),
+					strings.NewReader("3\n"),
 					strings.NewReader("https://ahost\n"),
 					strings.NewReader("1\n"),
 					strings.NewReader("1\n"),
@@ -334,7 +335,7 @@ func TestInitConfig(t *testing.T) {
 			wantOutput: disclaimer +
 				fmt.Sprintf(settingsPathMsg, "test_files/userpassmodif.yaml") +
 				userPassConfigToModifyContents + "\n" + existingConfigMsg + hostChoiceMsg +
-				"\n" + hostMsg + formatChoiceMsg + "\n" + authChoiceMsg + "\n" + apiKeyMsg +
+				"\n" + esspHostMsg + formatChoiceMsg + "\n" + authChoiceMsg + "\n" + apiKeyMsg +
 				"\n" + "\n" + fmt.Sprintf(validCredentialsMsg, "anacleto") + finalMsg + "\n",
 		},
 		{
@@ -374,7 +375,7 @@ func TestInitConfig(t *testing.T) {
 			wantOutput: disclaimer +
 				fmt.Sprintf(settingsPathMsg, "test_files/apikeymodif.yaml") +
 				apiKeyConfigToModifyContents + "\n" + existingConfigMsg + hostChoiceMsg +
-				"\n" + hostMsg + formatChoiceMsg + "\n" + authChoiceMsg + "\n" + userMsg +
+				"\n" + eceHostMsg + formatChoiceMsg + "\n" + authChoiceMsg + "\n" + userMsg +
 				passMsg + "\n" + "\n" + fmt.Sprintf(validCredentialsMsg, "auser") + finalMsg + "\n",
 		},
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
The init command will now ask for the type of infrastructure to determine whether to ask for a custom host address or to use the default ESS public api address (https://api.elastic-cloud.com) .

The output is as follows:

When choosing ESS:
```console
Select which type of infrastructure this configuration will for:
  [1] Elastic Cloud (Elasticsearch Service).
  [2] Elastic Cloud Enterprise (ECE).

Please enter your choice: 1

What default output format...
```

When choosing ECE:
```console
Select which type of infrastructure this configuration will for:
  [1] Elastic Cloud (Elasticsearch Service).
  [2] Elastic Cloud Enterprise (ECE).

Please enter your choice: 2

Enter the URL of your ECE installation:
```

Default to https://api.elastic-cloud.com:
```console
Select which type of infrastructure this configuration will for:
  [1] Elastic Cloud (Elasticsearch Service).
  [2] Elastic Cloud Enterprise (ECE).

Please enter your choice: 5

invalid choice, defaulting to "https://api.elastic-cloud.com"
```

## Related Issues
Closes: https://github.com/elastic/ecctl/issues/159

## Motivation and Context
Improved UX now that ESS public api will be available

## How Has This Been Tested?
Manually and unit tests

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
