### PR TITLE
cmd: Temporarily remove ability to create a flag based deployment

### DIFF
--- a/cmd/deployment/create.go
+++ b/cmd/deployment/create.go
@@ -36,8 +36,9 @@ var createCmd = &cobra.Command{
 	Use:     "create {--file | --size <int> --zones <string> | --topology-element <obj>}",
 	Short:   "Creates a deployment",
 	PreRunE: cobra.MaximumNArgs(0),
-	Long:    createLong,
-	Example: createExample,
+	// Switch back to non-temp constants when reads for deployment templates are available on ESS
+	Long:    createLongTemp,
+	Example: createExampleTemp,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var track, _ = cmd.Flags().GetBool("track")
 		var generatePayload, _ = cmd.Flags().GetBool("generate-payload")
@@ -45,9 +46,9 @@ var createCmd = &cobra.Command{
 		var version, _ = cmd.Flags().GetString("version")
 		var dt, _ = cmd.Flags().GetString("deployment-template")
 
-		var zoneCount, _ = cmd.Flags().GetInt32("zones")
-		var size, _ = cmd.Flags().GetInt32("size")
-		var esRefID, _ = cmd.Flags().GetString("ref-id")
+		var esZoneCount, _ = cmd.Flags().GetInt32("es-zones")
+		var esSize, _ = cmd.Flags().GetInt32("es-size")
+		var esRefID, _ = cmd.Flags().GetString("es-ref-id")
 		var te, _ = cmd.Flags().GetStringArray("topology-element")
 		var plugin, _ = cmd.Flags().GetStringSlice("plugin")
 
@@ -93,8 +94,8 @@ var createCmd = &cobra.Command{
 				AppsearchEnable:      appsearchEnable,
 				ElasticsearchInstance: depresource.InstanceParams{
 					RefID:     esRefID,
-					Size:      size,
-					ZoneCount: zoneCount,
+					Size:      esSize,
+					ZoneCount: esZoneCount,
 				},
 				KibanaInstance: depresource.InstanceParams{
 					RefID:     kibanaRefID,
@@ -164,6 +165,8 @@ var createCmd = &cobra.Command{
 func init() {
 	Command.AddCommand(createCmd)
 	createCmd.Flags().StringP("file", "f", "", "DeploymentCreateRequest file definition. See help for more information")
+	// Remove when reads for deployment templates are available on ESS
+	createCmd.MarkFlagRequired("file")
 	createCmd.Flags().String("deployment-template", "default", "Deployment template ID on which to base the deployment from")
 	createCmd.Flags().String("version", "", "Version to use, if not specified, the latest available stack version will be used")
 	createCmd.Flags().String("name", "", "Optional name for the deployment")
@@ -171,9 +174,9 @@ func init() {
 	createCmd.Flags().Bool("generate-payload", false, "Returns the deployment payload without actually creating the deployment resources")
 	createCmd.Flags().String("request-id", "", "Optional idempotency token - Can be found in the Stderr device when a previous deployment creation failed, for more information see the examples in the help command page")
 
-	createCmd.Flags().String("ref-id", "main-elasticsearch", "Optional RefId for the Elasticsearch deployment")
-	createCmd.Flags().Int32("zones", 1, "Number of zones the Elasticsearch instances will span")
-	createCmd.Flags().Int32("size", 4096, "Memory (RAM) in MB that each of the Elasticsearch instances will have")
+	createCmd.Flags().String("es-ref-id", "main-elasticsearch", "Optional RefId for the Elasticsearch deployment")
+	createCmd.Flags().Int32("es-zones", 1, "Number of zones the Elasticsearch instances will span")
+	createCmd.Flags().Int32("es-size", 4096, "Memory (RAM) in MB that each of the Elasticsearch instances will have")
 	createCmd.Flags().StringArrayP("topology-element", "e", nil, "Optional Elasticsearch topology element definition. See help for more information")
 	createCmd.Flags().StringSlice("plugin", nil, "Additional plugins to add to the Elasticsearch deployment")
 
@@ -190,4 +193,26 @@ func init() {
 	createCmd.Flags().String("appsearch-ref-id", "main-appsearch", "Optional RefId for the AppSearch deployment")
 	createCmd.Flags().Int32("appsearch-zones", 1, "Number of zones the AppSearch instances will span")
 	createCmd.Flags().Int32("appsearch-size", 2048, "Memory (RAM) in MB that each of the AppSearch instances will have")
+
+	// The following flags will remain hidden until reads for deployment templates are available on ESS
+	createCmd.Flags().MarkHidden("deployment-template")
+	createCmd.Flags().MarkHidden("version")
+	createCmd.Flags().MarkHidden("name")
+	createCmd.Flags().MarkHidden("generate-payload")
+	createCmd.Flags().MarkHidden("es-ref-id")
+	createCmd.Flags().MarkHidden("es-zones")
+	createCmd.Flags().MarkHidden("es-size")
+	createCmd.Flags().MarkHidden("topology-element")
+	createCmd.Flags().MarkHidden("plugin")
+	createCmd.Flags().MarkHidden("kibana-ref-id")
+	createCmd.Flags().MarkHidden("kibana-zones")
+	createCmd.Flags().MarkHidden("kibana-size")
+	createCmd.Flags().MarkHidden("apm")
+	createCmd.Flags().MarkHidden("apm-ref-id")
+	createCmd.Flags().MarkHidden("apm-zones")
+	createCmd.Flags().MarkHidden("apm-size")
+	createCmd.Flags().MarkHidden("appsearch")
+	createCmd.Flags().MarkHidden("appsearch-ref-id")
+	createCmd.Flags().MarkHidden("appsearch-zones")
+	createCmd.Flags().MarkHidden("appsearch-size")
 }

--- a/cmd/deployment/create_help.go
+++ b/cmd/deployment/create_help.go
@@ -18,6 +18,7 @@
 package cmddeployment
 
 const (
+	// nolint
 	createLong = `Creates a deployment which can be defined through flags or from a file definition.
 Sane default values are provided, making the command work out of the box even when no parameters are set. 
 When version is not specified, the latest available stack version will automatically be used. 
@@ -38,6 +39,7 @@ These are the available options:
 As an option "--generate-payload" can be used in order to obtain the generated payload that would be sent as a request. 
 Save it, update or extend the topology and create a deployment using the saved payload with the "--file" flag.`
 
+	// nolint
 	createExample = `## Create a deployment with the default values for Elasticsearch, a Kibana instance with a modified size, 
 and a default APM instance. While Elasticsearch and Kibana come enabled by default, both APM and AppSearch need to be 
 enabled by using the "--apm" and "--appsearch" flags. The command will exit after the API response has been returned, without 
@@ -48,8 +50,8 @@ $ ecctl deployment create --name my-deployment --zones 2 --kibana-size 2048 --ap
 the current stage on which the deployment resources are in.
 $ deployment create --name my-deployment --track
 [...]
-Cluster [38e0ff5b58a9483c96a98c923b22194e][Elasticsearch]: finished running all the plan steps (Total plan duration: 1m0.911628175s)
-Cluster [51178ffc645d48b7859dbf17388a6c35][Kibana]: finished running all the plan steps (Total plan duration: 1m11.246662764s)
+Deployment [b6ecbea3d5c84124b7dca457f2892086] - [Elasticsearch][b6ecbea3d5c84124b7dca457f2892086]: finished running all the plan steps (Total plan duration: 5m11.s)
+Deployment [91c4d60acb804ba0a27651fac02780ec] - [Kibana][8a9d9916cd6e46a7bb0912211d76e2af]: finished running all the plan steps (Total plan duration: 4m29.58s)
 
 ## Additionally, a more advanced topology for Elasticsearch can be created through "--topology-element" or shorthand "-e".
 The following command will create a deployment with two 1GB Elasticsearch instances of the type "data" and 
@@ -84,8 +86,8 @@ You can create a definition by using the sample JSON seen here:
 the current stage on which the deployment resources are in.
 $ deployment create --file create_example.json --track
 [...]
-Cluster [38e0ff5b58a9483c96a98c923b22194e][Elasticsearch]: finished running all the plan steps (Total plan duration: 1m0.911628175s)
-Cluster [51178ffc645d48b7859dbf17388a6c35][Kibana]: finished running all the plan steps (Total plan duration: 1m11.246662764s)
+Deployment [b6ecbea3d5c84124b7dca457f2892086] - [Elasticsearch][b6ecbea3d5c84124b7dca457f2892086]: finished running all the plan steps (Total plan duration: 5m11.s)
+Deployment [91c4d60acb804ba0a27651fac02780ec] - [Kibana][8a9d9916cd6e46a7bb0912211d76e2af]: finished running all the plan steps (Total plan duration: 4m29.58s)
 
 ## To retry a when the previous deployment creation failed:
 $ ecctl deployment create --file create_example.json

--- a/cmd/deployment/create_help.go
+++ b/cmd/deployment/create_help.go
@@ -57,15 +57,14 @@ one 1GB Elasticsearch instance of the type "ml".
 $ ecctl deployment create --name my-deployment --topology-element '{"size": 1024, "zone_count": 2, "name": "data"}' --topology-element '{"size": 1024, "zone_count": 1, "name": "ml"}'
 
 ## In order to use the "--deployment-template" flag, you'll need to know which deployment templates ara available to you.
-Visit https://elastic.co/guide/en/cloud/current/ec-regions-templates-instances.html.
-If you are an Elastic Cloud Enterprise customer, you'll need to run the following command to view your deployment templates:
+You'll need to run the following command to view your deployment templates:
 $ ecctl platform deployment-template list
 
 ## Use the "--generate-payload" flag to save the definition to a file for later use.
-$ ecctl deployment create --name my-deployment --size 1024 --track --generate-payload --zones 2 > elasticsearch_create_example.json
+$ ecctl deployment create --name my-deployment --size 1024 --track --generate-payload --zones 2 > create_example.json
 
 ## Create a deployment through the file definition.
-$ ecctl deployment create --file elasticsearch_create_example.json --track
+$ ecctl deployment create --file create_example.json --track
 
 ## To retry a when the previous deployment creation failed:
 $ ecctl deployment create
@@ -74,4 +73,25 @@ to recreate the deployment resources
 Idempotency token: GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhGUSMXrEIzVXoBykSVRsKncNb
 unknown error (status 500)
 $ ecctl deployment create --request-id=GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhGUSMXrEIzVXoBykSVRsKncNb`
+
+	// Remove temporary constants when reads for deployment templates are available on ESS
+	createLongTemp = `Creates a deployment which can be defined from a file definition with the --file=<file path> (shorthand: -f) flag.
+
+You can create a definition by using the sample JSON seen here:
+  https://elastic.co/guide/en/cloud/current/ec-api-deployment-crud.html#ec_create_a_deployment`
+
+	createExampleTemp = `## To make the command wait until the resources have been created use the "--track" flag, which will output 
+the current stage on which the deployment resources are in.
+$ deployment create --file create_example.json --track
+[...]
+Cluster [38e0ff5b58a9483c96a98c923b22194e][Elasticsearch]: finished running all the plan steps (Total plan duration: 1m0.911628175s)
+Cluster [51178ffc645d48b7859dbf17388a6c35][Kibana]: finished running all the plan steps (Total plan duration: 1m11.246662764s)
+
+## To retry a when the previous deployment creation failed:
+$ ecctl deployment create --file create_example.json
+The deployment creation returned with an error, please use the displayed idempotency token
+to recreate the deployment resources
+Idempotency token: GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhGUSMXrEIzVXoBykSVRsKncNb
+unknown error (status 500)
+$ ecctl deployment create --file create_example.json --request-id=GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhGUSMXrEIzVXoBykSVRsKncNb`
 )

--- a/cmd/deployment/create_help.go
+++ b/cmd/deployment/create_help.go
@@ -75,7 +75,7 @@ unknown error (status 500)
 $ ecctl deployment create --request-id=GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhGUSMXrEIzVXoBykSVRsKncNb`
 
 	// Remove temporary constants when reads for deployment templates are available on ESS
-	createLongTemp = `Creates a deployment which can be defined from a file definition with the --file=<file path> (shorthand: -f) flag.
+	createLongTemp = `Creates a deployment which is defined from a file definition using the --file=<file path> (shorthand: -f) flag.
 
 You can create a definition by using the sample JSON seen here:
   https://elastic.co/guide/en/cloud/current/ec-api-deployment-crud.html#ec_create_a_deployment`

--- a/docs/ecctl_deployment_create.md
+++ b/docs/ecctl_deployment_create.md
@@ -4,25 +4,10 @@ Creates a deployment
 
 ### Synopsis
 
-Creates a deployment which can be defined through flags or from a file definition.
-Sane default values are provided, making the command work out of the box even when no parameters are set. 
-When version is not specified, the latest available stack version will automatically be used. 
-These are the available options:
+Creates a deployment which can be defined from a file definition with the --file=<file path> (shorthand: -f) flag.
 
-  * Simplified flags to set size and zone count for each instance type (Elasticsearch, Kibana, APM and AppSearch). 
-  * Advanced flag for different Elasticsearch node types: --topology-element <json obj> (shorthand: -e).
-    Note that the flag can be specified multiple times for complex topologies.
-    The JSON object has the following format:
-    {
-      "name": "["data", "master", "ml"]" # type string
-      "size": 1024 # type int32
-      "zone_count": 1 # type int32
-    }
-  * File definition: --file=<file path> (shorthand: -f). You can create a definition by using the sample JSON seen here:
-    https://elastic.co/guide/en/cloud/current/ec-api-deployment-crud.html#ec_create_a_deployment
-
-As an option "--generate-payload" can be used in order to obtain the generated payload that would be sent as a request. 
-Save it, update or extend the topology and create a deployment using the saved payload with the "--file" flag.
+You can create a definition by using the sample JSON seen here:
+  https://elastic.co/guide/en/cloud/current/ec-api-deployment-crud.html#ec_create_a_deployment
 
 ```
 ecctl deployment create {--file | --size <int> --zones <string> | --topology-element <obj>} [flags]
@@ -31,71 +16,29 @@ ecctl deployment create {--file | --size <int> --zones <string> | --topology-ele
 ### Examples
 
 ```
-## Create a deployment with the default values for Elasticsearch, a Kibana instance with a modified size, 
-and a default APM instance. While Elasticsearch and Kibana come enabled by default, both APM and AppSearch need to be 
-enabled by using the "--apm" and "--appsearch" flags. The command will exit after the API response has been returned, without 
-waiting until the deployment resources have been created. 
-$ ecctl deployment create --name my-deployment --zones 2 --kibana-size 2048 --apm --apm-size 1024
-
 ## To make the command wait until the resources have been created use the "--track" flag, which will output 
 the current stage on which the deployment resources are in.
-$ deployment create --name my-deployment --track
+$ deployment create --file create_example.json --track
 [...]
 Cluster [38e0ff5b58a9483c96a98c923b22194e][Elasticsearch]: finished running all the plan steps (Total plan duration: 1m0.911628175s)
 Cluster [51178ffc645d48b7859dbf17388a6c35][Kibana]: finished running all the plan steps (Total plan duration: 1m11.246662764s)
 
-## Additionally, a more advanced topology for Elasticsearch can be created through "--topology-element" or shorthand "-e".
-The following command will create a deployment with two 1GB Elasticsearch instances of the type "data" and 
-one 1GB Elasticsearch instance of the type "ml".
-$ ecctl deployment create --name my-deployment --topology-element '{"size": 1024, "zone_count": 2, "name": "data"}' --topology-element '{"size": 1024, "zone_count": 1, "name": "ml"}'
-
-## In order to use the "--deployment-template" flag, you'll need to know which deployment templates ara available to you.
-Visit https://elastic.co/guide/en/cloud/current/ec-regions-templates-instances.html.
-If you are an Elastic Cloud Enterprise customer, you'll need to run the following command to view your deployment templates:
-$ ecctl platform deployment-template list
-
-## Use the "--generate-payload" flag to save the definition to a file for later use.
-$ ecctl deployment create --name my-deployment --size 1024 --track --generate-payload --zones 2 > elasticsearch_create_example.json
-
-## Create a deployment through the file definition.
-$ ecctl deployment create --file elasticsearch_create_example.json --track
-
 ## To retry a when the previous deployment creation failed:
-$ ecctl deployment create
+$ ecctl deployment create --file create_example.json
 The deployment creation returned with an error, please use the displayed idempotency token
 to recreate the deployment resources
 Idempotency token: GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhGUSMXrEIzVXoBykSVRsKncNb
 unknown error (status 500)
-$ ecctl deployment create --request-id=GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhGUSMXrEIzVXoBykSVRsKncNb
+$ ecctl deployment create --file create_example.json --request-id=GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhGUSMXrEIzVXoBykSVRsKncNb
 ```
 
 ### Options
 
 ```
-      --apm                            Enables APM for the deployment
-      --apm-ref-id string              Optional RefId for the APM deployment (default "main-apm")
-      --apm-size int32                 Memory (RAM) in MB that each of the APM instances will have (default 512)
-      --apm-zones int32                Number of zones the APM instances will span (default 1)
-      --appsearch                      Enables AppSearch for the deployment
-      --appsearch-ref-id string        Optional RefId for the AppSearch deployment (default "main-appsearch")
-      --appsearch-size int32           Memory (RAM) in MB that each of the AppSearch instances will have (default 2048)
-      --appsearch-zones int32          Number of zones the AppSearch instances will span (default 1)
-      --deployment-template string     Deployment template ID on which to base the deployment from (default "default")
-  -f, --file string                    DeploymentCreateRequest file definition. See help for more information
-      --generate-payload               Returns the deployment payload without actually creating the deployment resources
-  -h, --help                           help for create
-      --kibana-ref-id string           Optional RefId for the Kibana deployment (default "main-kibana")
-      --kibana-size int32              Memory (RAM) in MB that each of the Kibana instances will have (default 1024)
-      --kibana-zones int32             Number of zones the Kibana instances will span (default 1)
-      --name string                    Optional name for the deployment
-      --plugin strings                 Additional plugins to add to the Elasticsearch deployment
-      --ref-id string                  Optional RefId for the Elasticsearch deployment (default "main-elasticsearch")
-      --request-id string              Optional idempotency token - Can be found in the Stderr device when a previous deployment creation failed, for more information see the examples in the help command page
-      --size int32                     Memory (RAM) in MB that each of the Elasticsearch instances will have (default 4096)
-  -e, --topology-element stringArray   Optional Elasticsearch topology element definition. See help for more information
-  -t, --track                          Tracks the progress of the performed task
-      --version string                 Version to use, if not specified, the latest available stack version will be used
-      --zones int32                    Number of zones the Elasticsearch instances will span (default 1)
+  -f, --file string         DeploymentCreateRequest file definition. See help for more information
+  -h, --help                help for create
+      --request-id string   Optional idempotency token - Can be found in the Stderr device when a previous deployment creation failed, for more information see the examples in the help command page
+  -t, --track               Tracks the progress of the performed task
 ```
 
 ### Options inherited from parent commands

--- a/docs/ecctl_deployment_create.md
+++ b/docs/ecctl_deployment_create.md
@@ -20,8 +20,8 @@ ecctl deployment create {--file | --size <int> --zones <string> | --topology-ele
 the current stage on which the deployment resources are in.
 $ deployment create --file create_example.json --track
 [...]
-Cluster [38e0ff5b58a9483c96a98c923b22194e][Elasticsearch]: finished running all the plan steps (Total plan duration: 1m0.911628175s)
-Cluster [51178ffc645d48b7859dbf17388a6c35][Kibana]: finished running all the plan steps (Total plan duration: 1m11.246662764s)
+Deployment [b6ecbea3d5c84124b7dca457f2892086] - [Elasticsearch][b6ecbea3d5c84124b7dca457f2892086]: finished running all the plan steps (Total plan duration: 5m11.s)
+Deployment [91c4d60acb804ba0a27651fac02780ec] - [Kibana][8a9d9916cd6e46a7bb0912211d76e2af]: finished running all the plan steps (Total plan duration: 4m29.58s)
 
 ## To retry a when the previous deployment creation failed:
 $ ecctl deployment create --file create_example.json

--- a/docs/ecctl_deployment_create.md
+++ b/docs/ecctl_deployment_create.md
@@ -4,7 +4,7 @@ Creates a deployment
 
 ### Synopsis
 
-Creates a deployment which can be defined from a file definition with the --file=<file path> (shorthand: -f) flag.
+Creates a deployment which is defined from a file definition using the --file=<file path> (shorthand: -f) flag.
 
 You can create a definition by using the sample JSON seen here:
   https://elastic.co/guide/en/cloud/current/ec-api-deployment-crud.html#ec_create_a_deployment


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
This change temporarily removes the ability to create a flag based deployment until reads to deployment templates are available to all users.

## Motivation and Context
Currently only ECE users have permissions to perform reads on deployment templates. To create a flag based deployment all users would need these permissions. We will wait until these endpoints are available to all to reinstate flag based deployment creation.

## How Has This Been Tested?
Manually by running the command and by running `make docs`

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
