### PR TITLE
cmd: specify that deployment delete command is ECE specific

### DIFF
--- a/cmd/deployment/delete.go
+++ b/cmd/deployment/delete.go
@@ -18,17 +18,18 @@
 package cmddeployment
 
 import (
-	"github.com/elastic/cloud-sdk-go/pkg/util/cmdutil"
+	sdkcmdutil "github.com/elastic/cloud-sdk-go/pkg/util/cmdutil"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/deployment"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
 var deleteCmd = &cobra.Command{
 	Use:     "delete <deployment-id>",
-	Short:   "Deletes a previously stopped deployment from the platform",
-	PreRunE: cmdutil.MinimumNArgsAndUUID(1),
+	Short:   cmdutil.AdminReqDescription("Deletes a previously shutdown deployment"),
+	PreRunE: sdkcmdutil.MinimumNArgsAndUUID(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		res, err := deployment.Delete(deployment.DeleteParams{
 			API:          ecctl.Get().API,

--- a/docs/ecctl_deployment.md
+++ b/docs/ecctl_deployment.md
@@ -43,7 +43,7 @@ ecctl deployment [flags]
 * [ecctl deployment apm](ecctl_deployment_apm.md)	 - Manages APM deployments
 * [ecctl deployment appsearch](ecctl_deployment_appsearch.md)	 - Manages AppSearch deployments
 * [ecctl deployment create](ecctl_deployment_create.md)	 - Creates a deployment
-* [ecctl deployment delete](ecctl_deployment_delete.md)	 - Deletes a previously stopped deployment from the platform
+* [ecctl deployment delete](ecctl_deployment_delete.md)	 - Deletes a previously shutdown deployment (Available for ECE only)
 * [ecctl deployment elasticsearch](ecctl_deployment_elasticsearch.md)	 - Manages Elasticsearch clusters
 * [ecctl deployment kibana](ecctl_deployment_kibana.md)	 - Manages Kibana instances
 * [ecctl deployment list](ecctl_deployment_list.md)	 - Lists the platform's deployments

--- a/docs/ecctl_deployment_delete.md
+++ b/docs/ecctl_deployment_delete.md
@@ -1,10 +1,10 @@
 ## ecctl deployment delete
 
-Deletes a previously stopped deployment from the platform
+Deletes a previously shutdown deployment (Available for ECE only)
 
 ### Synopsis
 
-Deletes a previously stopped deployment from the platform
+Deletes a previously shutdown deployment (Available for ECE only)
 
 ```
 ecctl deployment delete <deployment-id> [flags]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Adds text to specify that the deployment delete command is ECE specific.

## Related Issues
Closes: https://github.com/elastic/ecctl/issues/231

## How Has This Been Tested?
By running `make docs`

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
