### PR TITLE
allocator: Vacate now moves AppSearch instances

### DIFF
--- a/pkg/platform/allocator/vacate.go
+++ b/pkg/platform/allocator/vacate.go
@@ -174,8 +174,9 @@ func waitVacateCompletion(p *pool.Pool, hasWork bool) error {
 	return errs.ErrorOrNil()
 }
 
-// nolint better to have this grouped rather than scattered around, there's
-// already enough private functions.
+// nolint since the linter says it's too complex, it's because of the for loop
+// combination with ifs. It's better to have this grouped rather than scattered
+// around.
 func addAllocatorMovesToPool(params addAllocatorMovesToPoolParams) ([]pool.Validator, bool) {
 	var leftovers []pool.Validator
 	var vacates = make([]pool.Validator, 0)
@@ -403,6 +404,7 @@ func trackMovedCluster(params *VacateClusterParams) error {
 	})
 	if err != nil {
 		// Remove this after AppSearch is supported in the plan tracker
+		// https://github.com/elastic/cloud-sdk-go/issues/34
 		if params.Kind == "appsearch" {
 			wrapMessage := "instance is being moved but tracking is not supported, please check the vacate progress from the UI"
 			return errors.New(vacateWrapMessage(params, wrapMessage))
@@ -417,7 +419,7 @@ func trackMovedCluster(params *VacateClusterParams) error {
 // CheckVacateFailures iterates over the list of failures returning
 // a multierror with any of the failures found.
 //
-// nolint
+// nolint because of the complexity score here
 func CheckVacateFailures(failures *models.MoveClustersDetails, filter []string) error {
 	if failures == nil {
 		return nil

--- a/pkg/platform/allocator/vacate.go
+++ b/pkg/platform/allocator/vacate.go
@@ -174,6 +174,8 @@ func waitVacateCompletion(p *pool.Pool, hasWork bool) error {
 	return errs.ErrorOrNil()
 }
 
+// nolint better to have this grouped rather than scattered around, there's
+// already enough private functions.
 func addAllocatorMovesToPool(params addAllocatorMovesToPoolParams) ([]pool.Validator, bool) {
 	var leftovers []pool.Validator
 	var vacates = make([]pool.Validator, 0)
@@ -414,6 +416,8 @@ func trackMovedCluster(params *VacateClusterParams) error {
 
 // CheckVacateFailures iterates over the list of failures returning
 // a multierror with any of the failures found.
+//
+// nolint
 func CheckVacateFailures(failures *models.MoveClustersDetails, filter []string) error {
 	if failures == nil {
 		return nil

--- a/pkg/platform/allocator/vacate.go
+++ b/pkg/platform/allocator/vacate.go
@@ -219,6 +219,18 @@ func addAllocatorMovesToPool(params addAllocatorMovesToPoolParams) ([]pool.Valid
 		vacates = append(vacates, newVacateClusterParams(params, *move.ClusterID, kind))
 	}
 
+	for _, move := range params.Moves.AppsearchClusters {
+		if len(filter) > 0 && !slice.HasString(filter, *move.ClusterID) {
+			continue
+		}
+
+		var kind = "appsearch"
+		if kindFilter != "" && kind != kindFilter {
+			break
+		}
+		vacates = append(vacates, newVacateClusterParams(params, *move.ClusterID, kind))
+	}
+
 	if leftover, _ := params.Pool.Add(vacates...); len(leftover) > 0 {
 		leftovers = append(leftovers, leftover...)
 	}
@@ -353,6 +365,10 @@ func newMoveClusterParams(params *VacateClusterParams) (*platform_infrastructure
 		moveParams.SetClusterType(ec.String("apm"))
 	}
 
+	if len(req.AppsearchClusters) > 0 {
+		moveParams.SetClusterType(ec.String("appsearch"))
+	}
+
 	return moveParams, nil
 }
 
@@ -384,7 +400,13 @@ func trackMovedCluster(params *VacateClusterParams) error {
 		MaxRetries:    params.MaxPollRetries,
 	})
 	if err != nil {
-		return errors.Wrap(err, vacateWrapMessage(params, "track"))
+		// Remove this after AppSearch is supported in the plan tracker
+		if params.Kind == "appsearch" {
+			wrapMessage := "instance is being moved but tracking is not supported, please check the vacate progress from the UI"
+			return errors.New(vacateWrapMessage(params, wrapMessage))
+		}
+		wrapMessage := "plan tracker returned an error but vacate is in progress"
+		return errors.Wrap(err, vacateWrapMessage(params, wrapMessage))
 	}
 
 	return plan.Stream(channel, params.Output)
@@ -451,6 +473,24 @@ func CheckVacateFailures(failures *models.MoveClustersDetails, filter []string) 
 		}
 	}
 
+	for _, failure := range failures.AppsearchClusters {
+		if len(filter) > 0 && !slice.HasString(filter, *failure.ClusterID) {
+			continue
+		}
+
+		var ferr error
+		if len(failure.Errors) > 0 {
+			var err = failure.Errors[0]
+			ferr = fmt.Errorf("code: %s, message: %s", *err.Code, *err.Message)
+		}
+
+		if !strings.Contains(ferr.Error(), PlanPendingMessage) {
+			merr = multierror.Append(merr,
+				fmt.Errorf("cluster [%s][appsearch] failed vacating, reason: %s", *failure.ClusterID, ferr),
+			)
+		}
+	}
+
 	return merr.ErrorOrNil()
 }
 
@@ -507,6 +547,20 @@ func ComputeVacateRequest(pr *models.MoveClustersDetails, clusters, to []string,
 		c.CalculatedPlan.PlanConfiguration.PreferredAllocators = to
 		req.ApmClusters = append(req.ApmClusters,
 			&models.MoveApmClusterConfiguration{
+				ClusterIds:   []string{*c.ClusterID},
+				PlanOverride: c.CalculatedPlan,
+			},
+		)
+	}
+
+	for _, c := range pr.AppsearchClusters {
+		if len(clusters) > 0 && !slice.HasString(clusters, *c.ClusterID) {
+			continue
+		}
+
+		c.CalculatedPlan.PlanConfiguration.PreferredAllocators = to
+		req.AppsearchClusters = append(req.AppsearchClusters,
+			&models.MoveAppSearchConfiguration{
 				ClusterIds:   []string{*c.ClusterID},
 				PlanOverride: c.CalculatedPlan,
 			},

--- a/pkg/platform/allocator/vacate_full_test.go
+++ b/pkg/platform/allocator/vacate_full_test.go
@@ -142,6 +142,67 @@ func TestVacate(t *testing.T) {
 			),
 		},
 		{
+			name: "Succeeds moving a single Appsearch cluster from a single allocator (without tracking)",
+			args: args{
+				buf: sdkSync.NewBuffer(),
+				params: newVacateTestCase(t, vacateCase{
+					skipTracking: true,
+					topology: []vacateCaseClusters{
+						{
+							Allocator: "allocatorID",
+							appsearch: []vacateCaseClusterConfig{
+								{
+									ID: "3ee11eb40eda22cac0cce259625c6734",
+									steps: [][]*models.ClusterPlanStepInfo{
+										{
+											newPlanStep("step1", "success"),
+											newPlanStep("step2", "pending"),
+										},
+									},
+									plan: []*models.ClusterPlanStepInfo{
+										newPlanStep("step1", "success"),
+										newPlanStep("step2", "success"),
+									},
+								},
+							},
+						},
+					},
+				}),
+			},
+		},
+		{
+			name: "Succeeds moving a single Appsearch cluster from a single allocator, but returns error due to unsupported tracking type",
+			args: args{
+				buf: sdkSync.NewBuffer(),
+				params: newVacateTestCase(t, vacateCase{
+					topology: []vacateCaseClusters{
+						{
+							Allocator: "allocatorID",
+							appsearch: []vacateCaseClusterConfig{
+								{
+									ID: "3ee11eb40eda22cac0cce259625c6734",
+									steps: [][]*models.ClusterPlanStepInfo{
+										{
+											newPlanStep("step1", "success"),
+											newPlanStep("step2", "pending"),
+										},
+									},
+									plan: []*models.ClusterPlanStepInfo{
+										newPlanStep("step1", "success"),
+										newPlanStep("step2", "success"),
+									},
+								},
+							},
+						},
+					},
+				}),
+			},
+			err: `1 error occurred:
+	* allocator allocatorID: cluster [3ee11eb40eda22cac0cce259625c6734][appsearch]: instance is being moved but tracking is not supported, please check the vacate progress from the UI
+
+`,
+		},
+		{
 			name: "Succeeds moving a multiple clusters from a single allocator",
 			args: args{
 				buf: sdkSync.NewBuffer(),

--- a/pkg/platform/allocator/vacate_params.go
+++ b/pkg/platform/allocator/vacate_params.go
@@ -40,7 +40,7 @@ var (
 	errOutputDeviceCannotBeNil      = errors.New("output device cannot be nil")
 	errCannotOverrideAllocatorDown  = errors.New("cannot set the AllocatorDown when multiple allocators are specified")
 
-	allowedClusterKinds = []string{"apm", "elasticsearch", "kibana"}
+	allowedClusterKinds = []string{"apm", "elasticsearch", "kibana", "appsearch"}
 )
 
 // VacateParams used to vacate N allocators or clusters.

--- a/pkg/platform/allocator/vacate_responses_test.go
+++ b/pkg/platform/allocator/vacate_responses_test.go
@@ -449,7 +449,7 @@ func newVacateTestCase(t *testing.T, tc vacateCase) *VacateParams {
 		}
 
 		for ii := range topology.appsearch {
-			_, r := newAPMVacateMove(t, alloc, topology.appsearch[ii])
+			_, r := newAppsearchVacateMove(t, alloc, topology.appsearch[ii])
 			responses = append(responses, r...)
 		}
 	}
@@ -724,8 +724,8 @@ func newAppsearchVacateMove(t *testing.T, alloc string, move vacateCaseClusterCo
 		var step = move.steps[iii]
 		responses = append(responses, mock.Response{Response: http.Response{
 			StatusCode: 200,
-			Body: newApmPollerBody(t,
-				&models.ApmPlanInfo{PlanAttemptLog: step},
+			Body: newAppSearchPollerBody(t,
+				&models.AppSearchPlanInfo{PlanAttemptLog: step},
 				nil,
 			),
 		}})
@@ -737,9 +737,9 @@ func newAppsearchVacateMove(t *testing.T, alloc string, move vacateCaseClusterCo
 		util.PlanNotFound,
 		mock.Response{Response: http.Response{
 			StatusCode: 200,
-			Body: newApmPollerBody(t,
+			Body: newAppSearchPollerBody(t,
 				nil,
-				&models.ApmPlanInfo{PlanAttemptLog: move.plan},
+				&models.AppSearchPlanInfo{PlanAttemptLog: move.plan},
 			),
 		}},
 	)

--- a/pkg/platform/allocator/vacate_responses_test.go
+++ b/pkg/platform/allocator/vacate_responses_test.go
@@ -42,6 +42,35 @@ import (
 
 const planStepLogErrorMessage = "Unexpected error during step: [perform-snapshot]: [no.found.constructor.models.TimeoutException: Timeout]"
 
+type vacateCase struct {
+	topology     []vacateCaseClusters
+	skipTracking bool
+}
+
+type vacateCaseClusters struct {
+	// Allocator ID
+	Allocator string
+	// Elasticsearch clusters that will be simulated
+	elasticsearch []vacateCaseClusterConfig
+	// Kibana instances that will be simulated
+	kibana []vacateCaseClusterConfig
+	// APM clusters that will be simulated
+	apm []vacateCaseClusterConfig
+	// AppSearch clusters that will be simulated
+	appsearch []vacateCaseClusterConfig
+}
+
+type vacateCaseClusterConfig struct {
+	// ID of the cluster
+	ID string
+	// Fails the `_move` api call to actually move a cluster
+	fail bool
+	// Plan steps that are fetched by the
+	steps [][]*models.ClusterPlanStepInfo
+	// Current plan steps the move
+	plan []*models.ClusterPlanStepInfo
+}
+
 func newBody(t *testing.T, v interface{}) string {
 	b, err := json.Marshal(v)
 	if err != nil {
@@ -119,6 +148,25 @@ func newApmMove(t *testing.T, clusterID, allocator string) io.ReadCloser {
 	)))
 }
 
+func newAppsearchMove(t *testing.T, clusterID, allocator string) io.ReadCloser {
+	return ioutil.NopCloser(strings.NewReader(newBody(t,
+		models.MoveClustersCommandResponse{
+			Moves: &models.MoveClustersDetails{
+				AppsearchClusters: []*models.MoveAppSearchDetails{{
+					ClusterID: ec.String(clusterID),
+					CalculatedPlan: &models.TransientAppSearchPlanConfiguration{
+						PlanConfiguration: &models.AppSearchPlanControlConfiguration{
+							MoveAllocators: []*models.AllocatorMoveRequest{
+								{From: ec.String(allocator)},
+							},
+						},
+					},
+				}},
+			},
+		},
+	)))
+}
+
 func newKibanaMoveFailure(t *testing.T, clusterID, allocator string) io.ReadCloser {
 	return ioutil.NopCloser(strings.NewReader(newBody(t,
 		models.MoveClustersCommandResponse{
@@ -148,7 +196,7 @@ func newKibanaMoveFailure(t *testing.T, clusterID, allocator string) io.ReadClos
 	)))
 }
 
-func newMulipleMoves(t *testing.T, allocator string, es, kibana, apm []string) io.ReadCloser {
+func newMulipleMoves(t *testing.T, allocator string, es, kibana, apm, appsearch []string) io.ReadCloser {
 	var res = models.MoveClustersCommandResponse{Moves: &models.MoveClustersDetails{}}
 	for _, id := range es {
 		res.Moves.ElasticsearchClusters = append(res.Moves.ElasticsearchClusters,
@@ -193,31 +241,45 @@ func newMulipleMoves(t *testing.T, allocator string, es, kibana, apm []string) i
 			},
 		)
 	}
+
+	for _, id := range appsearch {
+		res.Moves.AppsearchClusters = append(res.Moves.AppsearchClusters,
+			&models.MoveAppSearchDetails{
+				ClusterID: ec.String(id),
+				CalculatedPlan: &models.TransientAppSearchPlanConfiguration{
+					PlanConfiguration: &models.AppSearchPlanControlConfiguration{
+						MoveAllocators: []*models.AllocatorMoveRequest{
+							{From: ec.String(allocator)},
+						},
+					},
+				},
+			},
+		)
+	}
 	return ioutil.NopCloser(strings.NewReader(newBody(t, res)))
 }
 
 func newPollerBody(t *testing.T, pending, current *models.ElasticsearchClusterPlanInfo) io.ReadCloser {
 	payload := &models.ElasticsearchClusterPlansInfo{Pending: pending, Current: current}
-	var response, err = json.MarshalIndent(payload, "", "  ")
-	if err != nil {
-		t.Fatal(err)
-	}
-	response = append(response, []byte("\n\n")...)
-	return ioutil.NopCloser(bytes.NewReader(response))
+	return newPayloadFromStruct(t, payload)
 }
 
 func newApmPollerBody(t *testing.T, pending, current *models.ApmPlanInfo) io.ReadCloser {
 	payload := &models.ApmPlansInfo{Pending: pending, Current: current}
-	var response, err = json.MarshalIndent(payload, "", "  ")
-	if err != nil {
-		t.Fatal(err)
-	}
-	response = append(response, []byte("\n\n")...)
-	return ioutil.NopCloser(bytes.NewReader(response))
+	return newPayloadFromStruct(t, payload)
+}
+
+func newAppSearchPollerBody(t *testing.T, pending, current *models.AppSearchPlanInfo) io.ReadCloser {
+	payload := &models.AppSearchPlansInfo{Pending: pending, Current: current}
+	return newPayloadFromStruct(t, payload)
 }
 
 func newKibanaPollerBody(t *testing.T, pending, current *models.KibanaClusterPlanInfo) io.ReadCloser {
 	payload := &models.KibanaClusterPlansInfo{Pending: pending, Current: current}
+	return newPayloadFromStruct(t, payload)
+}
+
+func newPayloadFromStruct(t *testing.T, payload interface{}) io.ReadCloser {
 	var response, err = json.MarshalIndent(payload, "", "  ")
 	if err != nil {
 		t.Fatal(err)
@@ -331,32 +393,6 @@ func newAllocator(t *testing.T, id, clusterID, kind string) io.ReadCloser {
 	return ioutil.NopCloser(strings.NewReader(newBody(t, res)))
 }
 
-type vacateCase struct {
-	topology []vacateCaseClusters
-}
-
-type vacateCaseClusters struct {
-	// Allocator ID
-	Allocator string
-	// Elasticsearch clusters that will be simulated
-	elasticsearch []vacateCaseClusterConfig
-	// Kibana instances that will be simulated
-	kibana []vacateCaseClusterConfig
-	// APM clusters that will be simulated
-	apm []vacateCaseClusterConfig
-}
-
-type vacateCaseClusterConfig struct {
-	// ID of the cluster
-	ID string
-	// Fails the `_move` api call to actually move a cluster
-	fail bool
-	// Plan steps that are fetched by the
-	steps [][]*models.ClusterPlanStepInfo
-	// Current plan steps the move
-	plan []*models.ClusterPlanStepInfo
-}
-
 // newVacateTestCase builds a test case from a vacateCase topology
 func newVacateTestCase(t *testing.T, tc vacateCase) *VacateParams {
 	var responses = make([]mock.Response, 0, len(tc.topology))
@@ -370,6 +406,7 @@ func newVacateTestCase(t *testing.T, tc vacateCase) *VacateParams {
 		var esmoves []string
 		var kibanaMoves []string
 		var apmMoves []string
+		var appsearchMoves []string
 
 		// Get all moves
 		for ii := range topology.elasticsearch {
@@ -381,9 +418,12 @@ func newVacateTestCase(t *testing.T, tc vacateCase) *VacateParams {
 		for ii := range topology.apm {
 			apmMoves = append(apmMoves, topology.apm[ii].ID)
 		}
+		for ii := range topology.appsearch {
+			appsearchMoves = append(appsearchMoves, topology.appsearch[ii].ID)
+		}
 
 		responses = append(responses, mock.Response{Response: http.Response{
-			Body:       newMulipleMoves(t, alloc, esmoves, kibanaMoves, apmMoves),
+			Body:       newMulipleMoves(t, alloc, esmoves, kibanaMoves, apmMoves, appsearchMoves),
 			StatusCode: 202,
 		}})
 	}
@@ -407,8 +447,14 @@ func newVacateTestCase(t *testing.T, tc vacateCase) *VacateParams {
 			_, r := newAPMVacateMove(t, alloc, topology.apm[ii])
 			responses = append(responses, r...)
 		}
+
+		for ii := range topology.appsearch {
+			_, r := newAPMVacateMove(t, alloc, topology.appsearch[ii])
+			responses = append(responses, r...)
+		}
 	}
 	return &VacateParams{
+		SkipTracking:   tc.skipTracking,
 		Output:         output.NewDevice(sdkSync.NewBuffer()),
 		Allocators:     allocators,
 		API:            api.NewMock(responses...),
@@ -424,7 +470,7 @@ func newAPMVacateMove(t *testing.T, alloc string, move vacateCaseClusterConfig) 
 		Body:       newAllocator(t, alloc, move.ID, "apm"),
 		StatusCode: 200,
 	}}, mock.Response{Response: http.Response{
-		Body:       newKibanaMove(t, move.ID, alloc),
+		Body:       newApmMove(t, move.ID, alloc),
 		StatusCode: 202,
 	}})
 
@@ -623,6 +669,77 @@ func newElasticsearchVacateMove(t *testing.T, alloc string, move vacateCaseClust
 			Body: newPollerBody(t,
 				nil,
 				&models.ElasticsearchClusterPlanInfo{PlanAttemptLog: move.plan},
+			),
+		}},
+	)
+
+	return api.NewMock(responses...), responses
+}
+
+func newAppsearchVacateMove(t *testing.T, alloc string, move vacateCaseClusterConfig) (*api.API, []mock.Response) {
+	var responses = make([]mock.Response, 0, 4)
+	responses = append(responses, mock.Response{Response: http.Response{
+		Body:       newAllocator(t, alloc, move.ID, "appsearch"),
+		StatusCode: 200,
+	}}, mock.Response{Response: http.Response{
+		Body:       newAppsearchMove(t, move.ID, alloc),
+		StatusCode: 202,
+	}})
+
+	if move.fail {
+		body := ioutil.NopCloser(strings.NewReader(newBody(t, &models.MoveClustersCommandResponse{
+			Failures: &models.MoveClustersDetails{
+				ApmClusters: []*models.MoveApmClusterDetails{{
+					ClusterID: ec.String(move.ID),
+					CalculatedPlan: &models.TransientApmPlanConfiguration{
+						PlanConfiguration: &models.ApmPlanControlConfiguration{
+							MoveAllocators: []*models.AllocatorMoveRequest{{From: ec.String(alloc)}},
+						},
+					},
+					Errors: []*models.BasicFailedReplyElement{
+						{
+							Code:    ec.String("a code"),
+							Message: ec.String("a message"),
+						},
+					},
+				}},
+			}})))
+		// Return a response with a failed move
+		responses = append(responses, mock.Response{Response: http.Response{
+			Body:       body,
+			StatusCode: 202,
+		}})
+		// No extra responses should be given back for this cluster
+		// when a move failures happens.
+		return api.NewMock(responses...), responses
+	}
+
+	responses = append(responses, mock.Response{Response: http.Response{
+		Body:       newAppsearchMove(t, move.ID, alloc),
+		StatusCode: 202,
+	}})
+
+	// Define steps
+	for iii := range move.steps {
+		var step = move.steps[iii]
+		responses = append(responses, mock.Response{Response: http.Response{
+			StatusCode: 200,
+			Body: newApmPollerBody(t,
+				&models.ApmPlanInfo{PlanAttemptLog: step},
+				nil,
+			),
+		}})
+	}
+
+	// Plan finished
+	responses = append(responses,
+		util.PlanNotFound,
+		util.PlanNotFound,
+		mock.Response{Response: http.Response{
+			StatusCode: 200,
+			Body: newApmPollerBody(t,
+				nil,
+				&models.ApmPlanInfo{PlanAttemptLog: move.plan},
 			),
 		}},
 	)

--- a/pkg/platform/allocator/vacate_test.go
+++ b/pkg/platform/allocator/vacate_test.go
@@ -605,7 +605,7 @@ func TestCheckVacateFailures(t *testing.T) {
 			}},
 		},
 		{
-			name: "Returns na apm error on Kibana vacate failure",
+			name: "Returns an error on APM vacate failure",
 			args: args{
 				failures: &models.MoveClustersDetails{
 					ApmClusters: []*models.MoveApmClusterDetails{
@@ -626,7 +626,7 @@ func TestCheckVacateFailures(t *testing.T) {
 			}},
 		},
 		{
-			name: "Returns na apm error on Kibana vacate failure",
+			name: "Returns an error on AppSearch vacate failure",
 			args: args{
 				failures: &models.MoveClustersDetails{
 					AppsearchClusters: []*models.MoveAppSearchDetails{
@@ -871,7 +871,7 @@ func TestVacateCluster(t *testing.T) {
 			},
 		},
 		{
-			name: "Succeeds with a appsearch instance with no tracking",
+			name: "Succeeds with an appsearch instance with no tracking",
 			args: args{
 				buf: new(bytes.Buffer),
 				params: &VacateClusterParams{


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail. -->
Adds support for AppSearch instances to be moved when the `ecctl
platform allocator vacate` is called, adding support for workload
filtering too.

The only difference with other workloads is that plan tracking is not
supported for AppSearch workloads due to elastic/cloud-sdk-go#34.
Instead, an error message is returned after the vacate operations have
been completed which instructrs the user to check the UI to verify that
the vacate has indeed succeeded, of course this is less than ideal, but
once elastic/cloud-sdk-go#34 is resolved, this will no longer be the
case.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Resolves #175 

## Manual Tests

```console
$ dev-cli platform allocator vacate 192.168.44.11 --kind appsearch
1 error occurred:
	* allocator 192.168.44.11: cluster [716cfd4f68694f5f8c867428c8bf5491][appsearch]: instance is being moved but tracking is not supported, please check the vacate progress from the UI


exit status 255
```

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

