### PR TITLE
cmd: improve UX by defining which commands are admin specific

### DIFF
--- a/cmd/platform/allocator/command.go
+++ b/cmd/platform/allocator/command.go
@@ -18,8 +18,6 @@
 package cmdallocator
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	cmdallocatormetadata "github.com/elastic/ecctl/cmd/platform/allocator/metadata"
@@ -29,7 +27,7 @@ import (
 // Command represents the allocator command
 var Command = &cobra.Command{
 	Use:     "allocator",
-	Short:   fmt.Sprintf("Manages allocators %v", cmdutil.PlatformAdminRequired),
+	Short:   cmdutil.AdminReqDescription("Manages allocators"),
 	PreRunE: cobra.MaximumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()

--- a/cmd/platform/allocator/command.go
+++ b/cmd/platform/allocator/command.go
@@ -26,7 +26,7 @@ import (
 // Command represents the allocator command
 var Command = &cobra.Command{
 	Use:     "allocator",
-	Short:   "Manages allocators (for ECE installations only)",
+	Short:   "Manages allocators (Requires platform administration privileges)",
 	PreRunE: cobra.MaximumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()

--- a/cmd/platform/allocator/command.go
+++ b/cmd/platform/allocator/command.go
@@ -18,15 +18,18 @@
 package cmdallocator
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	cmdallocatormetadata "github.com/elastic/ecctl/cmd/platform/allocator/metadata"
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 )
 
 // Command represents the allocator command
 var Command = &cobra.Command{
 	Use:     "allocator",
-	Short:   "Manages allocators (Requires platform administration privileges)",
+	Short:   fmt.Sprintf("Manages allocators %v", cmdutil.PlatformAdminRequired),
 	PreRunE: cobra.MaximumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()

--- a/cmd/platform/constructor/command.go
+++ b/cmd/platform/constructor/command.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 	"github.com/elastic/ecctl/pkg/platform/constructor"
 )
@@ -36,7 +37,7 @@ const (
 // Command represents the constructor command
 var Command = &cobra.Command{
 	Use:     "constructor",
-	Short:   "Manages constructors (Requires platform administration privileges)",
+	Short:   fmt.Sprintf("Manages constructors %v", cmdutil.PlatformAdminRequired),
 	PreRunE: cobra.MaximumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()

--- a/cmd/platform/constructor/command.go
+++ b/cmd/platform/constructor/command.go
@@ -36,7 +36,7 @@ const (
 // Command represents the constructor command
 var Command = &cobra.Command{
 	Use:     "constructor",
-	Short:   "Manages constructors (for ECE installations only)",
+	Short:   "Manages constructors (Requires platform administration privileges)",
 	PreRunE: cobra.MaximumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()

--- a/cmd/platform/constructor/command.go
+++ b/cmd/platform/constructor/command.go
@@ -37,7 +37,7 @@ const (
 // Command represents the constructor command
 var Command = &cobra.Command{
 	Use:     "constructor",
-	Short:   fmt.Sprintf("Manages constructors %v", cmdutil.PlatformAdminRequired),
+	Short:   cmdutil.AdminReqDescription("Manages constructors"),
 	PreRunE: cobra.MaximumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()

--- a/cmd/platform/enrollment-token/command.go
+++ b/cmd/platform/enrollment-token/command.go
@@ -35,7 +35,7 @@ const (
 // Command represents the enrollment-token subcomand.
 var Command = &cobra.Command{
 	Use:     "enrollment-token",
-	Short:   "Manages tokens (for ECE installations only)",
+	Short:   "Manages tokens (Requires platform administration privileges)",
 	PreRunE: cobra.MaximumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()

--- a/cmd/platform/enrollment-token/command.go
+++ b/cmd/platform/enrollment-token/command.go
@@ -36,7 +36,7 @@ const (
 // Command represents the enrollment-token subcomand.
 var Command = &cobra.Command{
 	Use:     "enrollment-token",
-	Short:   fmt.Sprintf("Manages tokens %v", cmdutil.PlatformAdminRequired),
+	Short:   cmdutil.AdminReqDescription("Manages tokens"),
 	PreRunE: cobra.MaximumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()

--- a/cmd/platform/enrollment-token/command.go
+++ b/cmd/platform/enrollment-token/command.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 	enrollmenttoken "github.com/elastic/ecctl/pkg/platform/enrollment-token"
 )
@@ -35,7 +36,7 @@ const (
 // Command represents the enrollment-token subcomand.
 var Command = &cobra.Command{
 	Use:     "enrollment-token",
-	Short:   "Manages tokens (Requires platform administration privileges)",
+	Short:   fmt.Sprintf("Manages tokens %v", cmdutil.PlatformAdminRequired),
 	PreRunE: cobra.MaximumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()

--- a/cmd/platform/instance-configuration/command.go
+++ b/cmd/platform/instance-configuration/command.go
@@ -18,7 +18,6 @@
 package cmdinstanceconfig
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -34,7 +33,7 @@ import (
 // Command is the top instance-config subcommand.
 var Command = &cobra.Command{
 	Use:     "instance-configuration",
-	Short:   fmt.Sprintf("Manages instance configurations %v", cmdutil.PlatformAdminRequired),
+	Short:   cmdutil.AdminReqDescription("Manages instance configurations"),
 	PreRunE: cobra.MaximumNArgs(0),
 	Run:     func(cmd *cobra.Command, args []string) { cmd.Help() },
 }

--- a/cmd/platform/instance-configuration/command.go
+++ b/cmd/platform/instance-configuration/command.go
@@ -18,13 +18,15 @@
 package cmdinstanceconfig
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/elastic/cloud-sdk-go/pkg/input"
-	"github.com/elastic/cloud-sdk-go/pkg/util/cmdutil"
+	sdkcmdutil "github.com/elastic/cloud-sdk-go/pkg/util/cmdutil"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 	"github.com/elastic/ecctl/pkg/platform/instanceconfig"
 )
@@ -32,7 +34,7 @@ import (
 // Command is the top instance-config subcommand.
 var Command = &cobra.Command{
 	Use:     "instance-configuration",
-	Short:   "Manages instance configurations (Requires platform administration privileges)",
+	Short:   fmt.Sprintf("Manages instance configurations %v", cmdutil.PlatformAdminRequired),
 	PreRunE: cobra.MaximumNArgs(0),
 	Run:     func(cmd *cobra.Command, args []string) { cmd.Help() },
 }
@@ -60,7 +62,7 @@ var platformInstanceConfigurationCreateCmd = &cobra.Command{
 	PreRunE: cobra.MaximumNArgs(0),
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := cmdutil.FileOrStdin(cmd, "file"); err != nil {
+		if err := sdkcmdutil.FileOrStdin(cmd, "file"); err != nil {
 			return err
 		}
 
@@ -127,7 +129,7 @@ var platformInstanceConfigurationUpdateCmd = &cobra.Command{
 	Short:   "Overwrites an instance configuration",
 	PreRunE: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := cmdutil.FileOrStdin(cmd, "file"); err != nil {
+		if err := sdkcmdutil.FileOrStdin(cmd, "file"); err != nil {
 			return err
 		}
 

--- a/cmd/platform/instance-configuration/command.go
+++ b/cmd/platform/instance-configuration/command.go
@@ -32,7 +32,7 @@ import (
 // Command is the top instance-config subcommand.
 var Command = &cobra.Command{
 	Use:     "instance-configuration",
-	Short:   "Manages instance configurations (for ECE installations only)",
+	Short:   "Manages instance configurations (Requires platform administration privileges)",
 	PreRunE: cobra.MaximumNArgs(0),
 	Run:     func(cmd *cobra.Command, args []string) { cmd.Help() },
 }

--- a/cmd/platform/platform.go
+++ b/cmd/platform/platform.go
@@ -18,8 +18,6 @@
 package cmdplatform
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	cmdallocator "github.com/elastic/ecctl/cmd/platform/allocator"
@@ -49,7 +47,7 @@ var Command = &cobra.Command{
 
 var infoCmd = &cobra.Command{
 	Use:     "info",
-	Short:   fmt.Sprintf("Shows information about the platform %v", cmdutil.PlatformAdminRequired),
+	Short:   cmdutil.AdminReqDescription("Shows information about the platform"),
 	PreRunE: cobra.MaximumNArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		p, err := platform.GetInfo(platform.GetInfoParams{

--- a/cmd/platform/platform.go
+++ b/cmd/platform/platform.go
@@ -18,6 +18,8 @@
 package cmdplatform
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	cmdallocator "github.com/elastic/ecctl/cmd/platform/allocator"
@@ -30,6 +32,7 @@ import (
 	cmdrole "github.com/elastic/ecctl/cmd/platform/role"
 	cmdrunner "github.com/elastic/ecctl/cmd/platform/runner"
 	cmdstack "github.com/elastic/ecctl/cmd/platform/stack"
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 	"github.com/elastic/ecctl/pkg/platform"
 )
@@ -46,7 +49,7 @@ var Command = &cobra.Command{
 
 var infoCmd = &cobra.Command{
 	Use:     "info",
-	Short:   "Shows information about the platform (Requires platform administration privileges)",
+	Short:   fmt.Sprintf("Shows information about the platform %v", cmdutil.PlatformAdminRequired),
 	PreRunE: cobra.MaximumNArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		p, err := platform.GetInfo(platform.GetInfoParams{

--- a/cmd/platform/platform.go
+++ b/cmd/platform/platform.go
@@ -46,7 +46,7 @@ var Command = &cobra.Command{
 
 var infoCmd = &cobra.Command{
 	Use:     "info",
-	Short:   "Shows information about the platform (for ECE installations only)",
+	Short:   "Shows information about the platform (Requires platform administration privileges)",
 	PreRunE: cobra.MaximumNArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		p, err := platform.GetInfo(platform.GetInfoParams{

--- a/cmd/platform/proxy/command.go
+++ b/cmd/platform/proxy/command.go
@@ -18,11 +18,13 @@
 package cmdproxy
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
 
 	cmdfilteredgroup "github.com/elastic/ecctl/cmd/platform/proxy/filteredgroup"
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 	"github.com/elastic/ecctl/pkg/platform/proxy"
 )
@@ -35,7 +37,7 @@ const (
 // Command represents the proxy command
 var Command = &cobra.Command{
 	Use:     "proxy",
-	Short:   "Manages proxies (Requires platform administration privileges)",
+	Short:   fmt.Sprintf("Manages proxies %v", cmdutil.PlatformAdminRequired),
 	PreRunE: cobra.MaximumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()

--- a/cmd/platform/proxy/command.go
+++ b/cmd/platform/proxy/command.go
@@ -18,7 +18,6 @@
 package cmdproxy
 
 import (
-	"fmt"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
@@ -37,7 +36,7 @@ const (
 // Command represents the proxy command
 var Command = &cobra.Command{
 	Use:     "proxy",
-	Short:   fmt.Sprintf("Manages proxies %v", cmdutil.PlatformAdminRequired),
+	Short:   cmdutil.AdminReqDescription("Manages proxies"),
 	PreRunE: cobra.MaximumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()

--- a/cmd/platform/proxy/command.go
+++ b/cmd/platform/proxy/command.go
@@ -35,7 +35,7 @@ const (
 // Command represents the proxy command
 var Command = &cobra.Command{
 	Use:     "proxy",
-	Short:   "Manages proxies (for ECE installations only)",
+	Short:   "Manages proxies (Requires platform administration privileges)",
 	PreRunE: cobra.MaximumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()

--- a/cmd/platform/repository/command.go
+++ b/cmd/platform/repository/command.go
@@ -18,25 +18,28 @@
 package cmdrepository
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 
 	"github.com/elastic/cloud-sdk-go/pkg/input"
-	"github.com/elastic/cloud-sdk-go/pkg/util/cmdutil"
+	sdkcmdutil "github.com/elastic/cloud-sdk-go/pkg/util/cmdutil"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 	"github.com/elastic/ecctl/pkg/platform/snaprepo"
 	"github.com/elastic/ecctl/pkg/util"
 )
 
 const (
-	snapshotShortHelp       = "Manages snapshot repositories (Requires platform administration privileges)"
 	snapshotCreateShortHelp = "Creates / updates a snapshot repository"
 )
 
 var (
+	snapshotShortHelp = fmt.Sprintf("Manages snapshot repositories %v", cmdutil.PlatformAdminRequired)
+
 	snapshotLongHelp = `
 Manages snapshot repositories that are used by Elasticsearch clusters
 to perform snapshot operations.
@@ -146,7 +149,7 @@ func setSnapshot(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if err := cmdutil.FileOrStdin(cmd, "settings"); err != nil {
+	if err := sdkcmdutil.FileOrStdin(cmd, "settings"); err != nil {
 		return err
 	}
 

--- a/cmd/platform/repository/command.go
+++ b/cmd/platform/repository/command.go
@@ -18,7 +18,6 @@
 package cmdrepository
 
 import (
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -38,7 +37,7 @@ const (
 )
 
 var (
-	snapshotShortHelp = fmt.Sprintf("Manages snapshot repositories %v", cmdutil.PlatformAdminRequired)
+	snapshotShortHelp = cmdutil.AdminReqDescription("Manages snapshot repositories")
 
 	snapshotLongHelp = `
 Manages snapshot repositories that are used by Elasticsearch clusters

--- a/cmd/platform/repository/command.go
+++ b/cmd/platform/repository/command.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	snapshotShortHelp       = "Manages snapshot repositories (for ECE installations only)"
+	snapshotShortHelp       = "Manages snapshot repositories (Requires platform administration privileges)"
 	snapshotCreateShortHelp = "Creates / updates a snapshot repository"
 )
 

--- a/cmd/platform/role/command.go
+++ b/cmd/platform/role/command.go
@@ -24,7 +24,7 @@ import (
 // Command is the top level role command.
 var Command = &cobra.Command{
 	Use:     "role",
-	Short:   "Manages platform roles (for ECE installations only)",
+	Short:   "Manages platform roles (Requires platform administration privileges)",
 	PreRunE: cobra.MaximumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()

--- a/cmd/platform/runner/command.go
+++ b/cmd/platform/runner/command.go
@@ -18,8 +18,6 @@
 package cmdrunner
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	cmdutil "github.com/elastic/ecctl/cmd/util"
@@ -28,7 +26,7 @@ import (
 // Command is the top level runner command.
 var Command = &cobra.Command{
 	Use:     "runner",
-	Short:   fmt.Sprintf("Manages platform runners %v", cmdutil.PlatformAdminRequired),
+	Short:   cmdutil.AdminReqDescription("Manages platform runners"),
 	PreRunE: cobra.MaximumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()

--- a/cmd/platform/runner/command.go
+++ b/cmd/platform/runner/command.go
@@ -18,13 +18,17 @@
 package cmdrunner
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
+
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 )
 
 // Command is the top level runner command.
 var Command = &cobra.Command{
 	Use:     "runner",
-	Short:   "Manages platform runners (Requires platform administration privileges)",
+	Short:   fmt.Sprintf("Manages platform runners %v", cmdutil.PlatformAdminRequired),
 	PreRunE: cobra.MaximumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()

--- a/cmd/platform/runner/command.go
+++ b/cmd/platform/runner/command.go
@@ -24,7 +24,7 @@ import (
 // Command is the top level runner command.
 var Command = &cobra.Command{
 	Use:     "runner",
-	Short:   "Manages platform runners (for ECE installations only)",
+	Short:   "Manages platform runners (Requires platform administration privileges)",
 	PreRunE: cobra.MaximumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()

--- a/cmd/platform/stack/command.go
+++ b/cmd/platform/stack/command.go
@@ -18,11 +18,13 @@
 package cmdstack
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 	"github.com/elastic/ecctl/pkg/platform/stack"
 )
@@ -76,7 +78,7 @@ func listStackPacks(cmd *cobra.Command, args []string) error {
 
 var stackUploadCmd = &cobra.Command{
 	Use:     "upload",
-	Short:   "Uploads an Elastic StackPack (Requires platform administration privileges)",
+	Short:   fmt.Sprintf("Uploads an Elastic StackPack %v", cmdutil.PlatformAdminRequired),
 	PreRunE: cobra.MinimumNArgs(1),
 
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -95,7 +97,7 @@ var stackUploadCmd = &cobra.Command{
 
 var stackDeleteCmd = &cobra.Command{
 	Use:     "delete",
-	Short:   "Deletes an Elastic StackPack (Requires platform administration privileges)",
+	Short:   fmt.Sprintf("Deletes an Elastic StackPack %v", cmdutil.PlatformAdminRequired),
 	PreRunE: cobra.MinimumNArgs(1),
 
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/platform/stack/command.go
+++ b/cmd/platform/stack/command.go
@@ -76,7 +76,7 @@ func listStackPacks(cmd *cobra.Command, args []string) error {
 
 var stackUploadCmd = &cobra.Command{
 	Use:     "upload",
-	Short:   "Uploads an Elastic StackPack (for ECE installations only)",
+	Short:   "Uploads an Elastic StackPack (Requires platform administration privileges)",
 	PreRunE: cobra.MinimumNArgs(1),
 
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -95,7 +95,7 @@ var stackUploadCmd = &cobra.Command{
 
 var stackDeleteCmd = &cobra.Command{
 	Use:     "delete",
-	Short:   "Deletes an Elastic StackPack (for ECE installations only)",
+	Short:   "Deletes an Elastic StackPack (Requires platform administration privileges)",
 	PreRunE: cobra.MinimumNArgs(1),
 
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/platform/stack/command.go
+++ b/cmd/platform/stack/command.go
@@ -18,7 +18,6 @@
 package cmdstack
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -78,7 +77,7 @@ func listStackPacks(cmd *cobra.Command, args []string) error {
 
 var stackUploadCmd = &cobra.Command{
 	Use:     "upload",
-	Short:   fmt.Sprintf("Uploads an Elastic StackPack %v", cmdutil.PlatformAdminRequired),
+	Short:   cmdutil.AdminReqDescription("Uploads an Elastic StackPack"),
 	PreRunE: cobra.MinimumNArgs(1),
 
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -97,7 +96,7 @@ var stackUploadCmd = &cobra.Command{
 
 var stackDeleteCmd = &cobra.Command{
 	Use:     "delete",
-	Short:   fmt.Sprintf("Deletes an Elastic StackPack %v", cmdutil.PlatformAdminRequired),
+	Short:   cmdutil.AdminReqDescription("Deletes an Elastic StackPack"),
 	PreRunE: cobra.MinimumNArgs(1),
 
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/user/command.go
+++ b/cmd/user/command.go
@@ -18,8 +18,6 @@
 package cmduser
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	cmduserkey "github.com/elastic/ecctl/cmd/user/key"
@@ -29,7 +27,7 @@ import (
 // Command is the user subcommand
 var Command = &cobra.Command{
 	Use:     "user",
-	Short:   fmt.Sprintf("Manages the platform users %v", cmdutil.PlatformAdminRequired),
+	Short:   cmdutil.AdminReqDescription("Manages the platform users"),
 	PreRunE: cobra.MaximumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()

--- a/cmd/user/command.go
+++ b/cmd/user/command.go
@@ -26,7 +26,7 @@ import (
 // Command is the user subcommand
 var Command = &cobra.Command{
 	Use:     "user",
-	Short:   "Manages the platform users (for ECE installations only)",
+	Short:   "Manages the platform users (Requires platform administration privileges)",
 	PreRunE: cobra.MaximumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()

--- a/cmd/user/command.go
+++ b/cmd/user/command.go
@@ -18,15 +18,18 @@
 package cmduser
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	cmduserkey "github.com/elastic/ecctl/cmd/user/key"
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 )
 
 // Command is the user subcommand
 var Command = &cobra.Command{
 	Use:     "user",
-	Short:   "Manages the platform users (Requires platform administration privileges)",
+	Short:   fmt.Sprintf("Manages the platform users %v", cmdutil.PlatformAdminRequired),
 	PreRunE: cobra.MaximumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()

--- a/cmd/util/help_text.go
+++ b/cmd/util/help_text.go
@@ -17,5 +17,14 @@
 
 package cmdutil
 
+import (
+	"fmt"
+)
+
 // PlatformAdminRequired is an additional helper text for commands
 const PlatformAdminRequired = "(Requires platform administration privileges)"
+
+// AdminReqDescription adds a text about required admin permissions to a string
+func AdminReqDescription(desc string) string {
+	return fmt.Sprintf("%s %v", desc, PlatformAdminRequired)
+}

--- a/cmd/util/help_text.go
+++ b/cmd/util/help_text.go
@@ -15,26 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package cmdrole
+package cmdutil
 
-import (
-	"fmt"
-
-	"github.com/spf13/cobra"
-
-	cmdutil "github.com/elastic/ecctl/cmd/util"
-)
-
-// Command is the top level role command.
-var Command = &cobra.Command{
-	Use:     "role",
-	Short:   fmt.Sprintf("Manages platform roles %v", cmdutil.PlatformAdminRequired),
-	PreRunE: cobra.MaximumNArgs(0),
-	Run: func(cmd *cobra.Command, args []string) {
-		cmd.Help()
-	},
-}
-
-func init() {
-
-}
+// PlatformAdminRequired is an additional helper text for commands
+const PlatformAdminRequired = "(Requires platform administration privileges)"

--- a/cmd/util/help_text_test.go
+++ b/cmd/util/help_text_test.go
@@ -15,24 +15,37 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package cmdrole
+package cmdutil
 
 import (
-	"github.com/spf13/cobra"
-
-	cmdutil "github.com/elastic/ecctl/cmd/util"
+	"reflect"
+	"testing"
 )
 
-// Command is the top level role command.
-var Command = &cobra.Command{
-	Use:     "role",
-	Short:   cmdutil.AdminReqDescription("Manages platform roles"),
-	PreRunE: cobra.MaximumNArgs(0),
-	Run: func(cmd *cobra.Command, args []string) {
-		cmd.Help()
-	},
-}
+func TestAdminReqDescription(t *testing.T) {
+	type args struct {
+		msg string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Returns a string with the expected appended text",
+			args: args{
+				msg: "Manages resources",
+			},
+			want: "Manages resources (Requires platform administration privileges)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AdminReqDescription(tt.args.msg)
 
-func init() {
-
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("AdminReqDescription() expected = %v, but got %v", tt.want, got)
+			}
+		})
+	}
 }

--- a/docs/ecctl.md
+++ b/docs/ecctl.md
@@ -34,6 +34,6 @@ Elastic Cloud Control
 * [ecctl generate](ecctl_generate.md)	 - Generates completions and docs
 * [ecctl init](ecctl_init.md)	 - Creates an initial configuration file.
 * [ecctl platform](ecctl_platform.md)	 - Manages the platform
-* [ecctl user](ecctl_user.md)	 - Manages the platform users (for ECE installations only)
+* [ecctl user](ecctl_user.md)	 - Manages the platform users (Requires platform administration privileges)
 * [ecctl version](ecctl_version.md)	 - Shows ecctl version
 

--- a/docs/ecctl_platform.md
+++ b/docs/ecctl_platform.md
@@ -39,15 +39,15 @@ ecctl platform [flags]
 ### SEE ALSO
 
 * [ecctl](ecctl.md)	 - Elastic Cloud Control
-* [ecctl platform allocator](ecctl_platform_allocator.md)	 - Manages allocators (for ECE installations only)
-* [ecctl platform constructor](ecctl_platform_constructor.md)	 - Manages constructors (for ECE installations only)
+* [ecctl platform allocator](ecctl_platform_allocator.md)	 - Manages allocators (Requires platform administration privileges)
+* [ecctl platform constructor](ecctl_platform_constructor.md)	 - Manages constructors (Requires platform administration privileges)
 * [ecctl platform deployment-template](ecctl_platform_deployment-template.md)	 - Manages deployment templates
-* [ecctl platform enrollment-token](ecctl_platform_enrollment-token.md)	 - Manages tokens (for ECE installations only)
-* [ecctl platform info](ecctl_platform_info.md)	 - Shows information about the platform (for ECE installations only)
-* [ecctl platform instance-configuration](ecctl_platform_instance-configuration.md)	 - Manages instance configurations (for ECE installations only)
-* [ecctl platform proxy](ecctl_platform_proxy.md)	 - Manages proxies (for ECE installations only)
-* [ecctl platform repository](ecctl_platform_repository.md)	 - Manages snapshot repositories (for ECE installations only)
-* [ecctl platform role](ecctl_platform_role.md)	 - Manages platform roles (for ECE installations only)
-* [ecctl platform runner](ecctl_platform_runner.md)	 - Manages platform runners (for ECE installations only)
+* [ecctl platform enrollment-token](ecctl_platform_enrollment-token.md)	 - Manages tokens (Requires platform administration privileges)
+* [ecctl platform info](ecctl_platform_info.md)	 - Shows information about the platform (Requires platform administration privileges)
+* [ecctl platform instance-configuration](ecctl_platform_instance-configuration.md)	 - Manages instance configurations (Requires platform administration privileges)
+* [ecctl platform proxy](ecctl_platform_proxy.md)	 - Manages proxies (Requires platform administration privileges)
+* [ecctl platform repository](ecctl_platform_repository.md)	 - Manages snapshot repositories (Requires platform administration privileges)
+* [ecctl platform role](ecctl_platform_role.md)	 - Manages platform roles (Requires platform administration privileges)
+* [ecctl platform runner](ecctl_platform_runner.md)	 - Manages platform runners (Requires platform administration privileges)
 * [ecctl platform stack](ecctl_platform_stack.md)	 - Manages Elastic StackPacks
 

--- a/docs/ecctl_platform_allocator.md
+++ b/docs/ecctl_platform_allocator.md
@@ -1,10 +1,10 @@
 ## ecctl platform allocator
 
-Manages allocators (for ECE installations only)
+Manages allocators (Requires platform administration privileges)
 
 ### Synopsis
 
-Manages allocators (for ECE installations only)
+Manages allocators (Requires platform administration privileges)
 
 ```
 ecctl platform allocator [flags]

--- a/docs/ecctl_platform_allocator_list.md
+++ b/docs/ecctl_platform_allocator_list.md
@@ -63,5 +63,5 @@ ecctl platform allocator list [flags]
 
 ### SEE ALSO
 
-* [ecctl platform allocator](ecctl_platform_allocator.md)	 - Manages allocators (for ECE installations only)
+* [ecctl platform allocator](ecctl_platform_allocator.md)	 - Manages allocators (Requires platform administration privileges)
 

--- a/docs/ecctl_platform_allocator_maintenance.md
+++ b/docs/ecctl_platform_allocator_maintenance.md
@@ -39,5 +39,5 @@ ecctl platform allocator maintenance <allocator id> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform allocator](ecctl_platform_allocator.md)	 - Manages allocators (for ECE installations only)
+* [ecctl platform allocator](ecctl_platform_allocator.md)	 - Manages allocators (Requires platform administration privileges)
 

--- a/docs/ecctl_platform_allocator_metadata.md
+++ b/docs/ecctl_platform_allocator_metadata.md
@@ -38,7 +38,7 @@ ecctl platform allocator metadata [flags]
 
 ### SEE ALSO
 
-* [ecctl platform allocator](ecctl_platform_allocator.md)	 - Manages allocators (for ECE installations only)
+* [ecctl platform allocator](ecctl_platform_allocator.md)	 - Manages allocators (Requires platform administration privileges)
 * [ecctl platform allocator metadata delete](ecctl_platform_allocator_metadata_delete.md)	 - Deletes a single metadata item from a given allocators metadata
 * [ecctl platform allocator metadata set](ecctl_platform_allocator_metadata_set.md)	 - Sets or updates a single metadata item to a given allocators metadata
 * [ecctl platform allocator metadata show](ecctl_platform_allocator_metadata_show.md)	 - Shows allocator metadata

--- a/docs/ecctl_platform_allocator_search.md
+++ b/docs/ecctl_platform_allocator_search.md
@@ -40,5 +40,5 @@ ecctl platform allocator search [flags]
 
 ### SEE ALSO
 
-* [ecctl platform allocator](ecctl_platform_allocator.md)	 - Manages allocators (for ECE installations only)
+* [ecctl platform allocator](ecctl_platform_allocator.md)	 - Manages allocators (Requires platform administration privileges)
 

--- a/docs/ecctl_platform_allocator_show.md
+++ b/docs/ecctl_platform_allocator_show.md
@@ -39,5 +39,5 @@ ecctl platform allocator show <allocator id> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform allocator](ecctl_platform_allocator.md)	 - Manages allocators (for ECE installations only)
+* [ecctl platform allocator](ecctl_platform_allocator.md)	 - Manages allocators (Requires platform administration privileges)
 

--- a/docs/ecctl_platform_allocator_vacate.md
+++ b/docs/ecctl_platform_allocator_vacate.md
@@ -89,5 +89,5 @@ ecctl platform allocator vacate <source> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform allocator](ecctl_platform_allocator.md)	 - Manages allocators (for ECE installations only)
+* [ecctl platform allocator](ecctl_platform_allocator.md)	 - Manages allocators (Requires platform administration privileges)
 

--- a/docs/ecctl_platform_constructor.md
+++ b/docs/ecctl_platform_constructor.md
@@ -1,10 +1,10 @@
 ## ecctl platform constructor
 
-Manages constructors (for ECE installations only)
+Manages constructors (Requires platform administration privileges)
 
 ### Synopsis
 
-Manages constructors (for ECE installations only)
+Manages constructors (Requires platform administration privileges)
 
 ```
 ecctl platform constructor [flags]

--- a/docs/ecctl_platform_constructor_list.md
+++ b/docs/ecctl_platform_constructor_list.md
@@ -38,5 +38,5 @@ ecctl platform constructor list [flags]
 
 ### SEE ALSO
 
-* [ecctl platform constructor](ecctl_platform_constructor.md)	 - Manages constructors (for ECE installations only)
+* [ecctl platform constructor](ecctl_platform_constructor.md)	 - Manages constructors (Requires platform administration privileges)
 

--- a/docs/ecctl_platform_constructor_maintenance.md
+++ b/docs/ecctl_platform_constructor_maintenance.md
@@ -39,5 +39,5 @@ ecctl platform constructor maintenance <constructor id> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform constructor](ecctl_platform_constructor.md)	 - Manages constructors (for ECE installations only)
+* [ecctl platform constructor](ecctl_platform_constructor.md)	 - Manages constructors (Requires platform administration privileges)
 

--- a/docs/ecctl_platform_constructor_resync.md
+++ b/docs/ecctl_platform_constructor_resync.md
@@ -39,5 +39,5 @@ ecctl platform constructor resync {<constructor id> | --all} [flags]
 
 ### SEE ALSO
 
-* [ecctl platform constructor](ecctl_platform_constructor.md)	 - Manages constructors (for ECE installations only)
+* [ecctl platform constructor](ecctl_platform_constructor.md)	 - Manages constructors (Requires platform administration privileges)
 

--- a/docs/ecctl_platform_constructor_show.md
+++ b/docs/ecctl_platform_constructor_show.md
@@ -38,5 +38,5 @@ ecctl platform constructor show <constructor id> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform constructor](ecctl_platform_constructor.md)	 - Manages constructors (for ECE installations only)
+* [ecctl platform constructor](ecctl_platform_constructor.md)	 - Manages constructors (Requires platform administration privileges)
 

--- a/docs/ecctl_platform_enrollment-token.md
+++ b/docs/ecctl_platform_enrollment-token.md
@@ -1,10 +1,10 @@
 ## ecctl platform enrollment-token
 
-Manages tokens (for ECE installations only)
+Manages tokens (Requires platform administration privileges)
 
 ### Synopsis
 
-Manages tokens (for ECE installations only)
+Manages tokens (Requires platform administration privileges)
 
 ```
 ecctl platform enrollment-token [flags]

--- a/docs/ecctl_platform_enrollment-token_create.md
+++ b/docs/ecctl_platform_enrollment-token_create.md
@@ -49,5 +49,5 @@ ecctl platform enrollment-token create --role <ROLE> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform enrollment-token](ecctl_platform_enrollment-token.md)	 - Manages tokens (for ECE installations only)
+* [ecctl platform enrollment-token](ecctl_platform_enrollment-token.md)	 - Manages tokens (Requires platform administration privileges)
 

--- a/docs/ecctl_platform_enrollment-token_delete.md
+++ b/docs/ecctl_platform_enrollment-token_delete.md
@@ -38,5 +38,5 @@ ecctl platform enrollment-token delete <enrollment-token> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform enrollment-token](ecctl_platform_enrollment-token.md)	 - Manages tokens (for ECE installations only)
+* [ecctl platform enrollment-token](ecctl_platform_enrollment-token.md)	 - Manages tokens (Requires platform administration privileges)
 

--- a/docs/ecctl_platform_enrollment-token_list.md
+++ b/docs/ecctl_platform_enrollment-token_list.md
@@ -38,5 +38,5 @@ ecctl platform enrollment-token list [flags]
 
 ### SEE ALSO
 
-* [ecctl platform enrollment-token](ecctl_platform_enrollment-token.md)	 - Manages tokens (for ECE installations only)
+* [ecctl platform enrollment-token](ecctl_platform_enrollment-token.md)	 - Manages tokens (Requires platform administration privileges)
 

--- a/docs/ecctl_platform_info.md
+++ b/docs/ecctl_platform_info.md
@@ -1,10 +1,10 @@
 ## ecctl platform info
 
-Shows information about the platform (for ECE installations only)
+Shows information about the platform (Requires platform administration privileges)
 
 ### Synopsis
 
-Shows information about the platform (for ECE installations only)
+Shows information about the platform (Requires platform administration privileges)
 
 ```
 ecctl platform info [flags]

--- a/docs/ecctl_platform_instance-configuration.md
+++ b/docs/ecctl_platform_instance-configuration.md
@@ -1,10 +1,10 @@
 ## ecctl platform instance-configuration
 
-Manages instance configurations (for ECE installations only)
+Manages instance configurations (Requires platform administration privileges)
 
 ### Synopsis
 
-Manages instance configurations (for ECE installations only)
+Manages instance configurations (Requires platform administration privileges)
 
 ```
 ecctl platform instance-configuration [flags]

--- a/docs/ecctl_platform_instance-configuration_create.md
+++ b/docs/ecctl_platform_instance-configuration_create.md
@@ -40,5 +40,5 @@ ecctl platform instance-configuration create -f <config.json> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform instance-configuration](ecctl_platform_instance-configuration.md)	 - Manages instance configurations (for ECE installations only)
+* [ecctl platform instance-configuration](ecctl_platform_instance-configuration.md)	 - Manages instance configurations (Requires platform administration privileges)
 

--- a/docs/ecctl_platform_instance-configuration_delete.md
+++ b/docs/ecctl_platform_instance-configuration_delete.md
@@ -38,5 +38,5 @@ ecctl platform instance-configuration delete <config id> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform instance-configuration](ecctl_platform_instance-configuration.md)	 - Manages instance configurations (for ECE installations only)
+* [ecctl platform instance-configuration](ecctl_platform_instance-configuration.md)	 - Manages instance configurations (Requires platform administration privileges)
 

--- a/docs/ecctl_platform_instance-configuration_list.md
+++ b/docs/ecctl_platform_instance-configuration_list.md
@@ -38,5 +38,5 @@ ecctl platform instance-configuration list [flags]
 
 ### SEE ALSO
 
-* [ecctl platform instance-configuration](ecctl_platform_instance-configuration.md)	 - Manages instance configurations (for ECE installations only)
+* [ecctl platform instance-configuration](ecctl_platform_instance-configuration.md)	 - Manages instance configurations (Requires platform administration privileges)
 

--- a/docs/ecctl_platform_instance-configuration_pull.md
+++ b/docs/ecctl_platform_instance-configuration_pull.md
@@ -39,5 +39,5 @@ ecctl platform instance-configuration pull --path <path> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform instance-configuration](ecctl_platform_instance-configuration.md)	 - Manages instance configurations (for ECE installations only)
+* [ecctl platform instance-configuration](ecctl_platform_instance-configuration.md)	 - Manages instance configurations (Requires platform administration privileges)
 

--- a/docs/ecctl_platform_instance-configuration_show.md
+++ b/docs/ecctl_platform_instance-configuration_show.md
@@ -38,5 +38,5 @@ ecctl platform instance-configuration show <config id> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform instance-configuration](ecctl_platform_instance-configuration.md)	 - Manages instance configurations (for ECE installations only)
+* [ecctl platform instance-configuration](ecctl_platform_instance-configuration.md)	 - Manages instance configurations (Requires platform administration privileges)
 

--- a/docs/ecctl_platform_instance-configuration_update.md
+++ b/docs/ecctl_platform_instance-configuration_update.md
@@ -39,5 +39,5 @@ ecctl platform instance-configuration update <config id> -f <config.json> [flags
 
 ### SEE ALSO
 
-* [ecctl platform instance-configuration](ecctl_platform_instance-configuration.md)	 - Manages instance configurations (for ECE installations only)
+* [ecctl platform instance-configuration](ecctl_platform_instance-configuration.md)	 - Manages instance configurations (Requires platform administration privileges)
 

--- a/docs/ecctl_platform_proxy.md
+++ b/docs/ecctl_platform_proxy.md
@@ -1,10 +1,10 @@
 ## ecctl platform proxy
 
-Manages proxies (for ECE installations only)
+Manages proxies (Requires platform administration privileges)
 
 ### Synopsis
 
-Manages proxies (for ECE installations only)
+Manages proxies (Requires platform administration privileges)
 
 ```
 ecctl platform proxy [flags]

--- a/docs/ecctl_platform_proxy_filtered-group.md
+++ b/docs/ecctl_platform_proxy_filtered-group.md
@@ -38,7 +38,7 @@ ecctl platform proxy filtered-group [flags]
 
 ### SEE ALSO
 
-* [ecctl platform proxy](ecctl_platform_proxy.md)	 - Manages proxies (for ECE installations only)
+* [ecctl platform proxy](ecctl_platform_proxy.md)	 - Manages proxies (Requires platform administration privileges)
 * [ecctl platform proxy filtered-group create](ecctl_platform_proxy_filtered-group_create.md)	 - Creates proxies filtered group
 * [ecctl platform proxy filtered-group delete](ecctl_platform_proxy_filtered-group_delete.md)	 - Deletes proxies filtered group
 * [ecctl platform proxy filtered-group list](ecctl_platform_proxy_filtered-group_list.md)	 - Returns all proxies filtered groups in the platform

--- a/docs/ecctl_platform_proxy_list.md
+++ b/docs/ecctl_platform_proxy_list.md
@@ -38,5 +38,5 @@ ecctl platform proxy list [flags]
 
 ### SEE ALSO
 
-* [ecctl platform proxy](ecctl_platform_proxy.md)	 - Manages proxies (for ECE installations only)
+* [ecctl platform proxy](ecctl_platform_proxy.md)	 - Manages proxies (Requires platform administration privileges)
 

--- a/docs/ecctl_platform_proxy_show.md
+++ b/docs/ecctl_platform_proxy_show.md
@@ -38,5 +38,5 @@ ecctl platform proxy show <proxy id> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform proxy](ecctl_platform_proxy.md)	 - Manages proxies (for ECE installations only)
+* [ecctl platform proxy](ecctl_platform_proxy.md)	 - Manages proxies (Requires platform administration privileges)
 

--- a/docs/ecctl_platform_repository.md
+++ b/docs/ecctl_platform_repository.md
@@ -1,6 +1,6 @@
 ## ecctl platform repository
 
-Manages snapshot repositories (for ECE installations only)
+Manages snapshot repositories (Requires platform administration privileges)
 
 ### Synopsis
 

--- a/docs/ecctl_platform_repository_create.md
+++ b/docs/ecctl_platform_repository_create.md
@@ -60,5 +60,5 @@ ecctl platform repository create custom --type fs --settings settings.yml
 
 ### SEE ALSO
 
-* [ecctl platform repository](ecctl_platform_repository.md)	 - Manages snapshot repositories (for ECE installations only)
+* [ecctl platform repository](ecctl_platform_repository.md)	 - Manages snapshot repositories (Requires platform administration privileges)
 

--- a/docs/ecctl_platform_repository_delete.md
+++ b/docs/ecctl_platform_repository_delete.md
@@ -38,5 +38,5 @@ ecctl platform repository delete <repository name> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform repository](ecctl_platform_repository.md)	 - Manages snapshot repositories (for ECE installations only)
+* [ecctl platform repository](ecctl_platform_repository.md)	 - Manages snapshot repositories (Requires platform administration privileges)
 

--- a/docs/ecctl_platform_repository_list.md
+++ b/docs/ecctl_platform_repository_list.md
@@ -38,5 +38,5 @@ ecctl platform repository list [flags]
 
 ### SEE ALSO
 
-* [ecctl platform repository](ecctl_platform_repository.md)	 - Manages snapshot repositories (for ECE installations only)
+* [ecctl platform repository](ecctl_platform_repository.md)	 - Manages snapshot repositories (Requires platform administration privileges)
 

--- a/docs/ecctl_platform_repository_show.md
+++ b/docs/ecctl_platform_repository_show.md
@@ -38,5 +38,5 @@ ecctl platform repository show <repository name> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform repository](ecctl_platform_repository.md)	 - Manages snapshot repositories (for ECE installations only)
+* [ecctl platform repository](ecctl_platform_repository.md)	 - Manages snapshot repositories (Requires platform administration privileges)
 

--- a/docs/ecctl_platform_role.md
+++ b/docs/ecctl_platform_role.md
@@ -1,10 +1,10 @@
 ## ecctl platform role
 
-Manages platform roles (for ECE installations only)
+Manages platform roles (Requires platform administration privileges)
 
 ### Synopsis
 
-Manages platform roles (for ECE installations only)
+Manages platform roles (Requires platform administration privileges)
 
 ```
 ecctl platform role [flags]

--- a/docs/ecctl_platform_role_create.md
+++ b/docs/ecctl_platform_role_create.md
@@ -39,5 +39,5 @@ ecctl platform role create --file <filename.json> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform role](ecctl_platform_role.md)	 - Manages platform roles (for ECE installations only)
+* [ecctl platform role](ecctl_platform_role.md)	 - Manages platform roles (Requires platform administration privileges)
 

--- a/docs/ecctl_platform_role_delete.md
+++ b/docs/ecctl_platform_role_delete.md
@@ -38,5 +38,5 @@ ecctl platform role delete <role> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform role](ecctl_platform_role.md)	 - Manages platform roles (for ECE installations only)
+* [ecctl platform role](ecctl_platform_role.md)	 - Manages platform roles (Requires platform administration privileges)
 

--- a/docs/ecctl_platform_role_list.md
+++ b/docs/ecctl_platform_role_list.md
@@ -38,5 +38,5 @@ ecctl platform role list [flags]
 
 ### SEE ALSO
 
-* [ecctl platform role](ecctl_platform_role.md)	 - Manages platform roles (for ECE installations only)
+* [ecctl platform role](ecctl_platform_role.md)	 - Manages platform roles (Requires platform administration privileges)
 

--- a/docs/ecctl_platform_role_show.md
+++ b/docs/ecctl_platform_role_show.md
@@ -38,5 +38,5 @@ ecctl platform role show <role> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform role](ecctl_platform_role.md)	 - Manages platform roles (for ECE installations only)
+* [ecctl platform role](ecctl_platform_role.md)	 - Manages platform roles (Requires platform administration privileges)
 

--- a/docs/ecctl_platform_runner.md
+++ b/docs/ecctl_platform_runner.md
@@ -1,10 +1,10 @@
 ## ecctl platform runner
 
-Manages platform runners (for ECE installations only)
+Manages platform runners (Requires platform administration privileges)
 
 ### Synopsis
 
-Manages platform runners (for ECE installations only)
+Manages platform runners (Requires platform administration privileges)
 
 ```
 ecctl platform runner [flags]

--- a/docs/ecctl_platform_runner_list.md
+++ b/docs/ecctl_platform_runner_list.md
@@ -38,5 +38,5 @@ ecctl platform runner list [flags]
 
 ### SEE ALSO
 
-* [ecctl platform runner](ecctl_platform_runner.md)	 - Manages platform runners (for ECE installations only)
+* [ecctl platform runner](ecctl_platform_runner.md)	 - Manages platform runners (Requires platform administration privileges)
 

--- a/docs/ecctl_platform_runner_show.md
+++ b/docs/ecctl_platform_runner_show.md
@@ -38,5 +38,5 @@ ecctl platform runner show <runner id> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform runner](ecctl_platform_runner.md)	 - Manages platform runners (for ECE installations only)
+* [ecctl platform runner](ecctl_platform_runner.md)	 - Manages platform runners (Requires platform administration privileges)
 

--- a/docs/ecctl_platform_stack.md
+++ b/docs/ecctl_platform_stack.md
@@ -39,8 +39,8 @@ ecctl platform stack [flags]
 ### SEE ALSO
 
 * [ecctl platform](ecctl_platform.md)	 - Manages the platform
-* [ecctl platform stack delete](ecctl_platform_stack_delete.md)	 - Deletes an Elastic StackPack (for ECE installations only)
+* [ecctl platform stack delete](ecctl_platform_stack_delete.md)	 - Deletes an Elastic StackPack (Requires platform administration privileges)
 * [ecctl platform stack list](ecctl_platform_stack_list.md)	 - Lists Elastic StackPacks
 * [ecctl platform stack show](ecctl_platform_stack_show.md)	 - Shows information about an Elastic StackPack
-* [ecctl platform stack upload](ecctl_platform_stack_upload.md)	 - Uploads an Elastic StackPack (for ECE installations only)
+* [ecctl platform stack upload](ecctl_platform_stack_upload.md)	 - Uploads an Elastic StackPack (Requires platform administration privileges)
 

--- a/docs/ecctl_platform_stack_delete.md
+++ b/docs/ecctl_platform_stack_delete.md
@@ -1,10 +1,10 @@
 ## ecctl platform stack delete
 
-Deletes an Elastic StackPack (for ECE installations only)
+Deletes an Elastic StackPack (Requires platform administration privileges)
 
 ### Synopsis
 
-Deletes an Elastic StackPack (for ECE installations only)
+Deletes an Elastic StackPack (Requires platform administration privileges)
 
 ```
 ecctl platform stack delete [flags]

--- a/docs/ecctl_platform_stack_upload.md
+++ b/docs/ecctl_platform_stack_upload.md
@@ -1,10 +1,10 @@
 ## ecctl platform stack upload
 
-Uploads an Elastic StackPack (for ECE installations only)
+Uploads an Elastic StackPack (Requires platform administration privileges)
 
 ### Synopsis
 
-Uploads an Elastic StackPack (for ECE installations only)
+Uploads an Elastic StackPack (Requires platform administration privileges)
 
 ```
 ecctl platform stack upload [flags]

--- a/docs/ecctl_user.md
+++ b/docs/ecctl_user.md
@@ -1,10 +1,10 @@
 ## ecctl user
 
-Manages the platform users (for ECE installations only)
+Manages the platform users (Requires platform administration privileges)
 
 ### Synopsis
 
-Manages the platform users (for ECE installations only)
+Manages the platform users (Requires platform administration privileges)
 
 ```
 ecctl user [flags]

--- a/docs/ecctl_user_create.md
+++ b/docs/ecctl_user_create.md
@@ -53,5 +53,5 @@ ecctl user create --username <username> --role <role> [flags]
 
 ### SEE ALSO
 
-* [ecctl user](ecctl_user.md)	 - Manages the platform users (for ECE installations only)
+* [ecctl user](ecctl_user.md)	 - Manages the platform users (Requires platform administration privileges)
 

--- a/docs/ecctl_user_delete.md
+++ b/docs/ecctl_user_delete.md
@@ -38,5 +38,5 @@ ecctl user delete <user name> <user name>... [flags]
 
 ### SEE ALSO
 
-* [ecctl user](ecctl_user.md)	 - Manages the platform users (for ECE installations only)
+* [ecctl user](ecctl_user.md)	 - Manages the platform users (Requires platform administration privileges)
 

--- a/docs/ecctl_user_disable.md
+++ b/docs/ecctl_user_disable.md
@@ -38,5 +38,5 @@ ecctl user disable <username> [flags]
 
 ### SEE ALSO
 
-* [ecctl user](ecctl_user.md)	 - Manages the platform users (for ECE installations only)
+* [ecctl user](ecctl_user.md)	 - Manages the platform users (Requires platform administration privileges)
 

--- a/docs/ecctl_user_enable.md
+++ b/docs/ecctl_user_enable.md
@@ -38,5 +38,5 @@ ecctl user enable <username> [flags]
 
 ### SEE ALSO
 
-* [ecctl user](ecctl_user.md)	 - Manages the platform users (for ECE installations only)
+* [ecctl user](ecctl_user.md)	 - Manages the platform users (Requires platform administration privileges)
 

--- a/docs/ecctl_user_key.md
+++ b/docs/ecctl_user_key.md
@@ -38,7 +38,7 @@ ecctl user key [flags]
 
 ### SEE ALSO
 
-* [ecctl user](ecctl_user.md)	 - Manages the platform users (for ECE installations only)
+* [ecctl user](ecctl_user.md)	 - Manages the platform users (Requires platform administration privileges)
 * [ecctl user key delete](ecctl_user_key_delete.md)	 - Deletes an existing API key for the specified user
 * [ecctl user key list](ecctl_user_key_list.md)	 - Lists the API keys for the specified user, or all platform users
 * [ecctl user key show](ecctl_user_key_show.md)	 - Shows the API key details for the specified user

--- a/docs/ecctl_user_list.md
+++ b/docs/ecctl_user_list.md
@@ -38,5 +38,5 @@ ecctl user list [flags]
 
 ### SEE ALSO
 
-* [ecctl user](ecctl_user.md)	 - Manages the platform users (for ECE installations only)
+* [ecctl user](ecctl_user.md)	 - Manages the platform users (Requires platform administration privileges)
 

--- a/docs/ecctl_user_show.md
+++ b/docs/ecctl_user_show.md
@@ -39,5 +39,5 @@ ecctl user show <user name> [flags]
 
 ### SEE ALSO
 
-* [ecctl user](ecctl_user.md)	 - Manages the platform users (for ECE installations only)
+* [ecctl user](ecctl_user.md)	 - Manages the platform users (Requires platform administration privileges)
 

--- a/docs/ecctl_user_update.md
+++ b/docs/ecctl_user_update.md
@@ -58,5 +58,5 @@ ecctl user update <username> --role <role> [flags]
 
 ### SEE ALSO
 
-* [ecctl user](ecctl_user.md)	 - Manages the platform users (for ECE installations only)
+* [ecctl user](ecctl_user.md)	 - Manages the platform users (Requires platform administration privileges)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
This PR introduces the text "(Requires platform administration privileges)" to those commands that require it. This improves UX for ESS users. 

## Related Issues
Related: https://github.com/elastic/ecctl/issues/160

## Motivation and Context
After a conversation in https://github.com/elastic/ecctl/pull/169 it was concluded that the best way forward was to use the text mentioned previously.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
