### PR TITLE
misc: Add delivery team as docs codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # These owners will be the default owners for everything in
 # the repository.
 *       @elastic/cloud-delivery
-docs/   @alaudazzi @nrichers
+docs/   @alaudazzi @nrichers @elastic/cloud-delivery


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Describe your changes in detail. -->
Adds delivery team as codeowners for the `docs/` directory
