### PR TITLE
init: Revert to ECE only workflow with bool toggle

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -49,6 +49,8 @@ var initCmd = &cobra.Command{
 			ErrWriter:        defaultError,
 			PasswordReadFunc: terminal.ReadPassword,
 			FilePath:         filepath.Join(fp, defaultViper.GetString("config")),
+			// Feature toggle to display slightly different information.
+			PublicAPINotReleased: true,
 		})
 		if err != nil {
 			return err

--- a/pkg/ecctl/init.go
+++ b/pkg/ecctl/init.go
@@ -226,6 +226,10 @@ type InitConfigParams struct {
 
 	// FilePath of the configuration
 	FilePath string
+
+	// PublicAPINotReleased will be removed very soon, using it to toggle a
+	// different workflow path.
+	PublicAPINotReleased bool
 }
 
 // Validate ensures the parameters are usable.
@@ -301,7 +305,15 @@ func InitConfig(params InitConfigParams) error {
 	// endpoints with self-signed certificates.
 	cfg.Insecure = true
 
-	if err := askInfraSelection(&cfg, scanner, params.Writer, params.ErrWriter, params.PasswordReadFunc); err != nil {
+	if params.PublicAPINotReleased {
+		fmt.Fprintln(params.Writer)
+		// Set region back to empty since it'll be an ECE environment
+		cfg.Region = ""
+		cfg.Host = scanner.Scan(eceHostMsg)
+		if err := askAuthMechanism(&cfg, scanner, params.Writer, params.PasswordReadFunc); err != nil {
+			return err
+		}
+	} else if err := askInfraSelection(&cfg, scanner, params.Writer, params.ErrWriter, params.PasswordReadFunc); err != nil {
 		return err
 	}
 

--- a/pkg/ecctl/init_test.go
+++ b/pkg/ecctl/init_test.go
@@ -269,6 +269,39 @@ func TestInitConfig(t *testing.T) {
 				fmt.Sprintf(validCredentialsMsg, "anacleto") + finalMsg + "\n",
 		},
 		{
+			name: "no config file with apikey creates a new one when no public api",
+			args: args{params: InitConfigParams{
+				Viper:                emptyViperToCreateConfig,
+				FilePath:             filepath.Join(testFiles, "newConfig-ECE-NO-PUBLIC-API"),
+				PublicAPINotReleased: true,
+				Reader: io.MultiReader(
+					strings.NewReader("y\n"),
+					strings.NewReader("https://ahost\n"),
+					strings.NewReader("1\n"),
+					strings.NewReader("1\n"),
+					strings.NewReader("anapikey\n"),
+					strings.NewReader("1\n"),
+				),
+				Writer:    new(bytes.Buffer),
+				ErrWriter: new(bytes.Buffer),
+				PasswordReadFunc: func(int) ([]byte, error) {
+					return []byte("somekey"), nil
+				},
+				Client: mock.NewClient(mock.New200Response(mock.NewStructBody(models.User{
+					UserName: ec.String("anacleto"),
+				}))),
+			}},
+			wantSettings: map[string]interface{}{
+				"apikey":   "somekey",
+				"host":     "https://ahost",
+				"insecure": true,
+				"output":   "text",
+			},
+			wantOutput: disclaimer + missingConfigMsg + "\n" + eceHostMsg + authChoiceMsg +
+				"\n" + apiKeyMsg + "\n" + formatChoiceMsg + "\n" + "\n" +
+				fmt.Sprintf(validCredentialsMsg, "anacleto") + finalMsg + "\n",
+		},
+		{
 			name: "doesn't find a config file and user creates a new one with user/pass",
 			args: args{params: InitConfigParams{
 				Viper:    emptyViperToCreateConfigUserPass,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Reverts back to printing ECE only information through a boolean
parameter in the Params struct which controls which workflow is used.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Public API is still not available. Will disable this toggle once it is.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

```console
$ ecctl init
Welcome to Elastic Cloud Control (ecctl)! This command will guide you through authenticating and setting some default values.

Missing configuration file, would you like to initialise it? [y/n]: y

Enter the URL of your ECE installation: https://XXXX:12343

Which authentication mechanism would you like to use?
  [1] API Keys (Recommended).
  [2] Username and Password login.

Please enter your choice: 2

Type in your username: admin
Type in your password:

What default output format would you like?
  [1] text - Human-readable output format, commands with no output templates defined will fall back to JSON.
  [2] json - JSON formatted output API responses.

Please enter a choice: 1


Your credentials seem to be valid, and show you're authenticated as "admin".

You're all set! Here are some commands to try:
  $ ecctl deployment elasticsearch list

Config written to /Users/marc/.ecctl/config.json

```

