### PR TITLE
init: Change example command to deployment list

### DIFF
--- a/pkg/ecctl/init.go
+++ b/pkg/ecctl/init.go
@@ -169,7 +169,7 @@ Please enter a choice: `
 
 	finalMsg = `
 You're all set! Here are some commands to try:
-  $ ecctl deployment elasticsearch list`[1:]
+  $ ecctl deployment list`[1:]
 
 	// Remove once we have an endpoint available to list regions.
 	essRegions = map[int]string{


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail. -->
Changes the example command after a successful ecctl initialization from
`ecctl deployment elasticsearch list` to `ecctl deployment list`.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Resolves #216 

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
