### PR TITLE
cmd: new appsearch upgrade <deployment id>

### DIFF
--- a/cmd/deployment/appsearch/upgrade.go
+++ b/cmd/deployment/appsearch/upgrade.go
@@ -1,0 +1,72 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmdappsearch
+
+import (
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	sdkcmdutil "github.com/elastic/cloud-sdk-go/pkg/util/cmdutil"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+	"github.com/spf13/cobra"
+
+	cmdutil "github.com/elastic/ecctl/cmd/util"
+	"github.com/elastic/ecctl/pkg/deployment"
+	"github.com/elastic/ecctl/pkg/deployment/depresource"
+	"github.com/elastic/ecctl/pkg/ecctl"
+)
+
+// upgradeCmd is the deployment subcommand
+var upgradeCmd = &cobra.Command{
+	Use:     "upgrade <deployment id>",
+	Short:   "Upgrades an AppSearch deployment to the Elasticsearch deployment version",
+	PreRunE: sdkcmdutil.MinimumNArgsAndUUID(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		resType := "appsearch"
+		refID, _ := cmd.Flags().GetString("ref-id")
+
+		res, err := depresource.UpgradeStateless(deployment.ResourceParams{
+			API:          ecctl.Get().API,
+			DeploymentID: args[0],
+			Type:         resType,
+			RefID:        refID,
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if track, _ := cmd.Flags().GetBool("track"); !track {
+			return nil
+		}
+
+		return depresource.TrackResources(depresource.TrackResourcesParams{
+			API:          ecctl.Get().API,
+			OutputDevice: ecctl.Get().Config.OutputDevice,
+			Resources: []*models.DeploymentResource{{
+				ID:    ec.String(res.ResourceID),
+				Kind:  ec.String(resType),
+				RefID: ec.String(refID),
+			}},
+		})
+	},
+}
+
+func init() {
+	Command.AddCommand(upgradeCmd)
+	upgradeCmd.Flags().BoolP("track", "t", false, cmdutil.TrackFlagMessage)
+	upgradeCmd.Flags().String("ref-id", "", "Optional RefId, if not set, the RefId will be auto-discovered")
+}

--- a/docs/ecctl_deployment_appsearch.md
+++ b/docs/ecctl_deployment_appsearch.md
@@ -43,4 +43,5 @@ ecctl deployment appsearch [flags]
 * [ecctl deployment appsearch delete](ecctl_deployment_appsearch_delete.md)	 - Deletes a previously shut down AppSearch deployment resource
 * [ecctl deployment appsearch show](ecctl_deployment_appsearch_show.md)	 - Shows the specified AppSearch deployment
 * [ecctl deployment appsearch shutdown](ecctl_deployment_appsearch_shutdown.md)	 - Shuts down an AppSearch deployment
+* [ecctl deployment appsearch upgrade](ecctl_deployment_appsearch_upgrade.md)	 - Upgrades an AppSearch deployment to the Elasticsearch deployment version
 

--- a/docs/ecctl_deployment_appsearch_upgrade.md
+++ b/docs/ecctl_deployment_appsearch_upgrade.md
@@ -1,0 +1,44 @@
+## ecctl deployment appsearch upgrade
+
+Upgrades an AppSearch deployment to the Elasticsearch deployment version
+
+### Synopsis
+
+Upgrades an AppSearch deployment to the Elasticsearch deployment version
+
+```
+ecctl deployment appsearch upgrade <deployment id> [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for upgrade
+      --ref-id string   Optional RefId, if not set, the RefId will be auto-discovered
+  -t, --track           Tracks the progress of the performed task
+```
+
+### Options inherited from parent commands
+
+```
+      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
+      --force              Do not ask for confirmation
+      --format string      Formats the output using a Go template
+      --host string        Base URL to use
+      --insecure           Skips all TLS validation
+      --message string     A message to set on cluster operation
+      --output string      Output format [text|json] (default "text")
+      --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
+      --pprof              Enables pprofing and saves the profile to pprof-20060102150405
+  -q, --quiet              Suppresses the configuration file used for the run, if any
+      --timeout duration   Timeout to use on all HTTP calls (default 30s)
+      --trace              Enables tracing saves the trace to trace-20060102150405
+      --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)
+      --verbose            Enable verbose mode
+```
+
+### SEE ALSO
+
+* [ecctl deployment appsearch](ecctl_deployment_appsearch.md)	 - Manages AppSearch deployments
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Implements an `ecctl appsearch upgrade <deployment id>` command which upgrades the AppSearch deployment to match the Elasticsearch deployment.

## Related Issues
Related: https://github.com/elastic/ecctl/issues/166

## Motivation and Context
all the appsearch commands!

## How Has This Been Tested?
Manually and unit tests

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
