### PR TITLE
cmd: new appsearch create --id <deployment id>

### DIFF
--- a/cmd/deployment/appsearch/command.go
+++ b/cmd/deployment/appsearch/command.go
@@ -30,9 +30,3 @@ var Command = &cobra.Command{
 		cmd.Help()
 	},
 }
-
-func init() {
-	Command.AddCommand(
-		showAppSearchCmd,
-	)
-}

--- a/cmd/deployment/appsearch/create.go
+++ b/cmd/deployment/appsearch/create.go
@@ -104,12 +104,25 @@ var createAppSearchCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return ecctl.Get().Formatter.Format("", res)
+
+		var track, _ = cmd.Flags().GetBool("track")
+		return cmdutil.Track(cmdutil.TrackParams{
+			TrackResourcesParams: depresource.TrackResourcesParams{
+				API:          ecctl.Get().API,
+				Resources:    res.Resources,
+				Orphaned:     res.ShutdownResources,
+				OutputDevice: ecctl.Get().Config.OutputDevice,
+			},
+			Formatter: ecctl.Get().Formatter,
+			Track:     track,
+			Response:  res,
+		})
 	},
 }
 
 func init() {
 	Command.AddCommand(createAppSearchCmd)
+	createAppSearchCmd.Flags().BoolP("track", "t", false, cmdutil.TrackFlagMessage)
 	createAppSearchCmd.Flags().StringP("file", "f", "", "AppSearchPayload file definition. See help for more information")
 	createAppSearchCmd.Flags().String("deployment-template", "", "Optional deployment template ID, automatically obtained from the current deployment")
 	createAppSearchCmd.Flags().String("version", "", "Optional version to use. If not specified, it will default to the deployment's stack version")

--- a/cmd/deployment/appsearch/create.go
+++ b/cmd/deployment/appsearch/create.go
@@ -104,25 +104,12 @@ var createAppSearchCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-
-		var track, _ = cmd.Flags().GetBool("track")
-		return cmdutil.Track(cmdutil.TrackParams{
-			TrackResourcesParams: depresource.TrackResourcesParams{
-				API:          ecctl.Get().API,
-				Resources:    res.Resources,
-				Orphaned:     res.ShutdownResources,
-				OutputDevice: ecctl.Get().Config.OutputDevice,
-			},
-			Formatter: ecctl.Get().Formatter,
-			Track:     track,
-			Response:  res,
-		})
+		return ecctl.Get().Formatter.Format("", res)
 	},
 }
 
 func init() {
 	Command.AddCommand(createAppSearchCmd)
-	createAppSearchCmd.Flags().BoolP("track", "t", false, cmdutil.TrackFlagMessage)
 	createAppSearchCmd.Flags().StringP("file", "f", "", "AppSearchPayload file definition. See help for more information")
 	createAppSearchCmd.Flags().String("deployment-template", "", "Optional deployment template ID, automatically obtained from the current deployment")
 	createAppSearchCmd.Flags().String("version", "", "Optional version to use. If not specified, it will default to the deployment's stack version")

--- a/cmd/deployment/appsearch/create.go
+++ b/cmd/deployment/appsearch/create.go
@@ -1,0 +1,137 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmdappsearch
+
+import (
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	sdkcmdutil "github.com/elastic/cloud-sdk-go/pkg/util/cmdutil"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+	"github.com/spf13/cobra"
+
+	cmdutil "github.com/elastic/ecctl/cmd/util"
+	"github.com/elastic/ecctl/pkg/deployment"
+	"github.com/elastic/ecctl/pkg/deployment/depresource"
+	"github.com/elastic/ecctl/pkg/ecctl"
+)
+
+var createAppSearchCmd = &cobra.Command{
+	Use:     "create --id <deployment-id>",
+	Short:   "Creates an AppSearch instance",
+	Long:    appsearchCreateLong,
+	Example: appsearchCreateExample,
+	PreRunE: cobra.MaximumNArgs(0),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var generatePayload, _ = cmd.Flags().GetBool("generate-payload")
+		var zoneCount, _ = cmd.Flags().GetInt32("zones")
+		var size, _ = cmd.Flags().GetInt32("size")
+		var name, _ = cmd.Flags().GetString("name")
+		var refID, _ = cmd.Flags().GetString("ref-id")
+		var esRefID, _ = cmd.Flags().GetString("elasticsearch-ref-id")
+		var id, _ = cmd.Flags().GetString("id")
+		var version, _ = cmd.Flags().GetString("version")
+		var dt, _ = cmd.Flags().GetString("deployment-template")
+		var region = ecctl.Get().Config.Region
+		if ecctl.Get().Config.Region == "" {
+			region = cmdutil.DefaultECERegion
+		}
+
+		var payload *models.AppSearchPayload
+		if err := sdkcmdutil.FileOrStdin(cmd, "file"); err == nil {
+			err := sdkcmdutil.DecodeDefinition(cmd, "file", &payload)
+			if err != nil && err != sdkcmdutil.ErrNodefinitionLoaded {
+				return err
+			}
+		}
+
+		if payload == nil {
+			p, err := depresource.NewAppSearch(depresource.NewStateless{
+				DeploymentID:       id,
+				ElasticsearchRefID: esRefID,
+				API:                ecctl.Get().API,
+				RefID:              refID,
+				Version:            version,
+				Region:             region,
+				TemplateID:         dt,
+				Size:               size,
+				ZoneCount:          zoneCount,
+			})
+			if err != nil {
+				return err
+			}
+			payload = p
+		}
+
+		if payload.Region == nil || *payload.Region == "" {
+			payload.Region = ec.String(region)
+		}
+
+		// Returns the AppSearchPayload skipping the creation of the resources.
+		if generatePayload {
+			return ecctl.Get().Formatter.Format("", payload)
+		}
+
+		var updateParams = deployment.UpdateParams{
+			DeploymentID: id,
+			API:          ecctl.Get().API,
+			Request: &models.DeploymentUpdateRequest{
+				// Setting PruneOrphans to false since we don't want any side
+				// effects on the deployment when only a partial deployment
+				// definition is sent.
+				PruneOrphans: ec.Bool(false),
+				Name:         name,
+				Resources: &models.DeploymentUpdateResources{
+					Appsearch: []*models.AppSearchPayload{payload},
+				},
+			},
+		}
+
+		res, err := deployment.Update(updateParams)
+		if err != nil {
+			return err
+		}
+
+		var track, _ = cmd.Flags().GetBool("track")
+		return cmdutil.Track(cmdutil.TrackParams{
+			TrackResourcesParams: depresource.TrackResourcesParams{
+				API:          ecctl.Get().API,
+				Resources:    res.Resources,
+				Orphaned:     res.ShutdownResources,
+				OutputDevice: ecctl.Get().Config.OutputDevice,
+			},
+			Formatter: ecctl.Get().Formatter,
+			Track:     track,
+			Response:  res,
+		})
+	},
+}
+
+func init() {
+	Command.AddCommand(createAppSearchCmd)
+	createAppSearchCmd.Flags().BoolP("track", "t", false, cmdutil.TrackFlagMessage)
+	createAppSearchCmd.Flags().StringP("file", "f", "", "AppSearchPayload file definition. See help for more information")
+	createAppSearchCmd.Flags().String("deployment-template", "", "Optional deployment template ID, automatically obtained from the current deployment")
+	createAppSearchCmd.Flags().String("version", "", "Optional version to use. If not specified, it will default to the deployment's stack version")
+	createAppSearchCmd.Flags().String("ref-id", "main-appsearch", "RefId for the AppSearch deployment")
+	createAppSearchCmd.Flags().String("id", "", "Deployment ID where to create the AppSearch deployment")
+	createAppSearchCmd.MarkFlagRequired("id")
+	createAppSearchCmd.Flags().String("elasticsearch-ref-id", "", "Optional Elasticsearch ref ID where the AppSearch deployment will connect to")
+	createAppSearchCmd.Flags().String("name", "", "Optional name to set for the AppSearch deployment (Overrides name if present)")
+	createAppSearchCmd.Flags().Int32("zones", 1, "Number of zones the deployment will span")
+	createAppSearchCmd.Flags().Int32("size", 2048, "Memory (RAM) in MB that each of the deployment nodes will have")
+	createAppSearchCmd.Flags().Bool("generate-payload", false, "Returns the AppSearchPayload without actually creating the deployment resources")
+}

--- a/cmd/deployment/appsearch/create_help.go
+++ b/cmd/deployment/appsearch/create_help.go
@@ -1,0 +1,77 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmdappsearch
+
+const (
+	appsearchCreateLong = `Creates an AppSearch deployment, limitting the creation scope to AppSearch resources.
+There are a few ways to create an AppSearch deployment, sane default values are provided, making
+the command work out of the box even when no parameters are set. When version is not specified,
+the matching elasticsearch deployment version will be used. These are the available options:
+
+  * Simplified flags: --zones <zone count> --size <node memory in MB>
+  * File definition: --file=<file path> (shorthand: -f). The definition can be found in:
+    https://www.elastic.co/guide/en/cloud-enterprise/current/definitions.html#AppSearchPayload
+
+As an option, "--generate-payload" can be used in order to obtain the generated AppSearchPayload
+that would be sent as a request, save it, update or extend the topology and create an AppSearch
+deployment using the saved payload with the "--file" flag.`
+
+	appsearchCreateExample = `## Create a single AppSearch server. The command will exit after the API response has been returned, 
+## without waiting until the deployment resources have been created. To make the command wait until
+the resources have been created use the "--track" flag.
+$ ecctl deployment appsearch create --id=a57f8b7ce54c4afb90ce3755d1e94000 --track
+{
+  "id": "a57f8b7ce54c4afb90ce3755d1e94000",
+  "name": "a57f8b7ce54c4afb90ce3755d1e94000",
+  "resources": [
+    {
+      "elasticsearch_cluster_ref_id": "elasticsearch",
+      "id": "53d104a432a648f68ec76d52ecb521d5",
+      "kind": "appsearch",
+      "ref_id": "main-appsearch",
+      "region": "ece-region"
+    },
+    {
+      "elasticsearch_cluster_ref_id": "elasticsearch",
+      "id": "39e4a65fc2b14651b666aaff18a13b8f",
+      "kind": "kibana",
+      "ref_id": "main-kibana",
+      "region": "ece-region"
+    },
+    {
+      "cloud_id": "a57f8b7ce54c4afb90ce3755d1e94000:MTkyLjE2OC40NC4xMC5pcC5lcy5pbzo5MjQzJGQzODIwOWU4ZTYwYzRlYTliY2UzMDc1OThhMTljNGI3JDM5ZTRhNjVmYzJiMTQ2NTFiNjY2YWFmZjE4YTEzYjhm",
+      "id": "d38209e8e60c4ea9bce307598a19c4b7",
+      "kind": "elasticsearch",
+      "ref_id": "main-elasticsearch",
+      "region": "ece-region"
+    }
+  ]
+}
+Cluster [53d104a432a648f68ec76d52ecb521d5][AppSearch]: running step "wait-until-running" (Plan duration 1.38505959s)...
+Cluster [39e4a65fc2b14651b666aaff18a13b8f][Kibana]: finished running all the plan steps (Total plan duration: 1.73493053s)
+Cluster [d38209e8e60c4ea9bce307598a19c4b7][Elasticsearch]: finished running all the plan steps (Total plan duration: 1.849794895s)
+Cluster [53d104a432a648f68ec76d52ecb521d5][AppSearch]: running step "set-maintenance" (Plan duration 11.162178491s)...
+Cluster [53d104a432a648f68ec76d52ecb521d5][AppSearch]: finished running all the plan steps (Total plan duration: 16.677195277s)
+
+## Save the definition to a file for later use.
+$ ecctl deployment appsearch create --generate-payload --id a57f8b7ce54c4afb90ce3755d1e94000 --zones 2 --size 2048 > appsearch_create_example.json
+
+## Create the deployment piping through the file contents tracking the creation progress
+$ cat appsearch_create_example.json | dev-cli deployment appsearch create --track --id a57f8b7ce54c4afb90ce3755d1e94000
+[...]`
+)

--- a/cmd/deployment/appsearch/create_help.go
+++ b/cmd/deployment/appsearch/create_help.go
@@ -32,9 +32,8 @@ that would be sent as a request, save it, update or extend the topology and crea
 deployment using the saved payload with the "--file" flag.`
 
 	appsearchCreateExample = `## Create a single AppSearch server. The command will exit after the API response has been returned, 
-## without waiting until the deployment resources have been created. To make the command wait until
-the resources have been created use the "--track" flag.
-$ ecctl deployment appsearch create --id=a57f8b7ce54c4afb90ce3755d1e94000 --track
+## without waiting until the deployment resources have been created.
+$ ecctl deployment appsearch create --id=a57f8b7ce54c4afb90ce3755d1e94000
 {
   "id": "a57f8b7ce54c4afb90ce3755d1e94000",
   "name": "a57f8b7ce54c4afb90ce3755d1e94000",
@@ -62,16 +61,11 @@ $ ecctl deployment appsearch create --id=a57f8b7ce54c4afb90ce3755d1e94000 --trac
     }
   ]
 }
-Cluster [53d104a432a648f68ec76d52ecb521d5][AppSearch]: running step "wait-until-running" (Plan duration 1.38505959s)...
-Cluster [39e4a65fc2b14651b666aaff18a13b8f][Kibana]: finished running all the plan steps (Total plan duration: 1.73493053s)
-Cluster [d38209e8e60c4ea9bce307598a19c4b7][Elasticsearch]: finished running all the plan steps (Total plan duration: 1.849794895s)
-Cluster [53d104a432a648f68ec76d52ecb521d5][AppSearch]: running step "set-maintenance" (Plan duration 11.162178491s)...
-Cluster [53d104a432a648f68ec76d52ecb521d5][AppSearch]: finished running all the plan steps (Total plan duration: 16.677195277s)
 
 ## Save the definition to a file for later use.
 $ ecctl deployment appsearch create --generate-payload --id a57f8b7ce54c4afb90ce3755d1e94000 --zones 2 --size 2048 > appsearch_create_example.json
 
-## Create the deployment piping through the file contents tracking the creation progress
-$ cat appsearch_create_example.json | dev-cli deployment appsearch create --track --id a57f8b7ce54c4afb90ce3755d1e94000
+## Create the deployment piping through the file contents.
+$ cat appsearch_create_example.json | dev-cli deployment appsearch create --id a57f8b7ce54c4afb90ce3755d1e94000
 [...]`
 )

--- a/cmd/deployment/appsearch/show.go
+++ b/cmd/deployment/appsearch/show.go
@@ -64,6 +64,7 @@ var showAppSearchCmd = &cobra.Command{
 }
 
 func init() {
+	Command.AddCommand(showAppSearchCmd)
 	showAppSearchCmd.Flags().String("ref-id", "", "Optional RefId, auto-discovered if not specified")
 	showAppSearchCmd.Flags().Bool("plans", false, "Shows the deployment plans")
 	showAppSearchCmd.Flags().Bool("plan-logs", false, "Shows the deployment plan logs")

--- a/docs/ecctl_deployment_appsearch.md
+++ b/docs/ecctl_deployment_appsearch.md
@@ -39,5 +39,6 @@ ecctl deployment appsearch [flags]
 ### SEE ALSO
 
 * [ecctl deployment](ecctl_deployment.md)	 - Manages deployments
+* [ecctl deployment appsearch create](ecctl_deployment_appsearch_create.md)	 - Creates an AppSearch instance
 * [ecctl deployment appsearch show](ecctl_deployment_appsearch_show.md)	 - Shows the specified AppSearch deployment
 

--- a/docs/ecctl_deployment_appsearch_create.md
+++ b/docs/ecctl_deployment_appsearch_create.md
@@ -1,0 +1,112 @@
+## ecctl deployment appsearch create
+
+Creates an AppSearch instance
+
+### Synopsis
+
+Creates an AppSearch deployment, limitting the creation scope to AppSearch resources.
+There are a few ways to create an AppSearch deployment, sane default values are provided, making
+the command work out of the box even when no parameters are set. When version is not specified,
+the matching elasticsearch deployment version will be used. These are the available options:
+
+  * Simplified flags: --zones <zone count> --size <node memory in MB>
+  * File definition: --file=<file path> (shorthand: -f). The definition can be found in:
+    https://www.elastic.co/guide/en/cloud-enterprise/current/definitions.html#AppSearchPayload
+
+As an option, "--generate-payload" can be used in order to obtain the generated AppSearchPayload
+that would be sent as a request, save it, update or extend the topology and create an AppSearch
+deployment using the saved payload with the "--file" flag.
+
+```
+ecctl deployment appsearch create --id <deployment-id> [flags]
+```
+
+### Examples
+
+```
+## Create a single AppSearch server. The command will exit after the API response has been returned, 
+## without waiting until the deployment resources have been created. To make the command wait until
+the resources have been created use the "--track" flag.
+$ ecctl deployment appsearch create --id=a57f8b7ce54c4afb90ce3755d1e94000 --track
+{
+  "id": "a57f8b7ce54c4afb90ce3755d1e94000",
+  "name": "a57f8b7ce54c4afb90ce3755d1e94000",
+  "resources": [
+    {
+      "elasticsearch_cluster_ref_id": "elasticsearch",
+      "id": "53d104a432a648f68ec76d52ecb521d5",
+      "kind": "appsearch",
+      "ref_id": "main-appsearch",
+      "region": "ece-region"
+    },
+    {
+      "elasticsearch_cluster_ref_id": "elasticsearch",
+      "id": "39e4a65fc2b14651b666aaff18a13b8f",
+      "kind": "kibana",
+      "ref_id": "main-kibana",
+      "region": "ece-region"
+    },
+    {
+      "cloud_id": "a57f8b7ce54c4afb90ce3755d1e94000:MTkyLjE2OC40NC4xMC5pcC5lcy5pbzo5MjQzJGQzODIwOWU4ZTYwYzRlYTliY2UzMDc1OThhMTljNGI3JDM5ZTRhNjVmYzJiMTQ2NTFiNjY2YWFmZjE4YTEzYjhm",
+      "id": "d38209e8e60c4ea9bce307598a19c4b7",
+      "kind": "elasticsearch",
+      "ref_id": "main-elasticsearch",
+      "region": "ece-region"
+    }
+  ]
+}
+Cluster [53d104a432a648f68ec76d52ecb521d5][AppSearch]: running step "wait-until-running" (Plan duration 1.38505959s)...
+Cluster [39e4a65fc2b14651b666aaff18a13b8f][Kibana]: finished running all the plan steps (Total plan duration: 1.73493053s)
+Cluster [d38209e8e60c4ea9bce307598a19c4b7][Elasticsearch]: finished running all the plan steps (Total plan duration: 1.849794895s)
+Cluster [53d104a432a648f68ec76d52ecb521d5][AppSearch]: running step "set-maintenance" (Plan duration 11.162178491s)...
+Cluster [53d104a432a648f68ec76d52ecb521d5][AppSearch]: finished running all the plan steps (Total plan duration: 16.677195277s)
+
+## Save the definition to a file for later use.
+$ ecctl deployment appsearch create --generate-payload --id a57f8b7ce54c4afb90ce3755d1e94000 --zones 2 --size 2048 > appsearch_create_example.json
+
+## Create the deployment piping through the file contents tracking the creation progress
+$ cat appsearch_create_example.json | dev-cli deployment appsearch create --track --id a57f8b7ce54c4afb90ce3755d1e94000
+[...]
+```
+
+### Options
+
+```
+      --deployment-template string    Optional deployment template ID, automatically obtained from the current deployment
+      --elasticsearch-ref-id string   Optional Elasticsearch ref ID where the AppSearch deployment will connect to
+  -f, --file string                   AppSearchPayload file definition. See help for more information
+      --generate-payload              Returns the AppSearchPayload without actually creating the deployment resources
+  -h, --help                          help for create
+      --id string                     Deployment ID where to create the AppSearch deployment
+      --name string                   Optional name to set for the AppSearch deployment (Overrides name if present)
+      --ref-id string                 RefId for the AppSearch deployment (default "main-appsearch")
+      --size int32                    Memory (RAM) in MB that each of the deployment nodes will have (default 2048)
+  -t, --track                         Tracks the progress of the performed task
+      --version string                Optional version to use. If not specified, it will default to the deployment's stack version
+      --zones int32                   Number of zones the deployment will span (default 1)
+```
+
+### Options inherited from parent commands
+
+```
+      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
+      --force              Do not ask for confirmation
+      --format string      Formats the output using a Go template
+      --host string        Base URL to use
+      --insecure           Skips all TLS validation
+      --message string     A message to set on cluster operation
+      --output string      Output format [text|json] (default "text")
+      --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
+      --pprof              Enables pprofing and saves the profile to pprof-20060102150405
+  -q, --quiet              Suppresses the configuration file used for the run, if any
+      --timeout duration   Timeout to use on all HTTP calls (default 30s)
+      --trace              Enables tracing saves the trace to trace-20060102150405
+      --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)
+      --verbose            Enable verbose mode
+```
+
+### SEE ALSO
+
+* [ecctl deployment appsearch](ecctl_deployment_appsearch.md)	 - Manages AppSearch deployments
+

--- a/docs/ecctl_deployment_appsearch_create.md
+++ b/docs/ecctl_deployment_appsearch_create.md
@@ -25,9 +25,8 @@ ecctl deployment appsearch create --id <deployment-id> [flags]
 
 ```
 ## Create a single AppSearch server. The command will exit after the API response has been returned, 
-## without waiting until the deployment resources have been created. To make the command wait until
-the resources have been created use the "--track" flag.
-$ ecctl deployment appsearch create --id=a57f8b7ce54c4afb90ce3755d1e94000 --track
+## without waiting until the deployment resources have been created.
+$ ecctl deployment appsearch create --id=a57f8b7ce54c4afb90ce3755d1e94000
 {
   "id": "a57f8b7ce54c4afb90ce3755d1e94000",
   "name": "a57f8b7ce54c4afb90ce3755d1e94000",
@@ -55,17 +54,12 @@ $ ecctl deployment appsearch create --id=a57f8b7ce54c4afb90ce3755d1e94000 --trac
     }
   ]
 }
-Cluster [53d104a432a648f68ec76d52ecb521d5][AppSearch]: running step "wait-until-running" (Plan duration 1.38505959s)...
-Cluster [39e4a65fc2b14651b666aaff18a13b8f][Kibana]: finished running all the plan steps (Total plan duration: 1.73493053s)
-Cluster [d38209e8e60c4ea9bce307598a19c4b7][Elasticsearch]: finished running all the plan steps (Total plan duration: 1.849794895s)
-Cluster [53d104a432a648f68ec76d52ecb521d5][AppSearch]: running step "set-maintenance" (Plan duration 11.162178491s)...
-Cluster [53d104a432a648f68ec76d52ecb521d5][AppSearch]: finished running all the plan steps (Total plan duration: 16.677195277s)
 
 ## Save the definition to a file for later use.
 $ ecctl deployment appsearch create --generate-payload --id a57f8b7ce54c4afb90ce3755d1e94000 --zones 2 --size 2048 > appsearch_create_example.json
 
-## Create the deployment piping through the file contents tracking the creation progress
-$ cat appsearch_create_example.json | dev-cli deployment appsearch create --track --id a57f8b7ce54c4afb90ce3755d1e94000
+## Create the deployment piping through the file contents.
+$ cat appsearch_create_example.json | dev-cli deployment appsearch create --id a57f8b7ce54c4afb90ce3755d1e94000
 [...]
 ```
 
@@ -81,7 +75,6 @@ $ cat appsearch_create_example.json | dev-cli deployment appsearch create --trac
       --name string                   Optional name to set for the AppSearch deployment (Overrides name if present)
       --ref-id string                 RefId for the AppSearch deployment (default "main-appsearch")
       --size int32                    Memory (RAM) in MB that each of the deployment nodes will have (default 2048)
-  -t, --track                         Tracks the progress of the performed task
       --version string                Optional version to use. If not specified, it will default to the deployment's stack version
       --zones int32                   Number of zones the deployment will span (default 1)
 ```

--- a/docs/ecctl_deployment_appsearch_create.md
+++ b/docs/ecctl_deployment_appsearch_create.md
@@ -75,6 +75,7 @@ $ cat appsearch_create_example.json | dev-cli deployment appsearch create --id a
       --name string                   Optional name to set for the AppSearch deployment (Overrides name if present)
       --ref-id string                 RefId for the AppSearch deployment (default "main-appsearch")
       --size int32                    Memory (RAM) in MB that each of the deployment nodes will have (default 2048)
+  -t, --track                         Tracks the progress of the performed task
       --version string                Optional version to use. If not specified, it will default to the deployment's stack version
       --zones int32                   Number of zones the deployment will span (default 1)
 ```

--- a/pkg/deployment/depresource/appsearch.go
+++ b/pkg/deployment/depresource/appsearch.go
@@ -1,0 +1,87 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package depresource
+
+import (
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/client/platform_configuration_templates"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+)
+
+const (
+	// DefaultAppSearchRefID is used when the RefID is not specified.
+	DefaultAppSearchRefID = "main-appsearch"
+)
+
+// NewAppSearch creates a *models.AppSearchPayload from the parameters.
+// It relies on a simplified single dimension memory size and zone count to
+// construct the AppSearch's topology.
+func NewAppSearch(params NewStateless) (*models.AppSearchPayload, error) {
+	params.fillDefaults(DefaultAppSearchRefID)
+	if err := params.Validate(); err != nil {
+		return nil, err
+	}
+
+	// When either not set, we obtain the values from the running deployment.
+	// Overriding either or both is done at the end of the if.
+	if err := getTemplateAndRefID(&params); err != nil {
+		return nil, err
+	}
+
+	// Obtain the deployment template so we can create the appsearch topology from
+	// the specified sizes. The sizing overrides are done in newAppSearchPayload.
+	res, err := params.V1API.PlatformConfigurationTemplates.GetDeploymentTemplate(
+		platform_configuration_templates.NewGetDeploymentTemplateParams().
+			WithTemplateID(params.TemplateID).
+			WithShowInstanceConfigurations(ec.Bool(true)),
+		params.AuthWriter,
+	)
+	if err != nil {
+		return nil, api.UnwrapError(err)
+	}
+
+	var clusterTopology = res.Payload.ClusterTemplate.Appsearch.Plan.ClusterTopology
+	var topology = models.AppSearchTopologyElement{Size: new(models.TopologySize)}
+	if len(clusterTopology) > 0 {
+		topology = *clusterTopology[0]
+	}
+	var payload = newAppSearchPayload(params, topology)
+
+	return &payload, nil
+}
+
+func newAppSearchPayload(params NewStateless, topology models.AppSearchTopologyElement) models.AppSearchPayload {
+	if params.Size > 0 {
+		topology.Size.Value = ec.Int32(params.Size)
+	}
+	if params.ZoneCount > 0 {
+		topology.ZoneCount = params.ZoneCount
+	}
+
+	return models.AppSearchPayload{
+		ElasticsearchClusterRefID: ec.String(params.ElasticsearchRefID),
+		DisplayName:               params.Name,
+		Region:                    ec.String(params.Region),
+		RefID:                     ec.String(params.RefID),
+		Plan: &models.AppSearchPlan{
+			Appsearch:       &models.AppSearchConfiguration{Version: params.Version},
+			ClusterTopology: []*models.AppSearchTopologyElement{&topology},
+		},
+	}
+}

--- a/pkg/deployment/depresource/appsearch_test.go
+++ b/pkg/deployment/depresource/appsearch_test.go
@@ -1,0 +1,217 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package depresource
+
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/elastic/ecctl/pkg/util"
+)
+
+var appsearchTemplateResponse = models.DeploymentTemplateInfo{
+	ID: "default",
+	ClusterTemplate: &models.DeploymentTemplateDefinitionRequest{
+		Appsearch: &models.CreateAppSearchRequest{
+			Plan: &models.AppSearchPlan{
+				ClusterTopology: []*models.AppSearchTopologyElement{
+					{
+						Size: &models.TopologySize{
+							Resource: ec.String("memory"),
+							Value:    ec.Int32(1024),
+						},
+						ZoneCount: 1,
+					},
+				},
+			},
+		},
+		Plan: &models.ElasticsearchClusterPlan{
+			ClusterTopology: defaultESTopologies,
+		},
+	},
+}
+
+func TestNewAppSearch(t *testing.T) {
+	var internalError = models.BasicFailedReply{
+		Errors: []*models.BasicFailedReplyElement{
+			{},
+		},
+	}
+	internalErrorBytes, _ := json.MarshalIndent(internalError, "", "  ")
+
+	var getResponse = models.DeploymentGetResponse{
+		Resources: &models.DeploymentResources{
+			Elasticsearch: []*models.ElasticsearchResourceInfo{{
+				RefID: ec.String("main-elasticsearch"),
+				Info: &models.ElasticsearchClusterInfo{
+					PlanInfo: &models.ElasticsearchClusterPlansInfo{
+						Current: &models.ElasticsearchClusterPlanInfo{
+							Plan: &models.ElasticsearchClusterPlan{
+								DeploymentTemplate: &models.DeploymentTemplateReference{
+									ID: ec.String("an ID"),
+								},
+							},
+						},
+					},
+				},
+			}},
+		},
+	}
+
+	type args struct {
+		params NewStateless
+	}
+	tests := []struct {
+		name string
+		args args
+		want *models.AppSearchPayload
+		err  error
+	}{
+		{
+			name: "fails due to parameter validation",
+			args: args{params: NewStateless{}},
+			err: &multierror.Error{Errors: []error{
+				util.ErrAPIReq,
+				util.ErrDeploymentID,
+				errors.New("deployment topology: region cannot be empty"),
+			}},
+		},
+		{
+			name: "fails obtaining the deployment info",
+			args: args{params: NewStateless{
+				DeploymentID: util.ValidClusterID,
+				API:          api.NewMock(mock.New500Response(mock.NewStructBody(internalError))),
+				Region:       "ece-region",
+			}},
+			err: errors.New(string(internalErrorBytes)),
+		},
+		{
+			name: "obtains the deployment info but fails getting the template ID info",
+			args: args{params: NewStateless{
+				DeploymentID: util.ValidClusterID,
+				API: api.NewMock(
+					mock.New200Response(mock.NewStructBody(models.DeploymentGetResponse{
+						Resources: &models.DeploymentResources{
+							Elasticsearch: []*models.ElasticsearchResourceInfo{{
+								Info: &models.ElasticsearchClusterInfo{
+									PlanInfo: &models.ElasticsearchClusterPlansInfo{},
+								},
+							}},
+						},
+					})),
+				),
+				Region: "ece-region",
+			}},
+			err: errors.New("unable to obtain deployment template ID from existing deployment ID, please specify a one"),
+		},
+		{
+			name: "obtains the deployment info but fails getting the template ID info from the API",
+			args: args{params: NewStateless{
+				DeploymentID: util.ValidClusterID,
+				API: api.NewMock(
+					mock.New200Response(mock.NewStructBody(getResponse)),
+					mock.New404Response(mock.NewStructBody(internalError)),
+				),
+				Region: "ece-region",
+			}},
+			err: errors.New(string(internalErrorBytes)),
+		},
+		{
+			name: "succeeds with no argument override",
+			args: args{params: NewStateless{
+				DeploymentID: util.ValidClusterID,
+				API: api.NewMock(
+					mock.New200Response(mock.NewStructBody(getResponse)),
+					mock.New200Response(mock.NewStructBody(appsearchTemplateResponse)),
+				),
+				Region: "ece-region",
+			}},
+			want: &models.AppSearchPayload{
+				ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
+				Region:                    ec.String("ece-region"),
+				RefID:                     ec.String("main-appsearch"),
+				Plan: &models.AppSearchPlan{
+					Appsearch: &models.AppSearchConfiguration{},
+					ClusterTopology: []*models.AppSearchTopologyElement{
+						{
+							Size: &models.TopologySize{
+								Resource: ec.String("memory"),
+								Value:    ec.Int32(1024),
+							},
+							ZoneCount: 1,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "succeeds with argument overrides",
+			args: args{params: NewStateless{
+				Size:         4096,
+				ZoneCount:    3,
+				DeploymentID: util.ValidClusterID,
+				API: api.NewMock(
+					mock.New200Response(mock.NewStructBody(getResponse)),
+					mock.New200Response(mock.NewStructBody(appsearchTemplateResponse)),
+				),
+				Region: "ece-region",
+			}},
+			want: &models.AppSearchPayload{
+				ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
+				Region:                    ec.String("ece-region"),
+				RefID:                     ec.String("main-appsearch"),
+				Plan: &models.AppSearchPlan{
+					Appsearch: &models.AppSearchConfiguration{},
+					ClusterTopology: []*models.AppSearchTopologyElement{
+						{
+							Size: &models.TopologySize{
+								Resource: ec.String("memory"),
+								Value:    ec.Int32(4096),
+							},
+							ZoneCount: 3,
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewAppSearch(tt.args.params)
+			if !reflect.DeepEqual(err, tt.err) {
+				t.Errorf("NewAppSearch() error = %v, wantErr %v", err, tt.err)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				g, _ := json.Marshal(got)
+				w, _ := json.Marshal(tt.want)
+				println(string(g))
+				println(string(w))
+				t.Errorf("NewAppSearch() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Implements a new `ecctl deployment appsearch create --id <deployment id>` command.

## Related Issues
Related: https://github.com/elastic/ecctl/issues/166

## Motivation and Context
appsearch needs it's own commands :)

## How Has This Been Tested?
Unit tests and manually by running the following commands against an ECE environment:
- `ecctl deployment appsearch create --id 421b46a30bb84d66b8eeae8802846f3a`
- `ecctl deployment appsearch create --generate-payload --id 421b46a30bb84d66b8eeae8802846f3a --zones 3 --size 4096 > appsearchtest.json`
- `ecctl deployment appsearch create  --id 421b46a30bb84d66b8eeae8802846f3a -f appsearchtest.json `

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
