### PR TITLE
deployment: Add --plan-history flag to show cmd

### DIFF
--- a/cmd/deployment/show.go
+++ b/cmd/deployment/show.go
@@ -51,10 +51,11 @@ var showCmd = &cobra.Command{
 
 		planLogs, _ := cmd.Flags().GetBool("plan-logs")
 		planDefaults, _ := cmd.Flags().GetBool("plan-defaults")
+		planHistory, _ := cmd.Flags().GetBool("plan-history")
 		metadata, _ := cmd.Flags().GetBool("metadata")
 		settings, _ := cmd.Flags().GetBool("settings")
 		plans, _ := cmd.Flags().GetBool("plans")
-		showPlans := planLogs || planDefaults || plans
+		showPlans := planLogs || planDefaults || plans || planHistory
 
 		refID, _ := cmd.Flags().GetString("ref-id")
 		getParams := deployment.GetParams{
@@ -65,6 +66,7 @@ var showCmd = &cobra.Command{
 				ShowPlans:        showPlans,
 				ShowPlanLogs:     planLogs,
 				ShowPlanDefaults: planDefaults,
+				ShowPlanHistory:  planHistory,
 				ShowMetadata:     metadata,
 				ShowSettings:     settings,
 			},
@@ -89,6 +91,7 @@ func init() {
 	showCmd.Flags().Bool("plans", false, "Shows the deployment plans")
 	showCmd.Flags().Bool("plan-logs", false, "Shows the deployment plan logs")
 	showCmd.Flags().Bool("plan-defaults", false, "Shows the deployment plan defaults")
+	showCmd.Flags().Bool("plan-history", false, "Shows the deployment plan history")
 	showCmd.Flags().BoolP("metadata", "m", false, "Shows the deployment metadata")
 	showCmd.Flags().BoolP("settings", "s", false, "Shows the deployment settings")
 }

--- a/docs/ecctl_deployment_show.md
+++ b/docs/ecctl_deployment_show.md
@@ -27,6 +27,7 @@ ecctl deployment show <deployment-id> [flags]
   -h, --help            help for show
   -m, --metadata        Shows the deployment metadata
       --plan-defaults   Shows the deployment plan defaults
+      --plan-history    Shows the deployment plan history
       --plan-logs       Shows the deployment plan logs
       --plans           Shows the deployment plans
       --ref-id string   Optional deployment type RefId, if not set, the RefId will be auto-discovered

--- a/pkg/deployment/deputil/deputil.go
+++ b/pkg/deployment/deputil/deputil.go
@@ -101,6 +101,7 @@ type QueryParams struct {
 	ShowPlans        bool
 	ShowPlanDefaults bool
 	ShowPlanLogs     bool
+	ShowPlanHistory  bool
 	ShowMetadata     bool
 	ShowSettings     bool
 

--- a/pkg/deployment/get.go
+++ b/pkg/deployment/get.go
@@ -69,6 +69,7 @@ func Get(params GetParams) (*models.DeploymentGetResponse, error) {
 			WithShowPlans(ec.Bool(params.ShowPlans)).
 			WithShowPlanDefaults(ec.Bool(params.ShowPlanDefaults)).
 			WithShowPlanLogs(ec.Bool(params.ShowPlanLogs)).
+			WithShowPlanHistory(ec.Bool(params.ShowPlanHistory)).
 			WithShowMetadata(ec.Bool(params.ShowMetadata)).
 			WithShowSettings(ec.Bool(params.ShowSettings)).
 			WithShowSystemAlerts(systemAlerts),


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail. -->
Adds a `--plan-history` flag to `ecctl deployment show` to be able to
obtain the Deployment's plan history.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
While working on elastic/cloud-sdk-go#34 I noticed that there
was no way to obtain the plan history through ecctl. So added this flag.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
