### PR TITLE
cmd: new appsearch shutdown and delete commands

### DIFF
--- a/cmd/deployment/appsearch/delete.go
+++ b/cmd/deployment/appsearch/delete.go
@@ -1,0 +1,58 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmdappsearch
+
+import (
+	"os"
+
+	sdkcmdutil "github.com/elastic/cloud-sdk-go/pkg/util/cmdutil"
+	"github.com/spf13/cobra"
+
+	"github.com/elastic/ecctl/pkg/deployment"
+	"github.com/elastic/ecctl/pkg/deployment/depresource"
+	"github.com/elastic/ecctl/pkg/ecctl"
+)
+
+var deleteCmd = &cobra.Command{
+	Use:     "delete <deployment id>",
+	Short:   "Deletes a previously shut down AppSearch deployment resource",
+	PreRunE: sdkcmdutil.MinimumNArgsAndUUID(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		refID, _ := cmd.Flags().GetString("ref-id")
+
+		force, _ := cmd.Flags().GetBool("force")
+		var msg = "This action will delete the AppSearch deployment resource and its configuration history. Do you want to continue? [y/n]: "
+		if !force && !sdkcmdutil.ConfirmAction(msg, os.Stderr, os.Stdout) {
+			return nil
+		}
+
+		return depresource.DeleteStateless(depresource.DeleteStatelessParams{
+			ResourceParams: deployment.ResourceParams{
+				API:          ecctl.Get().API,
+				DeploymentID: args[0],
+				Type:         "appsearch",
+				RefID:        refID,
+			},
+		})
+	},
+}
+
+func init() {
+	Command.AddCommand(deleteCmd)
+	deleteCmd.Flags().String("ref-id", "", "Optional RefId, auto-discovered if not specified")
+}

--- a/cmd/deployment/appsearch/shutdown.go
+++ b/cmd/deployment/appsearch/shutdown.go
@@ -1,0 +1,65 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmdappsearch
+
+import (
+	"os"
+
+	"github.com/elastic/cloud-sdk-go/pkg/util/cmdutil"
+	"github.com/spf13/cobra"
+
+	"github.com/elastic/ecctl/pkg/deployment"
+	"github.com/elastic/ecctl/pkg/deployment/depresource"
+	"github.com/elastic/ecctl/pkg/ecctl"
+)
+
+var shutdownCmd = &cobra.Command{
+	Use:     "shutdown <deployment id>",
+	Short:   "Shuts down an AppSearch deployment",
+	PreRunE: cmdutil.MinimumNArgsAndUUID(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		refID, _ := cmd.Flags().GetString("ref-id")
+		skipSnapshot, _ := cmd.Flags().GetBool("skip-snapshot")
+		hide, _ := cmd.Flags().GetBool("hide")
+
+		force, _ := cmd.Flags().GetBool("force")
+		var msg = "This action will shutdown the AppSearch deployment. Do you want to continue? [y/n]: "
+		if !force && !cmdutil.ConfirmAction(msg, os.Stderr, os.Stdout) {
+			return nil
+		}
+
+		return depresource.Shutdown(depresource.ShutdownParams{
+			ResourceParams: deployment.ResourceParams{
+				API:          ecctl.Get().API,
+				DeploymentID: args[0],
+				Type:         "appsearch",
+				RefID:        refID,
+			},
+			SkipSnapshot: skipSnapshot,
+			Hide:         hide,
+		})
+
+	},
+}
+
+func init() {
+	Command.AddCommand(shutdownCmd)
+	shutdownCmd.Flags().String("ref-id", "", "Optional RefId, auto-discovered if not specified")
+	shutdownCmd.Flags().Bool("skip-snapshot", false, "Optional flag to toggle skipping the snapshot before shutting it down")
+	shutdownCmd.Flags().Bool("hide", false, "Optionally hides the deployment resource from being listed by default")
+}

--- a/docs/ecctl_deployment_appsearch.md
+++ b/docs/ecctl_deployment_appsearch.md
@@ -40,5 +40,7 @@ ecctl deployment appsearch [flags]
 
 * [ecctl deployment](ecctl_deployment.md)	 - Manages deployments
 * [ecctl deployment appsearch create](ecctl_deployment_appsearch_create.md)	 - Creates an AppSearch instance
+* [ecctl deployment appsearch delete](ecctl_deployment_appsearch_delete.md)	 - Deletes a previously shut down AppSearch deployment resource
 * [ecctl deployment appsearch show](ecctl_deployment_appsearch_show.md)	 - Shows the specified AppSearch deployment
+* [ecctl deployment appsearch shutdown](ecctl_deployment_appsearch_shutdown.md)	 - Shuts down an AppSearch deployment
 

--- a/docs/ecctl_deployment_appsearch_delete.md
+++ b/docs/ecctl_deployment_appsearch_delete.md
@@ -1,0 +1,43 @@
+## ecctl deployment appsearch delete
+
+Deletes a previously shut down AppSearch deployment resource
+
+### Synopsis
+
+Deletes a previously shut down AppSearch deployment resource
+
+```
+ecctl deployment appsearch delete <deployment id> [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for delete
+      --ref-id string   Optional RefId, auto-discovered if not specified
+```
+
+### Options inherited from parent commands
+
+```
+      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
+      --force              Do not ask for confirmation
+      --format string      Formats the output using a Go template
+      --host string        Base URL to use
+      --insecure           Skips all TLS validation
+      --message string     A message to set on cluster operation
+      --output string      Output format [text|json] (default "text")
+      --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
+      --pprof              Enables pprofing and saves the profile to pprof-20060102150405
+  -q, --quiet              Suppresses the configuration file used for the run, if any
+      --timeout duration   Timeout to use on all HTTP calls (default 30s)
+      --trace              Enables tracing saves the trace to trace-20060102150405
+      --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)
+      --verbose            Enable verbose mode
+```
+
+### SEE ALSO
+
+* [ecctl deployment appsearch](ecctl_deployment_appsearch.md)	 - Manages AppSearch deployments
+

--- a/docs/ecctl_deployment_appsearch_shutdown.md
+++ b/docs/ecctl_deployment_appsearch_shutdown.md
@@ -1,0 +1,45 @@
+## ecctl deployment appsearch shutdown
+
+Shuts down an AppSearch deployment
+
+### Synopsis
+
+Shuts down an AppSearch deployment
+
+```
+ecctl deployment appsearch shutdown <deployment id> [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for shutdown
+      --hide            Optionally hides the deployment resource from being listed by default
+      --ref-id string   Optional RefId, auto-discovered if not specified
+      --skip-snapshot   Optional flag to toggle skipping the snapshot before shutting it down
+```
+
+### Options inherited from parent commands
+
+```
+      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
+      --force              Do not ask for confirmation
+      --format string      Formats the output using a Go template
+      --host string        Base URL to use
+      --insecure           Skips all TLS validation
+      --message string     A message to set on cluster operation
+      --output string      Output format [text|json] (default "text")
+      --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
+      --pprof              Enables pprofing and saves the profile to pprof-20060102150405
+  -q, --quiet              Suppresses the configuration file used for the run, if any
+      --timeout duration   Timeout to use on all HTTP calls (default 30s)
+      --trace              Enables tracing saves the trace to trace-20060102150405
+      --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)
+      --verbose            Enable verbose mode
+```
+
+### SEE ALSO
+
+* [ecctl deployment appsearch](ecctl_deployment_appsearch.md)	 - Manages AppSearch deployments
+

--- a/pkg/deployment/depresource/delete_stateless.go
+++ b/pkg/deployment/depresource/delete_stateless.go
@@ -45,7 +45,7 @@ func (params *DeleteStatelessParams) Validate() error {
 	return merr.ErrorOrNil()
 }
 
-// DeleteStateless upgrades a stateless deployment resource like APM, Kibana
+// DeleteStateless deletes a stateless deployment resource like APM, Kibana
 // and AppSearch.
 func DeleteStateless(params DeleteStatelessParams) error {
 	if err := params.Validate(); err != nil {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Implements the new `ecctl deployment appsearch shutdown <deployment id>` and `ecctl deployment appsearch delete <deployment id>` commands

## Related Issues
Related https://github.com/elastic/ecctl/issues/166

## Motivation and Context
moar appsearch commands!

## How Has This Been Tested?
unit tests and manually against an ECE environment

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
