### PR TITLE
cmd: init now only allows API key auth for ESS users

### DIFF
--- a/pkg/ecctl/init_test.go
+++ b/pkg/ecctl/init_test.go
@@ -244,8 +244,8 @@ func TestInitConfig(t *testing.T) {
 					strings.NewReader("1\n"),
 					strings.NewReader("1\n"),
 					strings.NewReader("1\n"),
-					strings.NewReader("1\n"),
 					strings.NewReader("anapikey\n"),
+					strings.NewReader("1\n"),
 				),
 				Writer:    new(bytes.Buffer),
 				ErrWriter: new(bytes.Buffer),
@@ -265,8 +265,8 @@ func TestInitConfig(t *testing.T) {
 			},
 			wantOutput: disclaimer + missingConfigMsg + hostChoiceMsg + "\n" +
 				fmt.Sprintf(essChoiceMsg, essHostAddress) + regionChoiceMsg + "\n" +
-				formatChoiceMsg + "\n" + authChoiceMsg + "\n" + apiKeyMsg + "\n" +
-				"\n" + fmt.Sprintf(validCredentialsMsg, "anacleto") + finalMsg + "\n",
+				apiKeyMsg + "\n" + formatChoiceMsg + "\n" + "\n" +
+				fmt.Sprintf(validCredentialsMsg, "anacleto") + finalMsg + "\n",
 		},
 		{
 			name: "doesn't find a config file and user creates a new one with user/pass",
@@ -277,9 +277,9 @@ func TestInitConfig(t *testing.T) {
 					strings.NewReader("y\n"),
 					strings.NewReader("2\n"),
 					strings.NewReader("https://ahost\n"),
-					strings.NewReader("1\n"),
 					strings.NewReader("2\n"),
 					strings.NewReader("auser\n"),
+					strings.NewReader("1\n"),
 				),
 				Writer:    new(bytes.Buffer),
 				ErrWriter: new(bytes.Buffer),
@@ -303,7 +303,7 @@ func TestInitConfig(t *testing.T) {
 				"user":     "auser",
 			},
 			wantOutput: disclaimer + missingConfigMsg + hostChoiceMsg + "\n" + eceHostMsg +
-				formatChoiceMsg + "\n" + authChoiceMsg + "\n" + userMsg + passMsg +
+				authChoiceMsg + "\n" + userMsg + passMsg + "\n" + formatChoiceMsg +
 				"\n" + "\n" + fmt.Sprintf(validCredentialsMsg, "auser") + finalMsg + "\n",
 		},
 		{
@@ -316,8 +316,8 @@ func TestInitConfig(t *testing.T) {
 					strings.NewReader("3\n"),
 					strings.NewReader("https://ahost\n"),
 					strings.NewReader("1\n"),
-					strings.NewReader("1\n"),
 					strings.NewReader("anapikey\n"),
+					strings.NewReader("1\n"),
 				),
 				Writer:    new(bytes.Buffer),
 				ErrWriter: new(bytes.Buffer),
@@ -338,7 +338,7 @@ func TestInitConfig(t *testing.T) {
 			wantOutput: disclaimer +
 				fmt.Sprintf(settingsPathMsg, "test_files/userpassmodif.yaml") +
 				userPassConfigToModifyContents + "\n" + existingConfigMsg + hostChoiceMsg +
-				"\n" + esspHostMsg + formatChoiceMsg + "\n" + authChoiceMsg + "\n" + apiKeyMsg +
+				"\n" + esspHostMsg + apiKeyMsg + "\n" + formatChoiceMsg +
 				"\n" + "\n" + fmt.Sprintf(validCredentialsMsg, "anacleto") + finalMsg + "\n",
 		},
 		{
@@ -350,9 +350,9 @@ func TestInitConfig(t *testing.T) {
 					strings.NewReader("y\n"),
 					strings.NewReader("2\n"),
 					strings.NewReader("https://ahost\n"),
-					strings.NewReader("1\n"),
 					strings.NewReader("2\n"),
 					strings.NewReader("auser\n"),
+					strings.NewReader("1\n"),
 				),
 				Writer:    new(bytes.Buffer),
 				ErrWriter: new(bytes.Buffer),
@@ -378,8 +378,8 @@ func TestInitConfig(t *testing.T) {
 			wantOutput: disclaimer +
 				fmt.Sprintf(settingsPathMsg, "test_files/apikeymodif.yaml") +
 				apiKeyConfigToModifyContents + "\n" + existingConfigMsg + hostChoiceMsg +
-				"\n" + eceHostMsg + formatChoiceMsg + "\n" + authChoiceMsg + "\n" + userMsg +
-				passMsg + "\n" + "\n" + fmt.Sprintf(validCredentialsMsg, "auser") + finalMsg + "\n",
+				"\n" + eceHostMsg + authChoiceMsg + "\n" + userMsg +
+				passMsg + "\n" + formatChoiceMsg + "\n" + "\n" + fmt.Sprintf(validCredentialsMsg, "auser") + finalMsg + "\n",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
The `ecctl init` command disables the option to configure user/pass authentication for ESS and ESSP.

ECE auth configuration stays the same.

## Related Issues
Closes: https://github.com/elastic/ecctl/issues/157

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually and through unit tests

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
