### PR TITLE
docs: change to specify that ecctl is no longer ECE specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,9 @@
 
 NOTE: **You are looking at the documentation for a beta release. Please keep in mind that backwards-incompatible changes might be introduced in future releases.**
 
-`ecctl` is the CLI on steroids for the Elastic Cloud Enterprise API. It wraps typical operations commonly needed by ECE operators within a single command line tool.
+`ecctl` is the CLI on steroids for the Elastic Cloud API. It wraps typical operations commonly needed by operators within a single command line tool.
 
-The goal of this project is to provide an easier way to interact with the ECE API, ensuring each one of the provided commands is thoroughly tested.
-
-Note that, right now, `ecctl` targets ECE installations only. There are, however, plans to support public Elasticsearch Service API in the future.
+The goal of this project is to provide an easier way to interact with the Elastic Cloud API, ensuring each one of the provided commands is thoroughly tested.
 
 To get started with Elastic Cloud Control, see the [official documentation](https://www.elastic.co/guide/en/ecctl/current/index.html). 
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 NOTE: **You are looking at the documentation for a beta release. Please keep in mind that backwards-incompatible changes might be introduced in future releases.**
 
-`ecctl` is the CLI on steroids for the Elastic Cloud API. It wraps typical operations commonly needed by operators within a single command line tool.
+`ecctl` is the CLI on steroids for the Elasticsearch Service and Elastic Cloud Enterprise APIs. It wraps typical operations commonly needed by operators within a single command line tool.
 
-The goal of this project is to provide an easier way to interact with the Elastic Cloud API, ensuring each one of the provided commands is thoroughly tested.
+The goal of this project is to provide an easier way to interact with the Elasticsearch Service and Elastic Cloud Enterprise APIs, ensuring each one of the provided commands is thoroughly tested.
 
 To get started with Elastic Cloud Control, see the [official documentation](https://www.elastic.co/guide/en/ecctl/current/index.html). 
 

--- a/docs/ecctl-getting-started.asciidoc
+++ b/docs/ecctl-getting-started.asciidoc
@@ -3,8 +3,8 @@
 
 beta[]
 
-{p} is the CLI on steroids for the Elastic Cloud API. It wraps typical 
-operations commonly needed by operators within a single command line tool.
+{p} is the CLI on steroids for the Elasticsearch Service and Elastic Cloud Enterprise APIs. 
+It wraps typical operations commonly needed by operators within a single command line tool.
 
 Benefits of {p}:
 
@@ -139,7 +139,7 @@ Elastic Cloud uses API keys to authenticate users against its API.
 Additionally, it supports the usage of https://jwt.io/[JWT] to validate
 authenticated clients. The preferred authentication method is API keys.
 
-There are two ways to authenticate against the Elastic Cloud API using
+There are two ways to authenticate against the Elasticsearch Service or the Elastic Cloud Enterprise APIs
 {p}:
 
 * By specifying an API key using the `--apikey` flag
@@ -164,7 +164,7 @@ the binary for Elastic Cloud:
 
 [source,yaml]
 ----
-host: https://api.elastic-cloud.com # URL of your Elastic Cloud API endpoint
+host: https://api.elastic-cloud.com # URL of your Elasticsearch Service or Elastic Cloud Enterprise API endpoint
 
 # Credentials
 ## apikey is the preferred authentication mechanism.

--- a/docs/ecctl-getting-started.asciidoc
+++ b/docs/ecctl-getting-started.asciidoc
@@ -3,19 +3,14 @@
 
 beta[]
 
-{p} is the CLI on steroids for the Elastic Cloud Enterprise API. It wraps
-typical operations commonly needed by ECE operators within a
-single command line tool.
+{p} is the CLI on steroids for the Elastic Cloud API. It wraps typical 
+operations commonly needed by operators within a single command line tool.
 
 Benefits of {p}:
 
 * Easier to use than the Cloud UI or using the RESTful API directly
 * Helps you automate the deployment lifecycle
 * Provides a foundation for integration with other tools, such as Terraform and Ansible
-
-Right now, {p} supports ECE installations only.
-
-//, but we plan to support a public Elasticsearch Service API in the future.
 
 [id="{p}-installing"]
 == Installing
@@ -123,20 +118,13 @@ Please enter your choice: 1
 
 Using "https://api.elastic-cloud.com" as the API endpoint.
 
+Paste your API Key and press enter: xxxxx
+
 What default output format would you like?
   [1] text - Human-readable output format, commands with no output templates defined will fall back to JSON.
   [2] json - JSON formatted output API responses.
 
 Please enter a choice: 1
-
-
-Which authentication mechanism would you like to use?
-  [1] API Keys (Recommended).
-  [2] Username and Password login.
-
-Please enter your choice: 1
-
-Paste your API Key and press enter: xxxxx
 
 Your credentials seem to be valid, and show you're authenticated as "user".
 
@@ -176,7 +164,7 @@ the binary for Elastic Cloud:
 
 [source,yaml]
 ----
-host: https://api.elastic-cloud.com # URL of your ECE API endpoint
+host: https://api.elastic-cloud.com # URL of your Elastic Cloud API endpoint
 
 # Credentials
 ## apikey is the preferred authentication mechanism.
@@ -327,10 +315,8 @@ $ unset EC_FORMAT
 
 {n} includes commands to administer:
 
-* Platform components
-* Platform authentication
-* Platform users
 * Elastic Stack deployments
+* Platform components
 * And more
 
 :leveloffset: +1 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Documentation change to specify that ecctl is no longer ECE specific.

The docs have also been slightly modified to cater to our largest user base which will be ESS.

## Related Issues
Closes: https://github.com/elastic/ecctl/issues/161

## Motivation and Context
ESS public API launch!

## How Has This Been Tested?
n/a

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
