### PR TITLE
release: Change GitHub token for Tap modifications

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
         env:
           # elasticcloudmachine GitHub token.
           GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GH_TOKEN }}
-          GITHUB_USER: marclop
+          GITHUB_USER: elasticcloudmachine
           VERSION: ${{ steps.get_version.outputs.VERSION }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,8 +55,9 @@ jobs:
 
       - name: Run release post actions
         run: ./scripts/goreleaser-post-actions.sh $VERSION
-        env: 
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_EXTRA }}
+        env:
+          # elasticcloudmachine GitHub token.
+          GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GH_TOKEN }}
           GITHUB_USER: marclop
           VERSION: ${{ steps.get_version.outputs.VERSION }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail. -->
Changes the GitHub Personal Access Token which is used to create a PR
against elastic/tap to update ecctl's homebrew formula.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Resolves #140 
