### PR TITLE
cmd: mark --type flag as required for plan cancel

### DIFF
--- a/cmd/deployment/plan/cancel.go
+++ b/cmd/deployment/plan/cancel.go
@@ -53,7 +53,7 @@ var cancelPlan = &cobra.Command{
 
 func init() {
 	Command.AddCommand(cancelPlan)
-	cmdutil.AddTypeFlag(cancelPlan, "Optional", true)
+	cmdutil.AddTypeFlag(cancelPlan, "Required", true)
 	cancelPlan.MarkFlagRequired("type")
-	cancelPlan.Flags().String("ref-id", "", "Optional deployment type RefId, if not set, the RefId will be auto-discovered")
+	cancelPlan.Flags().String("ref-id", "", "Optional deployment RefId, if not set, the RefId will be auto-discovered")
 }

--- a/cmd/deployment/plan/cancel.go
+++ b/cmd/deployment/plan/cancel.go
@@ -29,7 +29,7 @@ import (
 
 // cancelPlan is the deployment subcommand
 var cancelPlan = &cobra.Command{
-	Use:     "cancel <deployment id> --type <type> --ref-id <ref-id>",
+	Use:     "cancel <deployment id> --type <type> [--ref-id <ref-id>]",
 	Short:   "Cancels a resource's pending plan",
 	PreRunE: sdkcmdutil.MinimumNArgsAndUUID(1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/docs/ecctl_deployment_plan_cancel.md
+++ b/docs/ecctl_deployment_plan_cancel.md
@@ -14,8 +14,8 @@ ecctl deployment plan cancel <deployment id> --type <type> --ref-id <ref-id> [fl
 
 ```
   -h, --help            help for cancel
-      --ref-id string   Optional deployment type RefId, if not set, the RefId will be auto-discovered
-      --type string     Optional deployment resource type (apm, appsearch, kibana, elasticsearch)
+      --ref-id string   Optional deployment RefId, if not set, the RefId will be auto-discovered
+      --type string     Required deployment resource type (apm, appsearch, kibana, elasticsearch)
 ```
 
 ### Options inherited from parent commands

--- a/docs/ecctl_deployment_plan_cancel.md
+++ b/docs/ecctl_deployment_plan_cancel.md
@@ -7,7 +7,7 @@ Cancels a resource's pending plan
 Cancels a resource's pending plan
 
 ```
-ecctl deployment plan cancel <deployment id> --type <type> --ref-id <ref-id> [flags]
+ecctl deployment plan cancel <deployment id> --type <type> [--ref-id <ref-id>] [flags]
 ```
 
 ### Options


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Fixes an issue where a required flag had an "Optional" prefix in the description. I've also taken the opportunity to update the command to use the [recommended CLI syntax](https://developers.google.com/style/code-syntax)

## Related Issues
n/a

## Motivation and Context
Our commands shouldn't lie about their flags :)

## How Has This Been Tested?
By running `ecctl deployment plan cancel --help` and `make docs`

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
