### PR TITLE
cmd: specify that deployment template commands are ECE specific

### DIFF
--- a/cmd/platform/deployment-template/command.go
+++ b/cmd/platform/deployment-template/command.go
@@ -26,10 +26,11 @@ import (
 
 	"github.com/elastic/cloud-sdk-go/pkg/input"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
-	"github.com/elastic/cloud-sdk-go/pkg/util/cmdutil"
+	sdkcmdutil "github.com/elastic/cloud-sdk-go/pkg/util/cmdutil"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 	"github.com/elastic/ecctl/pkg/platform/deployment"
 )
@@ -43,7 +44,7 @@ const (
 // Command represents the top level deployment-template command.
 var Command = &cobra.Command{
 	Use:     "deployment-template",
-	Short:   "Manages deployment templates",
+	Short:   cmdutil.AdminReqDescription("Manages deployment templates"),
 	PreRunE: cobra.MaximumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()
@@ -122,7 +123,7 @@ var platformDeploymentTemplateCreateCmd = &cobra.Command{
 	Short:   "Creates a platform deployment template",
 	PreRunE: cobra.MaximumNArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := cmdutil.FileOrStdin(cmd, "file-template"); err != nil {
+		if err := sdkcmdutil.FileOrStdin(cmd, "file-template"); err != nil {
 			return err
 		}
 
@@ -155,7 +156,7 @@ var platformDeploymentTemplateUpdateCmd = &cobra.Command{
 	Short:   "Updates a platform deployment template",
 	PreRunE: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := cmdutil.FileOrStdin(cmd, "file-template"); err != nil {
+		if err := sdkcmdutil.FileOrStdin(cmd, "file-template"); err != nil {
 			return err
 		}
 		tc, err := parseTemplateFile(cmd.Flag("file-template").Value.String())

--- a/docs/ecctl_platform.md
+++ b/docs/ecctl_platform.md
@@ -42,7 +42,7 @@ ecctl platform [flags]
 * [ecctl](ecctl.md)	 - Elastic Cloud Control
 * [ecctl platform allocator](ecctl_platform_allocator.md)	 - Manages allocators (Available for ECE only)
 * [ecctl platform constructor](ecctl_platform_constructor.md)	 - Manages constructors (Available for ECE only)
-* [ecctl platform deployment-template](ecctl_platform_deployment-template.md)	 - Manages deployment templates
+* [ecctl platform deployment-template](ecctl_platform_deployment-template.md)	 - Manages deployment templates (Available for ECE only)
 * [ecctl platform enrollment-token](ecctl_platform_enrollment-token.md)	 - Manages tokens (Available for ECE only)
 * [ecctl platform info](ecctl_platform_info.md)	 - Shows information about the platform (Available for ECE only)
 * [ecctl platform instance-configuration](ecctl_platform_instance-configuration.md)	 - Manages instance configurations (Available for ECE only)

--- a/docs/ecctl_platform_deployment-template.md
+++ b/docs/ecctl_platform_deployment-template.md
@@ -1,10 +1,10 @@
 ## ecctl platform deployment-template
 
-Manages deployment templates
+Manages deployment templates (Available for ECE only)
 
 ### Synopsis
 
-Manages deployment templates
+Manages deployment templates (Available for ECE only)
 
 ```
 ecctl platform deployment-template [flags]

--- a/docs/ecctl_platform_deployment-template_create.md
+++ b/docs/ecctl_platform_deployment-template_create.md
@@ -41,5 +41,5 @@ ecctl platform deployment-template create -f <template file>.json [flags]
 
 ### SEE ALSO
 
-* [ecctl platform deployment-template](ecctl_platform_deployment-template.md)	 - Manages deployment templates
+* [ecctl platform deployment-template](ecctl_platform_deployment-template.md)	 - Manages deployment templates (Available for ECE only)
 

--- a/docs/ecctl_platform_deployment-template_delete.md
+++ b/docs/ecctl_platform_deployment-template_delete.md
@@ -39,5 +39,5 @@ ecctl platform deployment-template delete <template id> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform deployment-template](ecctl_platform_deployment-template.md)	 - Manages deployment templates
+* [ecctl platform deployment-template](ecctl_platform_deployment-template.md)	 - Manages deployment templates (Available for ECE only)
 

--- a/docs/ecctl_platform_deployment-template_list.md
+++ b/docs/ecctl_platform_deployment-template_list.md
@@ -42,5 +42,5 @@ ecctl platform deployment-template list [flags]
 
 ### SEE ALSO
 
-* [ecctl platform deployment-template](ecctl_platform_deployment-template.md)	 - Manages deployment templates
+* [ecctl platform deployment-template](ecctl_platform_deployment-template.md)	 - Manages deployment templates (Available for ECE only)
 

--- a/docs/ecctl_platform_deployment-template_pull.md
+++ b/docs/ecctl_platform_deployment-template_pull.md
@@ -40,5 +40,5 @@ ecctl platform deployment-template pull --path <path> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform deployment-template](ecctl_platform_deployment-template.md)	 - Manages deployment templates
+* [ecctl platform deployment-template](ecctl_platform_deployment-template.md)	 - Manages deployment templates (Available for ECE only)
 

--- a/docs/ecctl_platform_deployment-template_show.md
+++ b/docs/ecctl_platform_deployment-template_show.md
@@ -40,5 +40,5 @@ ecctl platform deployment-template show <template id> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform deployment-template](ecctl_platform_deployment-template.md)	 - Manages deployment templates
+* [ecctl platform deployment-template](ecctl_platform_deployment-template.md)	 - Manages deployment templates (Available for ECE only)
 

--- a/docs/ecctl_platform_deployment-template_update.md
+++ b/docs/ecctl_platform_deployment-template_update.md
@@ -40,5 +40,5 @@ ecctl platform deployment-template update <template id> -f <template file>.json 
 
 ### SEE ALSO
 
-* [ecctl platform deployment-template](ecctl_platform_deployment-template.md)	 - Manages deployment templates
+* [ecctl platform deployment-template](ecctl_platform_deployment-template.md)	 - Manages deployment templates (Available for ECE only)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Adds text to specify that deployment template commands are ECE specific.

## Related Issues
Closes: https://github.com/elastic/ecctl/issues/229

## How Has This Been Tested?
By running `make docs`

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
