### PR TITLE
cmd: improve UX by defining which commands are only available in ECE

### DIFF
--- a/cmd/util/help_text.go
+++ b/cmd/util/help_text.go
@@ -22,7 +22,7 @@ import (
 )
 
 // PlatformAdminRequired is an additional helper text for commands
-const PlatformAdminRequired = "(Requires platform administration privileges)"
+const PlatformAdminRequired = "(Available for ECE only)"
 
 // AdminReqDescription adds a text about required admin permissions to a string
 func AdminReqDescription(desc string) string {

--- a/cmd/util/help_text_test.go
+++ b/cmd/util/help_text_test.go
@@ -36,7 +36,7 @@ func TestAdminReqDescription(t *testing.T) {
 			args: args{
 				msg: "Manages resources",
 			},
-			want: "Manages resources (Requires platform administration privileges)",
+			want: "Manages resources (Available for ECE only)",
 		},
 	}
 	for _, tt := range tests {

--- a/docs/ecctl.md
+++ b/docs/ecctl.md
@@ -34,6 +34,6 @@ Elastic Cloud Control
 * [ecctl generate](ecctl_generate.md)	 - Generates completions and docs
 * [ecctl init](ecctl_init.md)	 - Creates an initial configuration file.
 * [ecctl platform](ecctl_platform.md)	 - Manages the platform
-* [ecctl user](ecctl_user.md)	 - Manages the platform users (Requires platform administration privileges)
+* [ecctl user](ecctl_user.md)	 - Manages the platform users (Available for ECE only)
 * [ecctl version](ecctl_version.md)	 - Shows ecctl version
 

--- a/docs/ecctl_platform.md
+++ b/docs/ecctl_platform.md
@@ -39,15 +39,15 @@ ecctl platform [flags]
 ### SEE ALSO
 
 * [ecctl](ecctl.md)	 - Elastic Cloud Control
-* [ecctl platform allocator](ecctl_platform_allocator.md)	 - Manages allocators (Requires platform administration privileges)
-* [ecctl platform constructor](ecctl_platform_constructor.md)	 - Manages constructors (Requires platform administration privileges)
+* [ecctl platform allocator](ecctl_platform_allocator.md)	 - Manages allocators (Available for ECE only)
+* [ecctl platform constructor](ecctl_platform_constructor.md)	 - Manages constructors (Available for ECE only)
 * [ecctl platform deployment-template](ecctl_platform_deployment-template.md)	 - Manages deployment templates
-* [ecctl platform enrollment-token](ecctl_platform_enrollment-token.md)	 - Manages tokens (Requires platform administration privileges)
-* [ecctl platform info](ecctl_platform_info.md)	 - Shows information about the platform (Requires platform administration privileges)
-* [ecctl platform instance-configuration](ecctl_platform_instance-configuration.md)	 - Manages instance configurations (Requires platform administration privileges)
-* [ecctl platform proxy](ecctl_platform_proxy.md)	 - Manages proxies (Requires platform administration privileges)
-* [ecctl platform repository](ecctl_platform_repository.md)	 - Manages snapshot repositories (Requires platform administration privileges)
-* [ecctl platform role](ecctl_platform_role.md)	 - Manages platform roles (Requires platform administration privileges)
-* [ecctl platform runner](ecctl_platform_runner.md)	 - Manages platform runners (Requires platform administration privileges)
+* [ecctl platform enrollment-token](ecctl_platform_enrollment-token.md)	 - Manages tokens (Available for ECE only)
+* [ecctl platform info](ecctl_platform_info.md)	 - Shows information about the platform (Available for ECE only)
+* [ecctl platform instance-configuration](ecctl_platform_instance-configuration.md)	 - Manages instance configurations (Available for ECE only)
+* [ecctl platform proxy](ecctl_platform_proxy.md)	 - Manages proxies (Available for ECE only)
+* [ecctl platform repository](ecctl_platform_repository.md)	 - Manages snapshot repositories (Available for ECE only)
+* [ecctl platform role](ecctl_platform_role.md)	 - Manages platform roles (Available for ECE only)
+* [ecctl platform runner](ecctl_platform_runner.md)	 - Manages platform runners (Available for ECE only)
 * [ecctl platform stack](ecctl_platform_stack.md)	 - Manages Elastic StackPacks
 

--- a/docs/ecctl_platform_allocator.md
+++ b/docs/ecctl_platform_allocator.md
@@ -1,10 +1,10 @@
 ## ecctl platform allocator
 
-Manages allocators (Requires platform administration privileges)
+Manages allocators (Available for ECE only)
 
 ### Synopsis
 
-Manages allocators (Requires platform administration privileges)
+Manages allocators (Available for ECE only)
 
 ```
 ecctl platform allocator [flags]

--- a/docs/ecctl_platform_allocator_list.md
+++ b/docs/ecctl_platform_allocator_list.md
@@ -63,5 +63,5 @@ ecctl platform allocator list [flags]
 
 ### SEE ALSO
 
-* [ecctl platform allocator](ecctl_platform_allocator.md)	 - Manages allocators (Requires platform administration privileges)
+* [ecctl platform allocator](ecctl_platform_allocator.md)	 - Manages allocators (Available for ECE only)
 

--- a/docs/ecctl_platform_allocator_maintenance.md
+++ b/docs/ecctl_platform_allocator_maintenance.md
@@ -39,5 +39,5 @@ ecctl platform allocator maintenance <allocator id> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform allocator](ecctl_platform_allocator.md)	 - Manages allocators (Requires platform administration privileges)
+* [ecctl platform allocator](ecctl_platform_allocator.md)	 - Manages allocators (Available for ECE only)
 

--- a/docs/ecctl_platform_allocator_metadata.md
+++ b/docs/ecctl_platform_allocator_metadata.md
@@ -38,7 +38,7 @@ ecctl platform allocator metadata [flags]
 
 ### SEE ALSO
 
-* [ecctl platform allocator](ecctl_platform_allocator.md)	 - Manages allocators (Requires platform administration privileges)
+* [ecctl platform allocator](ecctl_platform_allocator.md)	 - Manages allocators (Available for ECE only)
 * [ecctl platform allocator metadata delete](ecctl_platform_allocator_metadata_delete.md)	 - Deletes a single metadata item from a given allocators metadata
 * [ecctl platform allocator metadata set](ecctl_platform_allocator_metadata_set.md)	 - Sets or updates a single metadata item to a given allocators metadata
 * [ecctl platform allocator metadata show](ecctl_platform_allocator_metadata_show.md)	 - Shows allocator metadata

--- a/docs/ecctl_platform_allocator_search.md
+++ b/docs/ecctl_platform_allocator_search.md
@@ -40,5 +40,5 @@ ecctl platform allocator search [flags]
 
 ### SEE ALSO
 
-* [ecctl platform allocator](ecctl_platform_allocator.md)	 - Manages allocators (Requires platform administration privileges)
+* [ecctl platform allocator](ecctl_platform_allocator.md)	 - Manages allocators (Available for ECE only)
 

--- a/docs/ecctl_platform_allocator_show.md
+++ b/docs/ecctl_platform_allocator_show.md
@@ -39,5 +39,5 @@ ecctl platform allocator show <allocator id> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform allocator](ecctl_platform_allocator.md)	 - Manages allocators (Requires platform administration privileges)
+* [ecctl platform allocator](ecctl_platform_allocator.md)	 - Manages allocators (Available for ECE only)
 

--- a/docs/ecctl_platform_allocator_vacate.md
+++ b/docs/ecctl_platform_allocator_vacate.md
@@ -89,5 +89,5 @@ ecctl platform allocator vacate <source> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform allocator](ecctl_platform_allocator.md)	 - Manages allocators (Requires platform administration privileges)
+* [ecctl platform allocator](ecctl_platform_allocator.md)	 - Manages allocators (Available for ECE only)
 

--- a/docs/ecctl_platform_constructor.md
+++ b/docs/ecctl_platform_constructor.md
@@ -1,10 +1,10 @@
 ## ecctl platform constructor
 
-Manages constructors (Requires platform administration privileges)
+Manages constructors (Available for ECE only)
 
 ### Synopsis
 
-Manages constructors (Requires platform administration privileges)
+Manages constructors (Available for ECE only)
 
 ```
 ecctl platform constructor [flags]

--- a/docs/ecctl_platform_constructor_list.md
+++ b/docs/ecctl_platform_constructor_list.md
@@ -38,5 +38,5 @@ ecctl platform constructor list [flags]
 
 ### SEE ALSO
 
-* [ecctl platform constructor](ecctl_platform_constructor.md)	 - Manages constructors (Requires platform administration privileges)
+* [ecctl platform constructor](ecctl_platform_constructor.md)	 - Manages constructors (Available for ECE only)
 

--- a/docs/ecctl_platform_constructor_maintenance.md
+++ b/docs/ecctl_platform_constructor_maintenance.md
@@ -39,5 +39,5 @@ ecctl platform constructor maintenance <constructor id> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform constructor](ecctl_platform_constructor.md)	 - Manages constructors (Requires platform administration privileges)
+* [ecctl platform constructor](ecctl_platform_constructor.md)	 - Manages constructors (Available for ECE only)
 

--- a/docs/ecctl_platform_constructor_resync.md
+++ b/docs/ecctl_platform_constructor_resync.md
@@ -39,5 +39,5 @@ ecctl platform constructor resync {<constructor id> | --all} [flags]
 
 ### SEE ALSO
 
-* [ecctl platform constructor](ecctl_platform_constructor.md)	 - Manages constructors (Requires platform administration privileges)
+* [ecctl platform constructor](ecctl_platform_constructor.md)	 - Manages constructors (Available for ECE only)
 

--- a/docs/ecctl_platform_constructor_show.md
+++ b/docs/ecctl_platform_constructor_show.md
@@ -38,5 +38,5 @@ ecctl platform constructor show <constructor id> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform constructor](ecctl_platform_constructor.md)	 - Manages constructors (Requires platform administration privileges)
+* [ecctl platform constructor](ecctl_platform_constructor.md)	 - Manages constructors (Available for ECE only)
 

--- a/docs/ecctl_platform_enrollment-token.md
+++ b/docs/ecctl_platform_enrollment-token.md
@@ -1,10 +1,10 @@
 ## ecctl platform enrollment-token
 
-Manages tokens (Requires platform administration privileges)
+Manages tokens (Available for ECE only)
 
 ### Synopsis
 
-Manages tokens (Requires platform administration privileges)
+Manages tokens (Available for ECE only)
 
 ```
 ecctl platform enrollment-token [flags]

--- a/docs/ecctl_platform_enrollment-token_create.md
+++ b/docs/ecctl_platform_enrollment-token_create.md
@@ -49,5 +49,5 @@ ecctl platform enrollment-token create --role <ROLE> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform enrollment-token](ecctl_platform_enrollment-token.md)	 - Manages tokens (Requires platform administration privileges)
+* [ecctl platform enrollment-token](ecctl_platform_enrollment-token.md)	 - Manages tokens (Available for ECE only)
 

--- a/docs/ecctl_platform_enrollment-token_delete.md
+++ b/docs/ecctl_platform_enrollment-token_delete.md
@@ -38,5 +38,5 @@ ecctl platform enrollment-token delete <enrollment-token> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform enrollment-token](ecctl_platform_enrollment-token.md)	 - Manages tokens (Requires platform administration privileges)
+* [ecctl platform enrollment-token](ecctl_platform_enrollment-token.md)	 - Manages tokens (Available for ECE only)
 

--- a/docs/ecctl_platform_enrollment-token_list.md
+++ b/docs/ecctl_platform_enrollment-token_list.md
@@ -38,5 +38,5 @@ ecctl platform enrollment-token list [flags]
 
 ### SEE ALSO
 
-* [ecctl platform enrollment-token](ecctl_platform_enrollment-token.md)	 - Manages tokens (Requires platform administration privileges)
+* [ecctl platform enrollment-token](ecctl_platform_enrollment-token.md)	 - Manages tokens (Available for ECE only)
 

--- a/docs/ecctl_platform_info.md
+++ b/docs/ecctl_platform_info.md
@@ -1,10 +1,10 @@
 ## ecctl platform info
 
-Shows information about the platform (Requires platform administration privileges)
+Shows information about the platform (Available for ECE only)
 
 ### Synopsis
 
-Shows information about the platform (Requires platform administration privileges)
+Shows information about the platform (Available for ECE only)
 
 ```
 ecctl platform info [flags]

--- a/docs/ecctl_platform_instance-configuration.md
+++ b/docs/ecctl_platform_instance-configuration.md
@@ -1,10 +1,10 @@
 ## ecctl platform instance-configuration
 
-Manages instance configurations (Requires platform administration privileges)
+Manages instance configurations (Available for ECE only)
 
 ### Synopsis
 
-Manages instance configurations (Requires platform administration privileges)
+Manages instance configurations (Available for ECE only)
 
 ```
 ecctl platform instance-configuration [flags]

--- a/docs/ecctl_platform_instance-configuration_create.md
+++ b/docs/ecctl_platform_instance-configuration_create.md
@@ -40,5 +40,5 @@ ecctl platform instance-configuration create -f <config.json> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform instance-configuration](ecctl_platform_instance-configuration.md)	 - Manages instance configurations (Requires platform administration privileges)
+* [ecctl platform instance-configuration](ecctl_platform_instance-configuration.md)	 - Manages instance configurations (Available for ECE only)
 

--- a/docs/ecctl_platform_instance-configuration_delete.md
+++ b/docs/ecctl_platform_instance-configuration_delete.md
@@ -38,5 +38,5 @@ ecctl platform instance-configuration delete <config id> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform instance-configuration](ecctl_platform_instance-configuration.md)	 - Manages instance configurations (Requires platform administration privileges)
+* [ecctl platform instance-configuration](ecctl_platform_instance-configuration.md)	 - Manages instance configurations (Available for ECE only)
 

--- a/docs/ecctl_platform_instance-configuration_list.md
+++ b/docs/ecctl_platform_instance-configuration_list.md
@@ -38,5 +38,5 @@ ecctl platform instance-configuration list [flags]
 
 ### SEE ALSO
 
-* [ecctl platform instance-configuration](ecctl_platform_instance-configuration.md)	 - Manages instance configurations (Requires platform administration privileges)
+* [ecctl platform instance-configuration](ecctl_platform_instance-configuration.md)	 - Manages instance configurations (Available for ECE only)
 

--- a/docs/ecctl_platform_instance-configuration_pull.md
+++ b/docs/ecctl_platform_instance-configuration_pull.md
@@ -39,5 +39,5 @@ ecctl platform instance-configuration pull --path <path> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform instance-configuration](ecctl_platform_instance-configuration.md)	 - Manages instance configurations (Requires platform administration privileges)
+* [ecctl platform instance-configuration](ecctl_platform_instance-configuration.md)	 - Manages instance configurations (Available for ECE only)
 

--- a/docs/ecctl_platform_instance-configuration_show.md
+++ b/docs/ecctl_platform_instance-configuration_show.md
@@ -38,5 +38,5 @@ ecctl platform instance-configuration show <config id> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform instance-configuration](ecctl_platform_instance-configuration.md)	 - Manages instance configurations (Requires platform administration privileges)
+* [ecctl platform instance-configuration](ecctl_platform_instance-configuration.md)	 - Manages instance configurations (Available for ECE only)
 

--- a/docs/ecctl_platform_instance-configuration_update.md
+++ b/docs/ecctl_platform_instance-configuration_update.md
@@ -39,5 +39,5 @@ ecctl platform instance-configuration update <config id> -f <config.json> [flags
 
 ### SEE ALSO
 
-* [ecctl platform instance-configuration](ecctl_platform_instance-configuration.md)	 - Manages instance configurations (Requires platform administration privileges)
+* [ecctl platform instance-configuration](ecctl_platform_instance-configuration.md)	 - Manages instance configurations (Available for ECE only)
 

--- a/docs/ecctl_platform_proxy.md
+++ b/docs/ecctl_platform_proxy.md
@@ -1,10 +1,10 @@
 ## ecctl platform proxy
 
-Manages proxies (Requires platform administration privileges)
+Manages proxies (Available for ECE only)
 
 ### Synopsis
 
-Manages proxies (Requires platform administration privileges)
+Manages proxies (Available for ECE only)
 
 ```
 ecctl platform proxy [flags]

--- a/docs/ecctl_platform_proxy_filtered-group.md
+++ b/docs/ecctl_platform_proxy_filtered-group.md
@@ -38,7 +38,7 @@ ecctl platform proxy filtered-group [flags]
 
 ### SEE ALSO
 
-* [ecctl platform proxy](ecctl_platform_proxy.md)	 - Manages proxies (Requires platform administration privileges)
+* [ecctl platform proxy](ecctl_platform_proxy.md)	 - Manages proxies (Available for ECE only)
 * [ecctl platform proxy filtered-group create](ecctl_platform_proxy_filtered-group_create.md)	 - Creates proxies filtered group
 * [ecctl platform proxy filtered-group delete](ecctl_platform_proxy_filtered-group_delete.md)	 - Deletes proxies filtered group
 * [ecctl platform proxy filtered-group list](ecctl_platform_proxy_filtered-group_list.md)	 - Returns all proxies filtered groups in the platform

--- a/docs/ecctl_platform_proxy_list.md
+++ b/docs/ecctl_platform_proxy_list.md
@@ -38,5 +38,5 @@ ecctl platform proxy list [flags]
 
 ### SEE ALSO
 
-* [ecctl platform proxy](ecctl_platform_proxy.md)	 - Manages proxies (Requires platform administration privileges)
+* [ecctl platform proxy](ecctl_platform_proxy.md)	 - Manages proxies (Available for ECE only)
 

--- a/docs/ecctl_platform_proxy_show.md
+++ b/docs/ecctl_platform_proxy_show.md
@@ -38,5 +38,5 @@ ecctl platform proxy show <proxy id> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform proxy](ecctl_platform_proxy.md)	 - Manages proxies (Requires platform administration privileges)
+* [ecctl platform proxy](ecctl_platform_proxy.md)	 - Manages proxies (Available for ECE only)
 

--- a/docs/ecctl_platform_repository.md
+++ b/docs/ecctl_platform_repository.md
@@ -1,6 +1,6 @@
 ## ecctl platform repository
 
-Manages snapshot repositories (Requires platform administration privileges)
+Manages snapshot repositories (Available for ECE only)
 
 ### Synopsis
 

--- a/docs/ecctl_platform_repository_create.md
+++ b/docs/ecctl_platform_repository_create.md
@@ -60,5 +60,5 @@ ecctl platform repository create custom --type fs --settings settings.yml
 
 ### SEE ALSO
 
-* [ecctl platform repository](ecctl_platform_repository.md)	 - Manages snapshot repositories (Requires platform administration privileges)
+* [ecctl platform repository](ecctl_platform_repository.md)	 - Manages snapshot repositories (Available for ECE only)
 

--- a/docs/ecctl_platform_repository_delete.md
+++ b/docs/ecctl_platform_repository_delete.md
@@ -38,5 +38,5 @@ ecctl platform repository delete <repository name> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform repository](ecctl_platform_repository.md)	 - Manages snapshot repositories (Requires platform administration privileges)
+* [ecctl platform repository](ecctl_platform_repository.md)	 - Manages snapshot repositories (Available for ECE only)
 

--- a/docs/ecctl_platform_repository_list.md
+++ b/docs/ecctl_platform_repository_list.md
@@ -38,5 +38,5 @@ ecctl platform repository list [flags]
 
 ### SEE ALSO
 
-* [ecctl platform repository](ecctl_platform_repository.md)	 - Manages snapshot repositories (Requires platform administration privileges)
+* [ecctl platform repository](ecctl_platform_repository.md)	 - Manages snapshot repositories (Available for ECE only)
 

--- a/docs/ecctl_platform_repository_show.md
+++ b/docs/ecctl_platform_repository_show.md
@@ -38,5 +38,5 @@ ecctl platform repository show <repository name> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform repository](ecctl_platform_repository.md)	 - Manages snapshot repositories (Requires platform administration privileges)
+* [ecctl platform repository](ecctl_platform_repository.md)	 - Manages snapshot repositories (Available for ECE only)
 

--- a/docs/ecctl_platform_role.md
+++ b/docs/ecctl_platform_role.md
@@ -1,10 +1,10 @@
 ## ecctl platform role
 
-Manages platform roles (Requires platform administration privileges)
+Manages platform roles (Available for ECE only)
 
 ### Synopsis
 
-Manages platform roles (Requires platform administration privileges)
+Manages platform roles (Available for ECE only)
 
 ```
 ecctl platform role [flags]

--- a/docs/ecctl_platform_role_create.md
+++ b/docs/ecctl_platform_role_create.md
@@ -39,5 +39,5 @@ ecctl platform role create --file <filename.json> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform role](ecctl_platform_role.md)	 - Manages platform roles (Requires platform administration privileges)
+* [ecctl platform role](ecctl_platform_role.md)	 - Manages platform roles (Available for ECE only)
 

--- a/docs/ecctl_platform_role_delete.md
+++ b/docs/ecctl_platform_role_delete.md
@@ -38,5 +38,5 @@ ecctl platform role delete <role> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform role](ecctl_platform_role.md)	 - Manages platform roles (Requires platform administration privileges)
+* [ecctl platform role](ecctl_platform_role.md)	 - Manages platform roles (Available for ECE only)
 

--- a/docs/ecctl_platform_role_list.md
+++ b/docs/ecctl_platform_role_list.md
@@ -38,5 +38,5 @@ ecctl platform role list [flags]
 
 ### SEE ALSO
 
-* [ecctl platform role](ecctl_platform_role.md)	 - Manages platform roles (Requires platform administration privileges)
+* [ecctl platform role](ecctl_platform_role.md)	 - Manages platform roles (Available for ECE only)
 

--- a/docs/ecctl_platform_role_show.md
+++ b/docs/ecctl_platform_role_show.md
@@ -38,5 +38,5 @@ ecctl platform role show <role> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform role](ecctl_platform_role.md)	 - Manages platform roles (Requires platform administration privileges)
+* [ecctl platform role](ecctl_platform_role.md)	 - Manages platform roles (Available for ECE only)
 

--- a/docs/ecctl_platform_runner.md
+++ b/docs/ecctl_platform_runner.md
@@ -1,10 +1,10 @@
 ## ecctl platform runner
 
-Manages platform runners (Requires platform administration privileges)
+Manages platform runners (Available for ECE only)
 
 ### Synopsis
 
-Manages platform runners (Requires platform administration privileges)
+Manages platform runners (Available for ECE only)
 
 ```
 ecctl platform runner [flags]

--- a/docs/ecctl_platform_runner_list.md
+++ b/docs/ecctl_platform_runner_list.md
@@ -38,5 +38,5 @@ ecctl platform runner list [flags]
 
 ### SEE ALSO
 
-* [ecctl platform runner](ecctl_platform_runner.md)	 - Manages platform runners (Requires platform administration privileges)
+* [ecctl platform runner](ecctl_platform_runner.md)	 - Manages platform runners (Available for ECE only)
 

--- a/docs/ecctl_platform_runner_show.md
+++ b/docs/ecctl_platform_runner_show.md
@@ -38,5 +38,5 @@ ecctl platform runner show <runner id> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform runner](ecctl_platform_runner.md)	 - Manages platform runners (Requires platform administration privileges)
+* [ecctl platform runner](ecctl_platform_runner.md)	 - Manages platform runners (Available for ECE only)
 

--- a/docs/ecctl_platform_stack.md
+++ b/docs/ecctl_platform_stack.md
@@ -39,8 +39,8 @@ ecctl platform stack [flags]
 ### SEE ALSO
 
 * [ecctl platform](ecctl_platform.md)	 - Manages the platform
-* [ecctl platform stack delete](ecctl_platform_stack_delete.md)	 - Deletes an Elastic StackPack (Requires platform administration privileges)
+* [ecctl platform stack delete](ecctl_platform_stack_delete.md)	 - Deletes an Elastic StackPack (Available for ECE only)
 * [ecctl platform stack list](ecctl_platform_stack_list.md)	 - Lists Elastic StackPacks
 * [ecctl platform stack show](ecctl_platform_stack_show.md)	 - Shows information about an Elastic StackPack
-* [ecctl platform stack upload](ecctl_platform_stack_upload.md)	 - Uploads an Elastic StackPack (Requires platform administration privileges)
+* [ecctl platform stack upload](ecctl_platform_stack_upload.md)	 - Uploads an Elastic StackPack (Available for ECE only)
 

--- a/docs/ecctl_platform_stack_delete.md
+++ b/docs/ecctl_platform_stack_delete.md
@@ -1,10 +1,10 @@
 ## ecctl platform stack delete
 
-Deletes an Elastic StackPack (Requires platform administration privileges)
+Deletes an Elastic StackPack (Available for ECE only)
 
 ### Synopsis
 
-Deletes an Elastic StackPack (Requires platform administration privileges)
+Deletes an Elastic StackPack (Available for ECE only)
 
 ```
 ecctl platform stack delete [flags]

--- a/docs/ecctl_platform_stack_upload.md
+++ b/docs/ecctl_platform_stack_upload.md
@@ -1,10 +1,10 @@
 ## ecctl platform stack upload
 
-Uploads an Elastic StackPack (Requires platform administration privileges)
+Uploads an Elastic StackPack (Available for ECE only)
 
 ### Synopsis
 
-Uploads an Elastic StackPack (Requires platform administration privileges)
+Uploads an Elastic StackPack (Available for ECE only)
 
 ```
 ecctl platform stack upload [flags]

--- a/docs/ecctl_user.md
+++ b/docs/ecctl_user.md
@@ -1,10 +1,10 @@
 ## ecctl user
 
-Manages the platform users (Requires platform administration privileges)
+Manages the platform users (Available for ECE only)
 
 ### Synopsis
 
-Manages the platform users (Requires platform administration privileges)
+Manages the platform users (Available for ECE only)
 
 ```
 ecctl user [flags]

--- a/docs/ecctl_user_create.md
+++ b/docs/ecctl_user_create.md
@@ -53,5 +53,5 @@ ecctl user create --username <username> --role <role> [flags]
 
 ### SEE ALSO
 
-* [ecctl user](ecctl_user.md)	 - Manages the platform users (Requires platform administration privileges)
+* [ecctl user](ecctl_user.md)	 - Manages the platform users (Available for ECE only)
 

--- a/docs/ecctl_user_delete.md
+++ b/docs/ecctl_user_delete.md
@@ -38,5 +38,5 @@ ecctl user delete <user name> <user name>... [flags]
 
 ### SEE ALSO
 
-* [ecctl user](ecctl_user.md)	 - Manages the platform users (Requires platform administration privileges)
+* [ecctl user](ecctl_user.md)	 - Manages the platform users (Available for ECE only)
 

--- a/docs/ecctl_user_disable.md
+++ b/docs/ecctl_user_disable.md
@@ -38,5 +38,5 @@ ecctl user disable <username> [flags]
 
 ### SEE ALSO
 
-* [ecctl user](ecctl_user.md)	 - Manages the platform users (Requires platform administration privileges)
+* [ecctl user](ecctl_user.md)	 - Manages the platform users (Available for ECE only)
 

--- a/docs/ecctl_user_enable.md
+++ b/docs/ecctl_user_enable.md
@@ -38,5 +38,5 @@ ecctl user enable <username> [flags]
 
 ### SEE ALSO
 
-* [ecctl user](ecctl_user.md)	 - Manages the platform users (Requires platform administration privileges)
+* [ecctl user](ecctl_user.md)	 - Manages the platform users (Available for ECE only)
 

--- a/docs/ecctl_user_key.md
+++ b/docs/ecctl_user_key.md
@@ -38,7 +38,7 @@ ecctl user key [flags]
 
 ### SEE ALSO
 
-* [ecctl user](ecctl_user.md)	 - Manages the platform users (Requires platform administration privileges)
+* [ecctl user](ecctl_user.md)	 - Manages the platform users (Available for ECE only)
 * [ecctl user key delete](ecctl_user_key_delete.md)	 - Deletes an existing API key for the specified user
 * [ecctl user key list](ecctl_user_key_list.md)	 - Lists the API keys for the specified user, or all platform users
 * [ecctl user key show](ecctl_user_key_show.md)	 - Shows the API key details for the specified user

--- a/docs/ecctl_user_list.md
+++ b/docs/ecctl_user_list.md
@@ -38,5 +38,5 @@ ecctl user list [flags]
 
 ### SEE ALSO
 
-* [ecctl user](ecctl_user.md)	 - Manages the platform users (Requires platform administration privileges)
+* [ecctl user](ecctl_user.md)	 - Manages the platform users (Available for ECE only)
 

--- a/docs/ecctl_user_show.md
+++ b/docs/ecctl_user_show.md
@@ -39,5 +39,5 @@ ecctl user show <user name> [flags]
 
 ### SEE ALSO
 
-* [ecctl user](ecctl_user.md)	 - Manages the platform users (Requires platform administration privileges)
+* [ecctl user](ecctl_user.md)	 - Manages the platform users (Available for ECE only)
 

--- a/docs/ecctl_user_update.md
+++ b/docs/ecctl_user_update.md
@@ -58,5 +58,5 @@ ecctl user update <username> --role <role> [flags]
 
 ### SEE ALSO
 
-* [ecctl user](ecctl_user.md)	 - Manages the platform users (Requires platform administration privileges)
+* [ecctl user](ecctl_user.md)	 - Manages the platform users (Available for ECE only)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Follow up from this comment https://github.com/elastic/ecctl/pull/174#issuecomment-585719777 where it has been agreed that `(Available for ECE only)` is a more appropriate text for the commands that require it.

## Related Issues
Related: #160

## How Has This Been Tested?
unit tests and running `make docs`

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
