### PR TITLE
cmd: Handle case when deployment template does not include kibana

### DIFF
--- a/pkg/deployment/depresource/kibana.go
+++ b/pkg/deployment/depresource/kibana.go
@@ -18,6 +18,8 @@
 package depresource
 
 import (
+	"fmt"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/client/platform_configuration_templates"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
@@ -54,6 +56,11 @@ func NewKibana(params NewStateless) (*models.KibanaPayload, error) {
 	)
 	if err != nil {
 		return nil, api.UnwrapError(err)
+	}
+
+	if res.Payload.ClusterTemplate.Kibana == nil {
+		return nil, fmt.Errorf("deployment: the %s template is not configured for Kibana. Please use another template if you wish to start Kibana instances",
+			params.TemplateID)
 	}
 
 	var clusterTopology = res.Payload.ClusterTemplate.Kibana.Plan.ClusterTopology

--- a/pkg/deployment/depresource/kibana_test.go
+++ b/pkg/deployment/depresource/kibana_test.go
@@ -54,6 +54,15 @@ var kibanaTemplateResponse = models.DeploymentTemplateInfo{
 	},
 }
 
+var invalidTemplateResponse = models.DeploymentTemplateInfo{
+	ID: "invalid",
+	ClusterTemplate: &models.DeploymentTemplateDefinitionRequest{
+		Plan: &models.ElasticsearchClusterPlan{
+			ClusterTopology: defaultESTopologies,
+		},
+	},
+}
+
 func TestNewKibana(t *testing.T) {
 	var internalError = models.BasicFailedReply{
 		Errors: []*models.BasicFailedReplyElement{
@@ -138,6 +147,18 @@ func TestNewKibana(t *testing.T) {
 				Region: "ece-region",
 			}},
 			err: errors.New(string(internalErrorBytes)),
+		},
+		{
+			name: "obtains the deployment template but it's an invalid template for kibana",
+			args: args{params: NewStateless{
+				DeploymentID: util.ValidClusterID,
+				API: api.NewMock(
+					mock.New200Response(mock.NewStructBody(getResponse)),
+					mock.New200Response(mock.NewStructBody(invalidTemplateResponse)),
+				),
+				Region: "ece-region",
+			}},
+			err: errors.New("deployment: the an ID template is not configured for Kibana. Please use another template if you wish to start Kibana instances"),
 		},
 		{
 			name: "succeeds with no argument override",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Fixes a bug where the application would panic if it could not find the desired resource kind in the deployment template.

## Related Issues
https://github.com/elastic/ecctl/pull/205

## How Has This Been Tested?
Manually and unit tests
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
