### PR TITLE
init: Provide alternative API validation call

### DIFF
--- a/pkg/ecctl/init.go
+++ b/pkg/ecctl/init.go
@@ -105,7 +105,7 @@ const (
 
 	validCredentialsMsg            = "Your credentials seem to be valid, and show you're authenticated as \"%s\".\n\n"
 	validCredentialsAlternativeMsg = "Your credentials seem to be valid.\n\n"
-	invalidCredentialsMsg          = "your credentials couldn't be validated make sure they're correct and try again"
+	invalidCredentialsMsg          = "Your credentials couldn't be validated. Make sure they're correct and try again"
 )
 
 var (
@@ -485,6 +485,7 @@ func validateAuth(cfg Config, writer io.Writer) error {
 		if _, e := deployment.List(deployment.ListParams{
 			API: a.API,
 		}); e != nil {
+			// nolint
 			return errors.New(invalidCredentialsMsg)
 		}
 		fmt.Fprint(writer, validCredentialsAlternativeMsg)

--- a/pkg/ecctl/init.go
+++ b/pkg/ecctl/init.go
@@ -105,7 +105,7 @@ const (
 
 	validCredentialsMsg            = "Your credentials seem to be valid, and show you're authenticated as \"%s\".\n\n"
 	validCredentialsAlternativeMsg = "Your credentials seem to be valid.\n\n"
-	invalidCredentialsMsg          = "Your credentials couldn't be validated, please make sure they're correct.\n\n"
+	invalidCredentialsMsg          = "your credentials couldn't be validated make sure they're correct and try again"
 )
 
 var (

--- a/pkg/ecctl/init.go
+++ b/pkg/ecctl/init.go
@@ -28,6 +28,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/elastic/ecctl/pkg/deployment"
 	"github.com/elastic/ecctl/pkg/user"
 
 	"github.com/elastic/cloud-sdk-go/pkg/input"
@@ -102,7 +103,9 @@ const (
 	//nolint
 	passMsg = "Type in your password: "
 
-	validCredentialsMsg = "Your credentials seem to be valid, and show you're authenticated as \"%s\".\n\n"
+	validCredentialsMsg            = "Your credentials seem to be valid, and show you're authenticated as \"%s\".\n\n"
+	validCredentialsAlternativeMsg = "Your credentials seem to be valid.\n\n"
+	invalidCredentialsMsg          = "Your credentials couldn't be validated, please make sure they're correct.\n\n"
 )
 
 var (
@@ -166,7 +169,6 @@ Please enter a choice: `
 
 	finalMsg = `
 You're all set! Here are some commands to try:
-  $ ecctl auth user key list
   $ ecctl deployment elasticsearch list`[1:]
 
 	// Remove once we have an endpoint available to list regions.
@@ -480,7 +482,13 @@ func validateAuth(cfg Config, writer io.Writer) error {
 
 	u, err := user.GetCurrent(user.GetCurrentParams{API: a.API})
 	if err != nil {
-		return err
+		if _, e := deployment.List(deployment.ListParams{
+			API: a.API,
+		}); e != nil {
+			return errors.New(invalidCredentialsMsg)
+		}
+		fmt.Fprint(writer, validCredentialsAlternativeMsg)
+		return nil
 	}
 
 	fmt.Fprintf(writer, validCredentialsMsg, *u.UserName)


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail. -->
Changes the message returned when the API call to validate the API key
cannot be made, and tries a different api (GET /deployments) before
returning a more curated error.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
#161 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Provide better messages for the init workflow.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

### Incorrect credentials

```console
$ ecctl init
Welcome to Elastic Cloud Control (ecctl)! This command will guide you through authenticating and setting some default values.

Missing configuration file, would you like to initialise it? [y/n]: y

Select which type of Elastic Cloud offering you will be working with:
  [1] Elasticsearch Service (default).
  [2] Elastic Cloud Enterprise (ECE).
  [3] Elasticsearch Service Private (ESSP).

Please enter your choice: 2

Enter the URL of your ECE installation: https://PUBLIC_API

Which authentication mechanism would you like to use?
  [1] API Keys (Recommended).
  [2] Username and Password login.

Please enter your choice: 1

Paste your API Key and press enter:

What default output format would you like?
  [1] text - Human-readable output format, commands with no output templates defined will fall back to JSON.
  [2] json - JSON formatted output API responses.

Please enter a choice: 1


Your credentials couldn't be validated, please make sure they're correct.


exit status 255
```

### Correct credentials

```console
$ ecctl init
Welcome to Elastic Cloud Control (ecctl)! This command will guide you through authenticating and setting some default values.

Missing configuration file, would you like to initialise it? [y/n]: y

Select which type of Elastic Cloud offering you will be working with:
  [1] Elasticsearch Service (default).
  [2] Elastic Cloud Enterprise (ECE).
  [3] Elasticsearch Service Private (ESSP).

Please enter your choice: 2

Enter the URL of your ECE installation: https://PUBLIC_API

Which authentication mechanism would you like to use?
  [1] API Keys (Recommended).
  [2] Username and Password login.

Please enter your choice: 1

Paste your API Key and press enter:

What default output format would you like?
  [1] text - Human-readable output format, commands with no output templates defined will fall back to JSON.
  [2] json - JSON formatted output API responses.

Please enter a choice: 1


Your credentials seem to be valid.

You're all set! Here are some commands to try:
  $ ecctl deployment elasticsearch list

Config written to /Users/marc/.ecctl/config.json

```

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
