### PR TITLE
cmd: Handle case when deployment template does not include resource

### DIFF
--- a/pkg/deployment/depresource/apm.go
+++ b/pkg/deployment/depresource/apm.go
@@ -18,6 +18,8 @@
 package depresource
 
 import (
+	"fmt"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/client/platform_configuration_templates"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
@@ -54,6 +56,11 @@ func NewApm(params NewStateless) (*models.ApmPayload, error) {
 	)
 	if err != nil {
 		return nil, api.UnwrapError(err)
+	}
+
+	if res.Payload.ClusterTemplate.Apm == nil {
+		return nil, fmt.Errorf("deployment: the %s template is not configured for APM. Please use another template if you wish to start APM instances",
+			params.TemplateID)
 	}
 
 	var clusterTopology = res.Payload.ClusterTemplate.Apm.Plan.ClusterTopology

--- a/pkg/deployment/depresource/apm_test.go
+++ b/pkg/deployment/depresource/apm_test.go
@@ -54,6 +54,15 @@ var apmTemplateResponse = models.DeploymentTemplateInfo{
 	},
 }
 
+var crossClusterTemplateResponse = models.DeploymentTemplateInfo{
+	ID: "cross-cluster-search",
+	ClusterTemplate: &models.DeploymentTemplateDefinitionRequest{
+		Plan: &models.ElasticsearchClusterPlan{
+			ClusterTopology: defaultESTopologies,
+		},
+	},
+}
+
 func TestNewApm(t *testing.T) {
 	var internalError = models.BasicFailedReply{
 		Errors: []*models.BasicFailedReplyElement{
@@ -138,6 +147,18 @@ func TestNewApm(t *testing.T) {
 				Region: "ece-region",
 			}},
 			err: errors.New(string(internalErrorBytes)),
+		},
+		{
+			name: "obtains the deployment template but it's an invalid template for appsearch",
+			args: args{params: NewStateless{
+				DeploymentID: util.ValidClusterID,
+				API: api.NewMock(
+					mock.New200Response(mock.NewStructBody(getResponse)),
+					mock.New200Response(mock.NewStructBody(crossClusterTemplateResponse)),
+				),
+				Region: "ece-region",
+			}},
+			err: errors.New("deployment: the an ID template is not configured for APM. Please use another template if you wish to start APM instances"),
 		},
 		{
 			name: "succeeds with no argument override",

--- a/pkg/deployment/depresource/appsearch.go
+++ b/pkg/deployment/depresource/appsearch.go
@@ -18,6 +18,8 @@
 package depresource
 
 import (
+	"fmt"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/client/platform_configuration_templates"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
@@ -54,6 +56,11 @@ func NewAppSearch(params NewStateless) (*models.AppSearchPayload, error) {
 	)
 	if err != nil {
 		return nil, api.UnwrapError(err)
+	}
+
+	if res.Payload.ClusterTemplate.Appsearch == nil {
+		return nil, fmt.Errorf("deployment: the %s template is not configured for AppSearch. Please use another template if you wish to start AppSearch instances",
+			params.TemplateID)
 	}
 
 	var clusterTopology = res.Payload.ClusterTemplate.Appsearch.Plan.ClusterTopology

--- a/pkg/deployment/depresource/appsearch_test.go
+++ b/pkg/deployment/depresource/appsearch_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 var appsearchTemplateResponse = models.DeploymentTemplateInfo{
-	ID: "default",
+	ID: "default.appsearch",
 	ClusterTemplate: &models.DeploymentTemplateDefinitionRequest{
 		Appsearch: &models.CreateAppSearchRequest{
 			Plan: &models.AppSearchPlan{
@@ -48,6 +48,15 @@ var appsearchTemplateResponse = models.DeploymentTemplateInfo{
 				},
 			},
 		},
+		Plan: &models.ElasticsearchClusterPlan{
+			ClusterTopology: defaultESTopologies,
+		},
+	},
+}
+
+var defaultTemplateResponse = models.DeploymentTemplateInfo{
+	ID: "default",
+	ClusterTemplate: &models.DeploymentTemplateDefinitionRequest{
 		Plan: &models.ElasticsearchClusterPlan{
 			ClusterTopology: defaultESTopologies,
 		},
@@ -138,6 +147,18 @@ func TestNewAppSearch(t *testing.T) {
 				Region: "ece-region",
 			}},
 			err: errors.New(string(internalErrorBytes)),
+		},
+		{
+			name: "obtains the deployment template but it's an invalid template for appsearch",
+			args: args{params: NewStateless{
+				DeploymentID: util.ValidClusterID,
+				API: api.NewMock(
+					mock.New200Response(mock.NewStructBody(getResponse)),
+					mock.New200Response(mock.NewStructBody(defaultTemplateResponse)),
+				),
+				Region: "ece-region",
+			}},
+			err: errors.New("deployment: the an ID template is not configured for AppSearch. Please use another template if you wish to start AppSearch instances"),
 		},
 		{
 			name: "succeeds with no argument override",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Fixes a bug where the application would panic if it could not find the desired resource kind in the deployment template.

## Related Issues
Found while working on https://github.com/elastic/ecctl/issues/116

## Motivation and Context
panics are annoying

## How Has This Been Tested?
Manually and through unit tests

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
