### PR TITLE
cmd: --region flag is not hidden anymore

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -117,12 +117,10 @@ func init() {
 	RootCmd.PersistentFlags().Bool("insecure", false, "Skips all TLS validation")
 	RootCmd.PersistentFlags().BoolP("quiet", "q", false, "Suppresses the configuration file used for the run, if any")
 	RootCmd.PersistentFlags().Duration("timeout", time.Second*30, "Timeout to use on all HTTP calls")
-	RootCmd.PersistentFlags().String("region", "", "Elastic Cloud region")
+	RootCmd.PersistentFlags().String("region", "", "Elasticsearch Service region")
 	RootCmd.Flag("region").Annotations = map[string][]string{
 		cobra.BashCompCustom: {"__ecctl_valid_regions"},
 	}
-	// Remove this line after ESS Public API is available.
-	RootCmd.PersistentFlags().MarkHidden("region")
 
 	defaultViper.BindPFlags(RootCmd.PersistentFlags())
 }

--- a/docs/ecctl.md
+++ b/docs/ecctl.md
@@ -21,6 +21,7 @@ Elastic Cloud Control
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_auth.md
+++ b/docs/ecctl_auth.md
@@ -30,6 +30,7 @@ ecctl auth [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_auth_key.md
+++ b/docs/ecctl_auth_key.md
@@ -30,6 +30,7 @@ ecctl auth key [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_auth_key_create.md
+++ b/docs/ecctl_auth_key_create.md
@@ -32,6 +32,7 @@ ecctl auth key create [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_auth_key_delete.md
+++ b/docs/ecctl_auth_key_delete.md
@@ -30,6 +30,7 @@ ecctl auth key delete <key id> <key id> ... [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_auth_key_list.md
+++ b/docs/ecctl_auth_key_list.md
@@ -30,6 +30,7 @@ ecctl auth key list [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_auth_key_show.md
+++ b/docs/ecctl_auth_key_show.md
@@ -30,6 +30,7 @@ ecctl auth key show <key id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment.md
+++ b/docs/ecctl_deployment.md
@@ -30,6 +30,7 @@ ecctl deployment [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_apm.md
+++ b/docs/ecctl_deployment_apm.md
@@ -30,6 +30,7 @@ ecctl deployment apm [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_apm_create.md
+++ b/docs/ecctl_deployment_apm_create.md
@@ -100,6 +100,7 @@ $ cat apm_create_example.json | dev-cli deployment apm create --track --id a57f8
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_apm_delete.md
+++ b/docs/ecctl_deployment_apm_delete.md
@@ -31,6 +31,7 @@ ecctl deployment apm delete <apm deployment id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_apm_list.md
+++ b/docs/ecctl_deployment_apm_list.md
@@ -37,6 +37,7 @@ ecctl deployment apm list [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_apm_plan.md
+++ b/docs/ecctl_deployment_apm_plan.md
@@ -30,6 +30,7 @@ ecctl deployment apm plan [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_apm_plan_cancel.md
+++ b/docs/ecctl_deployment_apm_plan_cancel.md
@@ -31,6 +31,7 @@ ecctl deployment apm plan cancel <cluster id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_apm_plan_history.md
+++ b/docs/ecctl_deployment_apm_plan_history.md
@@ -31,6 +31,7 @@ ecctl deployment apm plan history <cluster id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_apm_plan_monitor.md
+++ b/docs/ecctl_deployment_apm_plan_monitor.md
@@ -32,6 +32,7 @@ ecctl deployment apm plan monitor <cluster id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_apm_plan_reapply.md
+++ b/docs/ecctl_deployment_apm_plan_reapply.md
@@ -40,6 +40,7 @@ ecctl deployment apm plan reapply <cluster id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_apm_restart.md
+++ b/docs/ecctl_deployment_apm_restart.md
@@ -31,6 +31,7 @@ ecctl deployment apm restart [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_apm_resync.md
+++ b/docs/ecctl_deployment_apm_resync.md
@@ -31,6 +31,7 @@ ecctl deployment apm resync {<deployment id> | --all} [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_apm_show.md
+++ b/docs/ecctl_deployment_apm_show.md
@@ -35,6 +35,7 @@ ecctl deployment apm show [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_apm_stop.md
+++ b/docs/ecctl_deployment_apm_stop.md
@@ -32,6 +32,7 @@ ecctl deployment apm stop <apm deployment id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_apm_upgrade.md
+++ b/docs/ecctl_deployment_apm_upgrade.md
@@ -31,6 +31,7 @@ ecctl deployment apm upgrade <deployment id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_appsearch.md
+++ b/docs/ecctl_deployment_appsearch.md
@@ -30,6 +30,7 @@ ecctl deployment appsearch [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_appsearch_create.md
+++ b/docs/ecctl_deployment_appsearch_create.md
@@ -94,6 +94,7 @@ $ cat appsearch_create_example.json | dev-cli deployment appsearch create --id a
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_appsearch_delete.md
+++ b/docs/ecctl_deployment_appsearch_delete.md
@@ -31,6 +31,7 @@ ecctl deployment appsearch delete <deployment id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_appsearch_show.md
+++ b/docs/ecctl_deployment_appsearch_show.md
@@ -36,6 +36,7 @@ ecctl deployment appsearch show <deployment id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_appsearch_shutdown.md
+++ b/docs/ecctl_deployment_appsearch_shutdown.md
@@ -33,6 +33,7 @@ ecctl deployment appsearch shutdown <deployment id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_appsearch_upgrade.md
+++ b/docs/ecctl_deployment_appsearch_upgrade.md
@@ -32,6 +32,7 @@ ecctl deployment appsearch upgrade <deployment id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_create.md
+++ b/docs/ecctl_deployment_create.md
@@ -129,6 +129,7 @@ $ ecctl deployment create -f deployment_example.json --name adeploy --version=7.
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_delete.md
+++ b/docs/ecctl_deployment_delete.md
@@ -30,6 +30,7 @@ ecctl deployment delete <deployment-id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_elasticsearch.md
+++ b/docs/ecctl_deployment_elasticsearch.md
@@ -30,6 +30,7 @@ ecctl deployment elasticsearch [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_elasticsearch_console.md
+++ b/docs/ecctl_deployment_elasticsearch_console.md
@@ -43,6 +43,7 @@ ecctl deployment elasticsearch console <cluster id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_elasticsearch_delete.md
+++ b/docs/ecctl_deployment_elasticsearch_delete.md
@@ -32,6 +32,7 @@ ecctl deployment elasticsearch delete <cluster id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_elasticsearch_diagnose.md
+++ b/docs/ecctl_deployment_elasticsearch_diagnose.md
@@ -31,6 +31,7 @@ ecctl deployment elasticsearch diagnose <cluster id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_elasticsearch_instances.md
+++ b/docs/ecctl_deployment_elasticsearch_instances.md
@@ -30,6 +30,7 @@ ecctl deployment elasticsearch instances [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_elasticsearch_instances_override-capacity.md
+++ b/docs/ecctl_deployment_elasticsearch_instances_override-capacity.md
@@ -55,6 +55,7 @@ Set the cluster instance to 3x of its current capacity:
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_elasticsearch_instances_pause.md
+++ b/docs/ecctl_deployment_elasticsearch_instances_pause.md
@@ -32,6 +32,7 @@ ecctl deployment elasticsearch instances pause <cluster id> [--all|--instances] 
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_elasticsearch_instances_resume.md
+++ b/docs/ecctl_deployment_elasticsearch_instances_resume.md
@@ -32,6 +32,7 @@ ecctl deployment elasticsearch instances resume <cluster id> [--all|--instances]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_elasticsearch_instances_start-routing.md
+++ b/docs/ecctl_deployment_elasticsearch_instances_start-routing.md
@@ -32,6 +32,7 @@ ecctl deployment elasticsearch instances start-routing <cluster id> [--all|--ins
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_elasticsearch_instances_stop-routing.md
+++ b/docs/ecctl_deployment_elasticsearch_instances_stop-routing.md
@@ -32,6 +32,7 @@ ecctl deployment elasticsearch instances stop-routing <cluster id> [--all|--inst
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_elasticsearch_keystore.md
+++ b/docs/ecctl_deployment_elasticsearch_keystore.md
@@ -30,6 +30,7 @@ ecctl deployment elasticsearch keystore [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_elasticsearch_keystore_set.md
+++ b/docs/ecctl_deployment_elasticsearch_keystore_set.md
@@ -60,6 +60,7 @@ $ ecctl deployment elasticsearch keystore set 4c052fb17f65467a9b3c36d060106377 -
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_elasticsearch_keystore_show.md
+++ b/docs/ecctl_deployment_elasticsearch_keystore_show.md
@@ -46,6 +46,7 @@ $ ecctl deployment elasticsearch keystore show 4c052fb17f65467a9b3c36d060106377
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_elasticsearch_list.md
+++ b/docs/ecctl_deployment_elasticsearch_list.md
@@ -53,6 +53,7 @@ Read all the simple query string syntax in https://www.elastic.co/guide/en/elast
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_elasticsearch_monitoring.md
+++ b/docs/ecctl_deployment_elasticsearch_monitoring.md
@@ -30,6 +30,7 @@ ecctl deployment elasticsearch monitoring [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_elasticsearch_monitoring_disable.md
+++ b/docs/ecctl_deployment_elasticsearch_monitoring_disable.md
@@ -30,6 +30,7 @@ ecctl deployment elasticsearch monitoring disable <monitored cluster id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_elasticsearch_monitoring_enable.md
+++ b/docs/ecctl_deployment_elasticsearch_monitoring_enable.md
@@ -30,6 +30,7 @@ ecctl deployment elasticsearch monitoring enable <monitored cluster id> <monitor
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_elasticsearch_plan.md
+++ b/docs/ecctl_deployment_elasticsearch_plan.md
@@ -30,6 +30,7 @@ ecctl deployment elasticsearch plan [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_elasticsearch_plan_cancel.md
+++ b/docs/ecctl_deployment_elasticsearch_plan_cancel.md
@@ -30,6 +30,7 @@ ecctl deployment elasticsearch plan cancel <cluster id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_elasticsearch_plan_history.md
+++ b/docs/ecctl_deployment_elasticsearch_plan_history.md
@@ -30,6 +30,7 @@ ecctl deployment elasticsearch plan history <cluster id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_elasticsearch_plan_monitor.md
+++ b/docs/ecctl_deployment_elasticsearch_plan_monitor.md
@@ -32,6 +32,7 @@ ecctl deployment elasticsearch plan monitor <cluster id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_elasticsearch_plan_reapply.md
+++ b/docs/ecctl_deployment_elasticsearch_plan_reapply.md
@@ -43,6 +43,7 @@ ecctl deployment elasticsearch plan reapply <cluster id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_elasticsearch_plan_update.md
+++ b/docs/ecctl_deployment_elasticsearch_plan_update.md
@@ -36,6 +36,7 @@ ecctl deployment elasticsearch plan update <cluster id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_elasticsearch_reallocate.md
+++ b/docs/ecctl_deployment_elasticsearch_reallocate.md
@@ -32,6 +32,7 @@ ecctl deployment elasticsearch reallocate <cluster id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_elasticsearch_restart.md
+++ b/docs/ecctl_deployment_elasticsearch_restart.md
@@ -35,6 +35,7 @@ ecctl deployment elasticsearch restart <cluster id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_elasticsearch_resync.md
+++ b/docs/ecctl_deployment_elasticsearch_resync.md
@@ -30,6 +30,7 @@ ecctl deployment elasticsearch resync <cluster id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_elasticsearch_search.md
+++ b/docs/ecctl_deployment_elasticsearch_search.md
@@ -31,6 +31,7 @@ ecctl deployment elasticsearch search -f <query file>.json [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_elasticsearch_show.md
+++ b/docs/ecctl_deployment_elasticsearch_show.md
@@ -35,6 +35,7 @@ ecctl deployment elasticsearch show <cluster id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_elasticsearch_shutdown.md
+++ b/docs/ecctl_deployment_elasticsearch_shutdown.md
@@ -33,6 +33,7 @@ ecctl deployment elasticsearch shutdown <cluster id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_elasticsearch_start.md
+++ b/docs/ecctl_deployment_elasticsearch_start.md
@@ -31,6 +31,7 @@ ecctl deployment elasticsearch start <cluster id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_elasticsearch_upgrade.md
+++ b/docs/ecctl_deployment_elasticsearch_upgrade.md
@@ -32,6 +32,7 @@ ecctl deployment elasticsearch upgrade <cluster id> --version=<version> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_kibana.md
+++ b/docs/ecctl_deployment_kibana.md
@@ -30,6 +30,7 @@ ecctl deployment kibana [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_kibana_create.md
+++ b/docs/ecctl_deployment_kibana_create.md
@@ -92,6 +92,7 @@ $ cat kibana_create_example.json | dev-cli deployment kibana create --track --id
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_kibana_delete.md
+++ b/docs/ecctl_deployment_kibana_delete.md
@@ -32,6 +32,7 @@ ecctl deployment kibana delete <cluster id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_kibana_list.md
+++ b/docs/ecctl_deployment_kibana_list.md
@@ -33,6 +33,7 @@ ecctl deployment kibana list [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_kibana_plan.md
+++ b/docs/ecctl_deployment_kibana_plan.md
@@ -30,6 +30,7 @@ ecctl deployment kibana plan [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_kibana_plan_monitor.md
+++ b/docs/ecctl_deployment_kibana_plan_monitor.md
@@ -32,6 +32,7 @@ ecctl deployment kibana plan monitor <cluster id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_kibana_reallocate.md
+++ b/docs/ecctl_deployment_kibana_reallocate.md
@@ -31,6 +31,7 @@ ecctl deployment kibana reallocate <cluster id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_kibana_restart.md
+++ b/docs/ecctl_deployment_kibana_restart.md
@@ -31,6 +31,7 @@ ecctl deployment kibana restart <cluster id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_kibana_resync.md
+++ b/docs/ecctl_deployment_kibana_resync.md
@@ -31,6 +31,7 @@ ecctl deployment kibana resync {<deployment id> | --all} [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_kibana_show.md
+++ b/docs/ecctl_deployment_kibana_show.md
@@ -35,6 +35,7 @@ ecctl deployment kibana show <cluster id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_kibana_start.md
+++ b/docs/ecctl_deployment_kibana_start.md
@@ -31,6 +31,7 @@ ecctl deployment kibana start <cluster id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_kibana_stop.md
+++ b/docs/ecctl_deployment_kibana_stop.md
@@ -31,6 +31,7 @@ ecctl deployment kibana stop <cluster id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_kibana_upgrade.md
+++ b/docs/ecctl_deployment_kibana_upgrade.md
@@ -31,6 +31,7 @@ ecctl deployment kibana upgrade <cluster id>> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_list.md
+++ b/docs/ecctl_deployment_list.md
@@ -30,6 +30,7 @@ ecctl deployment list [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_note.md
+++ b/docs/ecctl_deployment_note.md
@@ -30,6 +30,7 @@ ecctl deployment note [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_note_create.md
+++ b/docs/ecctl_deployment_note_create.md
@@ -31,6 +31,7 @@ ecctl deployment note create <deployment id> --comment <comment content> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_note_list.md
+++ b/docs/ecctl_deployment_note_list.md
@@ -30,6 +30,7 @@ ecctl deployment note list <deployment id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_note_show.md
+++ b/docs/ecctl_deployment_note_show.md
@@ -31,6 +31,7 @@ ecctl deployment note show <deployment id> --id <note id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_note_update.md
+++ b/docs/ecctl_deployment_note_update.md
@@ -32,6 +32,7 @@ ecctl deployment note update <deployment id> --id <note id> --comment <comment c
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_plan.md
+++ b/docs/ecctl_deployment_plan.md
@@ -30,6 +30,7 @@ ecctl deployment plan [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_plan_cancel.md
+++ b/docs/ecctl_deployment_plan_cancel.md
@@ -32,6 +32,7 @@ ecctl deployment plan cancel <deployment id> --type <type> [--ref-id <ref-id>] [
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_resource.md
+++ b/docs/ecctl_deployment_resource.md
@@ -30,6 +30,7 @@ ecctl deployment resource [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_resource_delete.md
+++ b/docs/ecctl_deployment_resource_delete.md
@@ -32,6 +32,7 @@ ecctl deployment resource delete <deployment id> --type <type> --ref-id <ref-id>
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_resource_restore.md
+++ b/docs/ecctl_deployment_resource_restore.md
@@ -33,6 +33,7 @@ ecctl deployment resource restore <deployment id> --type <type> --ref-id <ref-id
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_resource_shutdown.md
+++ b/docs/ecctl_deployment_resource_shutdown.md
@@ -35,6 +35,7 @@ ecctl deployment resource shutdown <deployment id> --type <type> --ref-id <ref-i
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_resource_start-maintenance.md
+++ b/docs/ecctl_deployment_resource_start-maintenance.md
@@ -35,6 +35,7 @@ ecctl deployment resource start-maintenance <deployment id> --type <type> [--all
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_resource_start.md
+++ b/docs/ecctl_deployment_resource_start.md
@@ -35,6 +35,7 @@ ecctl deployment resource start <deployment id> --type <type> [--all|--i <instan
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_resource_stop-maintenance.md
+++ b/docs/ecctl_deployment_resource_stop-maintenance.md
@@ -35,6 +35,7 @@ ecctl deployment resource stop-maintenance <deployment id> --type <type> [--all|
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_resource_stop.md
+++ b/docs/ecctl_deployment_resource_stop.md
@@ -35,6 +35,7 @@ ecctl deployment resource stop <deployment id> --type <type> [--all|--i <instanc
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_resource_upgrade.md
+++ b/docs/ecctl_deployment_resource_upgrade.md
@@ -34,6 +34,7 @@ ecctl deployment resource upgrade <deployment id> --type <type> --ref-id <ref-id
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_restore.md
+++ b/docs/ecctl_deployment_restore.md
@@ -41,6 +41,7 @@ $ ecctl deployment restore 5c17ad7c8df73206baa54b6e2829d9bc
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_resync.md
+++ b/docs/ecctl_deployment_resync.md
@@ -31,6 +31,7 @@ ecctl deployment resync {<deployment id> | --all} [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_search.md
+++ b/docs/ecctl_deployment_search.md
@@ -46,6 +46,7 @@ $ ecctl deployment search -f query_string_query.json
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_show.md
+++ b/docs/ecctl_deployment_show.md
@@ -48,6 +48,7 @@ ecctl deployment show <deployment-id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_shutdown.md
+++ b/docs/ecctl_deployment_shutdown.md
@@ -33,6 +33,7 @@ ecctl deployment shutdown <deployment-id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_deployment_update.md
+++ b/docs/ecctl_deployment_update.md
@@ -130,6 +130,7 @@ setting --prune-orphans to "true" will cause any resources not specified in the 
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_generate.md
+++ b/docs/ecctl_generate.md
@@ -30,6 +30,7 @@ ecctl generate [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_generate_completions.md
+++ b/docs/ecctl_generate_completions.md
@@ -32,6 +32,7 @@ ecctl generate completions [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_generate_docs.md
+++ b/docs/ecctl_generate_docs.md
@@ -31,6 +31,7 @@ ecctl generate docs [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_init.md
+++ b/docs/ecctl_init.md
@@ -30,6 +30,7 @@ ecctl init [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform.md
+++ b/docs/ecctl_platform.md
@@ -30,6 +30,7 @@ ecctl platform [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_allocator.md
+++ b/docs/ecctl_platform_allocator.md
@@ -30,6 +30,7 @@ ecctl platform allocator [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_allocator_list.md
+++ b/docs/ecctl_platform_allocator_list.md
@@ -55,6 +55,7 @@ ecctl platform allocator list [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_allocator_maintenance.md
+++ b/docs/ecctl_platform_allocator_maintenance.md
@@ -31,6 +31,7 @@ ecctl platform allocator maintenance <allocator id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_allocator_metadata.md
+++ b/docs/ecctl_platform_allocator_metadata.md
@@ -30,6 +30,7 @@ ecctl platform allocator metadata [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_allocator_metadata_delete.md
+++ b/docs/ecctl_platform_allocator_metadata_delete.md
@@ -30,6 +30,7 @@ ecctl platform allocator metadata delete <allocator id> <key> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_allocator_metadata_set.md
+++ b/docs/ecctl_platform_allocator_metadata_set.md
@@ -30,6 +30,7 @@ ecctl platform allocator metadata set <allocator id> <key> <value> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_allocator_metadata_show.md
+++ b/docs/ecctl_platform_allocator_metadata_show.md
@@ -30,6 +30,7 @@ ecctl platform allocator metadata show <allocator id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_allocator_search.md
+++ b/docs/ecctl_platform_allocator_search.md
@@ -32,6 +32,7 @@ ecctl platform allocator search [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_allocator_show.md
+++ b/docs/ecctl_platform_allocator_show.md
@@ -31,6 +31,7 @@ ecctl platform allocator show <allocator id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_allocator_vacate.md
+++ b/docs/ecctl_platform_allocator_vacate.md
@@ -81,6 +81,7 @@ ecctl platform allocator vacate <source> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_constructor.md
+++ b/docs/ecctl_platform_constructor.md
@@ -30,6 +30,7 @@ ecctl platform constructor [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_constructor_list.md
+++ b/docs/ecctl_platform_constructor_list.md
@@ -30,6 +30,7 @@ ecctl platform constructor list [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_constructor_maintenance.md
+++ b/docs/ecctl_platform_constructor_maintenance.md
@@ -31,6 +31,7 @@ ecctl platform constructor maintenance <constructor id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_constructor_resync.md
+++ b/docs/ecctl_platform_constructor_resync.md
@@ -31,6 +31,7 @@ ecctl platform constructor resync {<constructor id> | --all} [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_constructor_show.md
+++ b/docs/ecctl_platform_constructor_show.md
@@ -30,6 +30,7 @@ ecctl platform constructor show <constructor id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_deployment-template.md
+++ b/docs/ecctl_platform_deployment-template.md
@@ -30,6 +30,7 @@ ecctl platform deployment-template [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_deployment-template_create.md
+++ b/docs/ecctl_platform_deployment-template_create.md
@@ -32,6 +32,7 @@ ecctl platform deployment-template create -f <template file>.json [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_deployment-template_delete.md
+++ b/docs/ecctl_platform_deployment-template_delete.md
@@ -30,6 +30,7 @@ ecctl platform deployment-template delete <template id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_deployment-template_list.md
+++ b/docs/ecctl_platform_deployment-template_list.md
@@ -33,6 +33,7 @@ ecctl platform deployment-template list [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_deployment-template_pull.md
+++ b/docs/ecctl_platform_deployment-template_pull.md
@@ -31,6 +31,7 @@ ecctl platform deployment-template pull --path <path> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_deployment-template_show.md
+++ b/docs/ecctl_platform_deployment-template_show.md
@@ -31,6 +31,7 @@ ecctl platform deployment-template show <template id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_deployment-template_update.md
+++ b/docs/ecctl_platform_deployment-template_update.md
@@ -31,6 +31,7 @@ ecctl platform deployment-template update <template id> -f <template file>.json 
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_enrollment-token.md
+++ b/docs/ecctl_platform_enrollment-token.md
@@ -30,6 +30,7 @@ ecctl platform enrollment-token [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_enrollment-token_create.md
+++ b/docs/ecctl_platform_enrollment-token_create.md
@@ -41,6 +41,7 @@ ecctl platform enrollment-token create --role <ROLE> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_enrollment-token_delete.md
+++ b/docs/ecctl_platform_enrollment-token_delete.md
@@ -30,6 +30,7 @@ ecctl platform enrollment-token delete <enrollment-token> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_enrollment-token_list.md
+++ b/docs/ecctl_platform_enrollment-token_list.md
@@ -30,6 +30,7 @@ ecctl platform enrollment-token list [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_info.md
+++ b/docs/ecctl_platform_info.md
@@ -30,6 +30,7 @@ ecctl platform info [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_instance-configuration.md
+++ b/docs/ecctl_platform_instance-configuration.md
@@ -30,6 +30,7 @@ ecctl platform instance-configuration [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_instance-configuration_create.md
+++ b/docs/ecctl_platform_instance-configuration_create.md
@@ -32,6 +32,7 @@ ecctl platform instance-configuration create -f <config.json> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_instance-configuration_delete.md
+++ b/docs/ecctl_platform_instance-configuration_delete.md
@@ -30,6 +30,7 @@ ecctl platform instance-configuration delete <config id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_instance-configuration_list.md
+++ b/docs/ecctl_platform_instance-configuration_list.md
@@ -30,6 +30,7 @@ ecctl platform instance-configuration list [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_instance-configuration_pull.md
+++ b/docs/ecctl_platform_instance-configuration_pull.md
@@ -31,6 +31,7 @@ ecctl platform instance-configuration pull --path <path> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_instance-configuration_show.md
+++ b/docs/ecctl_platform_instance-configuration_show.md
@@ -30,6 +30,7 @@ ecctl platform instance-configuration show <config id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_instance-configuration_update.md
+++ b/docs/ecctl_platform_instance-configuration_update.md
@@ -31,6 +31,7 @@ ecctl platform instance-configuration update <config id> -f <config.json> [flags
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_proxy.md
+++ b/docs/ecctl_platform_proxy.md
@@ -30,6 +30,7 @@ ecctl platform proxy [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_proxy_filtered-group.md
+++ b/docs/ecctl_platform_proxy_filtered-group.md
@@ -30,6 +30,7 @@ ecctl platform proxy filtered-group [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_proxy_filtered-group_create.md
+++ b/docs/ecctl_platform_proxy_filtered-group_create.md
@@ -32,6 +32,7 @@ ecctl platform proxy filtered-group create <filtered group id> --filters <key1=v
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_proxy_filtered-group_delete.md
+++ b/docs/ecctl_platform_proxy_filtered-group_delete.md
@@ -30,6 +30,7 @@ ecctl platform proxy filtered-group delete <filtered group id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_proxy_filtered-group_list.md
+++ b/docs/ecctl_platform_proxy_filtered-group_list.md
@@ -30,6 +30,7 @@ ecctl platform proxy filtered-group list [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_proxy_filtered-group_show.md
+++ b/docs/ecctl_platform_proxy_filtered-group_show.md
@@ -30,6 +30,7 @@ ecctl platform proxy filtered-group show <filtered group id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_proxy_filtered-group_update.md
+++ b/docs/ecctl_platform_proxy_filtered-group_update.md
@@ -33,6 +33,7 @@ ecctl platform proxy filtered-group update <filtered group id> --filters <key1=v
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_proxy_list.md
+++ b/docs/ecctl_platform_proxy_list.md
@@ -30,6 +30,7 @@ ecctl platform proxy list [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_proxy_show.md
+++ b/docs/ecctl_platform_proxy_show.md
@@ -30,6 +30,7 @@ ecctl platform proxy show <proxy id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_repository.md
+++ b/docs/ecctl_platform_repository.md
@@ -32,6 +32,7 @@ ecctl platform repository [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_repository_create.md
+++ b/docs/ecctl_platform_repository_create.md
@@ -52,6 +52,7 @@ ecctl platform repository create custom --type fs --settings settings.yml
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_repository_delete.md
+++ b/docs/ecctl_platform_repository_delete.md
@@ -30,6 +30,7 @@ ecctl platform repository delete <repository name> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_repository_list.md
+++ b/docs/ecctl_platform_repository_list.md
@@ -30,6 +30,7 @@ ecctl platform repository list [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_repository_show.md
+++ b/docs/ecctl_platform_repository_show.md
@@ -30,6 +30,7 @@ ecctl platform repository show <repository name> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_role.md
+++ b/docs/ecctl_platform_role.md
@@ -30,6 +30,7 @@ ecctl platform role [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_role_create.md
+++ b/docs/ecctl_platform_role_create.md
@@ -31,6 +31,7 @@ ecctl platform role create --file <filename.json> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_role_delete.md
+++ b/docs/ecctl_platform_role_delete.md
@@ -30,6 +30,7 @@ ecctl platform role delete <role> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_role_list.md
+++ b/docs/ecctl_platform_role_list.md
@@ -30,6 +30,7 @@ ecctl platform role list [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_role_show.md
+++ b/docs/ecctl_platform_role_show.md
@@ -30,6 +30,7 @@ ecctl platform role show <role> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_runner.md
+++ b/docs/ecctl_platform_runner.md
@@ -30,6 +30,7 @@ ecctl platform runner [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_runner_list.md
+++ b/docs/ecctl_platform_runner_list.md
@@ -30,6 +30,7 @@ ecctl platform runner list [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_runner_resync.md
+++ b/docs/ecctl_platform_runner_resync.md
@@ -31,6 +31,7 @@ ecctl platform runner resync {<runner id> | --all} [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_runner_search.md
+++ b/docs/ecctl_platform_runner_search.md
@@ -32,6 +32,7 @@ ecctl platform runner search [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_runner_show.md
+++ b/docs/ecctl_platform_runner_show.md
@@ -30,6 +30,7 @@ ecctl platform runner show <runner id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_stack.md
+++ b/docs/ecctl_platform_stack.md
@@ -30,6 +30,7 @@ ecctl platform stack [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_stack_delete.md
+++ b/docs/ecctl_platform_stack_delete.md
@@ -30,6 +30,7 @@ ecctl platform stack delete [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_stack_list.md
+++ b/docs/ecctl_platform_stack_list.md
@@ -31,6 +31,7 @@ ecctl platform stack list [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_stack_show.md
+++ b/docs/ecctl_platform_stack_show.md
@@ -30,6 +30,7 @@ ecctl platform stack show [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_platform_stack_upload.md
+++ b/docs/ecctl_platform_stack_upload.md
@@ -30,6 +30,7 @@ ecctl platform stack upload [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_user.md
+++ b/docs/ecctl_user.md
@@ -30,6 +30,7 @@ ecctl user [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_user_create.md
+++ b/docs/ecctl_user_create.md
@@ -45,6 +45,7 @@ ecctl user create --username <username> --role <role> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_user_delete.md
+++ b/docs/ecctl_user_delete.md
@@ -30,6 +30,7 @@ ecctl user delete <user name> <user name>... [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_user_disable.md
+++ b/docs/ecctl_user_disable.md
@@ -30,6 +30,7 @@ ecctl user disable <username> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_user_enable.md
+++ b/docs/ecctl_user_enable.md
@@ -30,6 +30,7 @@ ecctl user enable <username> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_user_key.md
+++ b/docs/ecctl_user_key.md
@@ -30,6 +30,7 @@ ecctl user key [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_user_key_delete.md
+++ b/docs/ecctl_user_key_delete.md
@@ -30,6 +30,7 @@ ecctl user key delete --user=<user id> <key id> <key id>... [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_user_key_list.md
+++ b/docs/ecctl_user_key_list.md
@@ -31,6 +31,7 @@ ecctl user key list --user=<user id>|--all [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_user_key_show.md
+++ b/docs/ecctl_user_key_show.md
@@ -30,6 +30,7 @@ ecctl user key show --user=<user id> <key id> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_user_list.md
+++ b/docs/ecctl_user_list.md
@@ -30,6 +30,7 @@ ecctl user list [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_user_show.md
+++ b/docs/ecctl_user_show.md
@@ -31,6 +31,7 @@ ecctl user show <user name> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_user_update.md
+++ b/docs/ecctl_user_update.md
@@ -50,6 +50,7 @@ ecctl user update <username> --role <role> [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)

--- a/docs/ecctl_version.md
+++ b/docs/ecctl_version.md
@@ -30,6 +30,7 @@ ecctl version [flags]
       --pass string        Password to use to authenticate (If empty will look for EC_PASS environment variable)
       --pprof              Enables pprofing and saves the profile to pprof-20060102150405
   -q, --quiet              Suppresses the configuration file used for the run, if any
+      --region string      Elasticsearch Service region
       --timeout duration   Timeout to use on all HTTP calls (default 30s)
       --trace              Enables tracing saves the trace to trace-20060102150405
       --user string        Username to use to authenticate (If empty will look for EC_USER environment variable)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Removes `MarkHidden("region")` method so the --region flag is visible again for ESS public API release.

I've also changed the "Elastic Cloud" wording for "Elasticsearch Service" following the feedback in this PR https://github.com/elastic/ecctl/pull/190 . @Kushmaro and @nrichers please let me know if this is accurate.

## Related Issues
https://github.com/elastic/ecctl/issues/161

## Motivation and Context
regions  flag should be visible for ESS users

## How Has This Been Tested?
make docs

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
