### PR TITLE
cmd: Change --cluster flag to --resource-id 

### DIFF
--- a/cmd/platform/allocator/vacate.go
+++ b/cmd/platform/allocator/vacate.go
@@ -68,7 +68,7 @@ const vacateExamples = `  ecctl platform allocator vacate i-05e245252362f7f1d
 `
 
 var vacateAllocatorCmd = &cobra.Command{
-	Use:     "vacate <source>",
+	Use:     "vacate <allocator-id>",
 	Short:   "Moves all the resources from the specified allocator",
 	Example: vacateExamples,
 	PreRunE: cobra.MinimumNArgs(1),

--- a/cmd/platform/allocator/vacate_test.go
+++ b/cmd/platform/allocator/vacate_test.go
@@ -24,8 +24,8 @@ import (
 
 func TestValidateSkipDataMigration(t *testing.T) {
 	type args struct {
-		clusters []string
-		moveOnly bool
+		resources []string
+		moveOnly  bool
 	}
 	tests := []struct {
 		name    string
@@ -34,35 +34,35 @@ func TestValidateSkipDataMigration(t *testing.T) {
 		err     error
 	}{
 		{
-			name: "Succeeds if a cluster has been set and moveOnly is set to true",
+			name: "Succeeds if a resource has been set and moveOnly is set to true",
 			args: args{
-				clusters: []string{"0f32fa44e"},
-				moveOnly: true,
+				resources: []string{"0f32fa44e"},
+				moveOnly:  true,
 			},
 			wantErr: false,
 		},
 		{
-			name: "Returns an error if a cluster has been set and moveOnly is set to false",
+			name: "Returns an error if a resource has been set and moveOnly is set to false",
 			args: args{
-				clusters: []string{"0f32fa44e"},
-				moveOnly: false,
+				resources: []string{"0f32fa44e"},
+				moveOnly:  false,
 			},
 			wantErr: true,
-			err:     errors.New("skip data migration is not available if there are no cluster IDs specified or move-only is set to false"),
+			err:     errors.New("skip data migration is not available if there are no resource IDs specified or move-only is set to false"),
 		},
 		{
-			name: "Returns an error if no cluster has been set and moveOnly is set to true",
+			name: "Returns an error if no resource has been set and moveOnly is set to true",
 			args: args{
-				clusters: []string{},
-				moveOnly: true,
+				resources: []string{},
+				moveOnly:  true,
 			},
 			wantErr: true,
-			err:     errors.New("skip data migration is not available if there are no cluster IDs specified or move-only is set to false"),
+			err:     errors.New("skip data migration is not available if there are no resource IDs specified or move-only is set to false"),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateSkipDataMigration(tt.args.clusters, tt.args.moveOnly)
+			err := validateSkipDataMigration(tt.args.resources, tt.args.moveOnly)
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("validateSkipDataMigration() error = %v, wantErr %v", err, tt.wantErr)

--- a/docs/ecctl_platform_allocator.adoc
+++ b/docs/ecctl_platform_allocator.adoc
@@ -50,4 +50,4 @@ ecctl platform allocator [flags]
 * xref:ecctl_platform_allocator_metadata[ecctl platform allocator metadata]	 - Manages an allocator's metadata
 * xref:ecctl_platform_allocator_search[ecctl platform allocator search]	 - Performs advanced allocator searching
 * xref:ecctl_platform_allocator_show[ecctl platform allocator show]	 - Returns information about the allocator
-* xref:ecctl_platform_allocator_vacate[ecctl platform allocator vacate]	 - Moves all the clusters from the specified allocator
+* xref:ecctl_platform_allocator_vacate[ecctl platform allocator vacate]	 - Moves all the resources from the specified allocator

--- a/docs/ecctl_platform_allocator.md
+++ b/docs/ecctl_platform_allocator.md
@@ -45,5 +45,5 @@ ecctl platform allocator [flags]
 * [ecctl platform allocator metadata](ecctl_platform_allocator_metadata.md)	 - Manages an allocator's metadata
 * [ecctl platform allocator search](ecctl_platform_allocator_search.md)	 - Performs advanced allocator searching
 * [ecctl platform allocator show](ecctl_platform_allocator_show.md)	 - Returns information about the allocator
-* [ecctl platform allocator vacate](ecctl_platform_allocator_vacate.md)	 - Moves all the clusters from the specified allocator
+* [ecctl platform allocator vacate](ecctl_platform_allocator_vacate.md)	 - Moves all the resources from the specified allocator
 

--- a/docs/ecctl_platform_allocator_vacate.adoc
+++ b/docs/ecctl_platform_allocator_vacate.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_allocator_vacate]
 == ecctl platform allocator vacate
 
-Moves all the clusters from the specified allocator
+Moves all the resources from the specified allocator
 
 [float]
 === Synopsis
 
-Moves all the clusters from the specified allocator
+Moves all the resources from the specified allocator
 
 ----
 ecctl platform allocator vacate <source> [flags]
@@ -16,38 +16,38 @@ ecctl platform allocator vacate <source> [flags]
 === Examples
 
 ----
-  ecctl [globalFlags] allocator vacate i-05e245252362f7f1d
+  ecctl platform allocator vacate i-05e245252362f7f1d
   # Move everything from multiple allocators
-  ecctl [globalFlags] allocator vacate i-05e245252362f7f1d i-2362f7f1d252362f7
+  ecctl platform allocator vacate i-05e245252362f7f1d i-2362f7f1d252362f7
 
-  # filter by a cluster kind
-  ecctl [globalFlags] allocator vacate -k kibana i-05e245252362f7f1d
+  # filter by a resource kind
+  ecctl platform allocator vacate -k kibana i-05e245252362f7f1d
 
-  # Only move specific cluster IDs
-  ecctl [globalFlags] allocator vacate -c f521dedb07194c478fbbc6624f3bbf8f -c f404eea372cc4ea5bd553d47a09705cd i-05e245252362f7f1d
+  # Only move specific resource IDs
+  ecctl platform allocator vacate -r f521dedb07194c478fbbc6624f3bbf8f -r f404eea372cc4ea5bd553d47a09705cd i-05e245252362f7f1d
 
   # Specify multiple allocator targets
-  ecctl [globalFlags] allocator vacate -t i-05e245252362f7f2d -t i-2362f7f1d252362f7 i-05e245252362f7f1d
-  ecctl [globalFlags] allocator vacate --target i-05e245252362f7f2d --target i-2362f7f1d252362f7 --kind kibana i-05e245252362f7f1d
+  ecctl platform allocator vacate -t i-05e245252362f7f2d -t i-2362f7f1d252362f7 i-05e245252362f7f1d
+  ecctl platform allocator vacate --target i-05e245252362f7f2d --target i-2362f7f1d252362f7 --kind kibana i-05e245252362f7f1d
 
   # Set the allocators to maintenance mode before vacating them
-  ecctl [globalFlags] allocator vacate --maintenance -t i-05e245252362f7f2d -t i-2362f7f1d252362f7 i-05e245252362f7f1d
+  ecctl platform allocator vacate --maintenance -t i-05e245252362f7f2d -t i-2362f7f1d252362f7 i-05e245252362f7f1d
 
   # Set the amount of maximum moves to happen at any time
-  ecctl [globalFlags] allocator vacate --concurrency 10 i-05e245252362f7f1d
+  ecctl platform allocator vacate --concurrency 10 i-05e245252362f7f1d
 
   # Override the allocator health auto discovery
-  ecctl [globalFlags] allocator vacate --allocator-down=true i-05e245252362f7f1d
+  ecctl platform allocator vacate --allocator-down=true i-05e245252362f7f1d
 
   # Override the skip_snapshot setting
-  ecctl [globalFlags] allocator vacate --skip-snapshot=true i-05e245252362f7f1d -c f521dedb07194c478fbbc6624f3bbf8f
+  ecctl platform allocator vacate --skip-snapshot=true i-05e245252362f7f1d -r f521dedb07194c478fbbc6624f3bbf8f
 
   # Override the skip_data_migration setting
-  ecctl [globalFlags] allocator vacate --skip-data-migration=true i-05e245252362f7f1d -c f521dedb07194c478fbbc6624f3bbf8f
+  ecctl platform allocator vacate --skip-data-migration=true i-05e245252362f7f1d -r f521dedb07194c478fbbc6624f3bbf8f
 
   # Skips tracking the vacate progress which will cause the command to return almost immediately.
   # Not recommended since it can lead to failed vacates without the operator knowing about them.
-  ecctl [globalFlags] allocator vacate --skip-tracking i-05e245252362f7f1d
+  ecctl platform allocator vacate --skip-tracking i-05e245252362f7f1d
 ----
 
 [float]
@@ -55,17 +55,17 @@ ecctl platform allocator vacate <source> [flags]
 
 ----
       --allocator-down string        Disables the allocator health auto-discovery, setting the allocator-down to either [true|false]
-  -c, --cluster stringArray          Cluster IDs to include in the vacate
       --concurrency uint             Maximum number of concurrent moves to perform at any time (default 8)
   -h, --help                         help for vacate
   -k, --kind string                  Kind of workload to vacate (elasticsearch|kibana)
   -m, --maintenance                  Whether to set the allocator(s) in maintenance before performing the vacate
       --max-poll-retries int         Optional maximum plan tracking retries (default 2)
-      --move-only                    Keeps the cluster in its current -possibly broken- state and just does the bare minimum to move the requested instances across to another allocator. [true|false] (default true)
+      --move-only                    Keeps the resource in its current -possibly broken- state and just does the bare minimum to move the requested instances across to another allocator. [true|false] (default true)
       --override-failsafe            If false (the default) then the plan will fail out if it believes the requested sequence of operations can result in data loss - this flag will override some of these restraints. [true|false]
       --poll-frequency duration      Optional polling frequency to check for plan change updates (default 10s)
-      --skip-data-migration string   Skips the data-migration operation on the specified cluster IDs. ONLY available when the cluster IDs are specified and --move-only is true. [true|false]
-      --skip-snapshot string         Skips the snapshot operation on the specified cluster IDs. ONLY available when the cluster IDs are specified. [true|false]
+  -r, --resource-id stringArray      Resource IDs to include in the vacate
+      --skip-data-migration string   Skips the data-migration operation on the specified resource IDs. ONLY available when the resource IDs are specified and --move-only is true. [true|false]
+      --skip-snapshot string         Skips the snapshot operation on the specified resource IDs. ONLY available when the resource IDs are specified. [true|false]
       --skip-tracking                Skips tracking the vacate progress causing the command to return after the move operation has been executed. Not recommended.
   -t, --target stringArray           Target allocator(s) on which to place the vacated workload
 ----

--- a/docs/ecctl_platform_allocator_vacate.adoc
+++ b/docs/ecctl_platform_allocator_vacate.adoc
@@ -9,7 +9,7 @@ Moves all the resources from the specified allocator
 Moves all the resources from the specified allocator
 
 ----
-ecctl platform allocator vacate <source> [flags]
+ecctl platform allocator vacate <allocator-id> [flags]
 ----
 
 [float]

--- a/docs/ecctl_platform_allocator_vacate.md
+++ b/docs/ecctl_platform_allocator_vacate.md
@@ -7,7 +7,7 @@ Moves all the resources from the specified allocator
 Moves all the resources from the specified allocator
 
 ```
-ecctl platform allocator vacate <source> [flags]
+ecctl platform allocator vacate <allocator-id> [flags]
 ```
 
 ### Examples

--- a/docs/ecctl_platform_allocator_vacate.md
+++ b/docs/ecctl_platform_allocator_vacate.md
@@ -1,10 +1,10 @@
 ## ecctl platform allocator vacate
 
-Moves all the clusters from the specified allocator
+Moves all the resources from the specified allocator
 
 ### Synopsis
 
-Moves all the clusters from the specified allocator
+Moves all the resources from the specified allocator
 
 ```
 ecctl platform allocator vacate <source> [flags]
@@ -13,38 +13,38 @@ ecctl platform allocator vacate <source> [flags]
 ### Examples
 
 ```
-  ecctl [globalFlags] allocator vacate i-05e245252362f7f1d
+  ecctl platform allocator vacate i-05e245252362f7f1d
   # Move everything from multiple allocators
-  ecctl [globalFlags] allocator vacate i-05e245252362f7f1d i-2362f7f1d252362f7
+  ecctl platform allocator vacate i-05e245252362f7f1d i-2362f7f1d252362f7
 
-  # filter by a cluster kind
-  ecctl [globalFlags] allocator vacate -k kibana i-05e245252362f7f1d
+  # filter by a resource kind
+  ecctl platform allocator vacate -k kibana i-05e245252362f7f1d
 
-  # Only move specific cluster IDs
-  ecctl [globalFlags] allocator vacate -c f521dedb07194c478fbbc6624f3bbf8f -c f404eea372cc4ea5bd553d47a09705cd i-05e245252362f7f1d
+  # Only move specific resource IDs
+  ecctl platform allocator vacate -r f521dedb07194c478fbbc6624f3bbf8f -r f404eea372cc4ea5bd553d47a09705cd i-05e245252362f7f1d
 
   # Specify multiple allocator targets
-  ecctl [globalFlags] allocator vacate -t i-05e245252362f7f2d -t i-2362f7f1d252362f7 i-05e245252362f7f1d
-  ecctl [globalFlags] allocator vacate --target i-05e245252362f7f2d --target i-2362f7f1d252362f7 --kind kibana i-05e245252362f7f1d
+  ecctl platform allocator vacate -t i-05e245252362f7f2d -t i-2362f7f1d252362f7 i-05e245252362f7f1d
+  ecctl platform allocator vacate --target i-05e245252362f7f2d --target i-2362f7f1d252362f7 --kind kibana i-05e245252362f7f1d
 
   # Set the allocators to maintenance mode before vacating them
-  ecctl [globalFlags] allocator vacate --maintenance -t i-05e245252362f7f2d -t i-2362f7f1d252362f7 i-05e245252362f7f1d
+  ecctl platform allocator vacate --maintenance -t i-05e245252362f7f2d -t i-2362f7f1d252362f7 i-05e245252362f7f1d
 
   # Set the amount of maximum moves to happen at any time
-  ecctl [globalFlags] allocator vacate --concurrency 10 i-05e245252362f7f1d
+  ecctl platform allocator vacate --concurrency 10 i-05e245252362f7f1d
 
   # Override the allocator health auto discovery
-  ecctl [globalFlags] allocator vacate --allocator-down=true i-05e245252362f7f1d
+  ecctl platform allocator vacate --allocator-down=true i-05e245252362f7f1d
 
   # Override the skip_snapshot setting
-  ecctl [globalFlags] allocator vacate --skip-snapshot=true i-05e245252362f7f1d -c f521dedb07194c478fbbc6624f3bbf8f
+  ecctl platform allocator vacate --skip-snapshot=true i-05e245252362f7f1d -r f521dedb07194c478fbbc6624f3bbf8f
 
   # Override the skip_data_migration setting
-  ecctl [globalFlags] allocator vacate --skip-data-migration=true i-05e245252362f7f1d -c f521dedb07194c478fbbc6624f3bbf8f
+  ecctl platform allocator vacate --skip-data-migration=true i-05e245252362f7f1d -r f521dedb07194c478fbbc6624f3bbf8f
   
   # Skips tracking the vacate progress which will cause the command to return almost immediately.
   # Not recommended since it can lead to failed vacates without the operator knowing about them.
-  ecctl [globalFlags] allocator vacate --skip-tracking i-05e245252362f7f1d
+  ecctl platform allocator vacate --skip-tracking i-05e245252362f7f1d
 
 ```
 
@@ -52,17 +52,17 @@ ecctl platform allocator vacate <source> [flags]
 
 ```
       --allocator-down string        Disables the allocator health auto-discovery, setting the allocator-down to either [true|false]
-  -c, --cluster stringArray          Cluster IDs to include in the vacate
       --concurrency uint             Maximum number of concurrent moves to perform at any time (default 8)
   -h, --help                         help for vacate
   -k, --kind string                  Kind of workload to vacate (elasticsearch|kibana)
   -m, --maintenance                  Whether to set the allocator(s) in maintenance before performing the vacate
       --max-poll-retries int         Optional maximum plan tracking retries (default 2)
-      --move-only                    Keeps the cluster in its current -possibly broken- state and just does the bare minimum to move the requested instances across to another allocator. [true|false] (default true)
+      --move-only                    Keeps the resource in its current -possibly broken- state and just does the bare minimum to move the requested instances across to another allocator. [true|false] (default true)
       --override-failsafe            If false (the default) then the plan will fail out if it believes the requested sequence of operations can result in data loss - this flag will override some of these restraints. [true|false]
       --poll-frequency duration      Optional polling frequency to check for plan change updates (default 10s)
-      --skip-data-migration string   Skips the data-migration operation on the specified cluster IDs. ONLY available when the cluster IDs are specified and --move-only is true. [true|false]
-      --skip-snapshot string         Skips the snapshot operation on the specified cluster IDs. ONLY available when the cluster IDs are specified. [true|false]
+  -r, --resource-id stringArray      Resource IDs to include in the vacate
+      --skip-data-migration string   Skips the data-migration operation on the specified resource IDs. ONLY available when the resource IDs are specified and --move-only is true. [true|false]
+      --skip-snapshot string         Skips the snapshot operation on the specified resource IDs. ONLY available when the resource IDs are specified. [true|false]
       --skip-tracking                Skips tracking the vacate progress causing the command to return after the move operation has been executed. Not recommended.
   -t, --target stringArray           Target allocator(s) on which to place the vacated workload
 ```


### PR DESCRIPTION
## Description
This PR changes the `--cluster` flag to `--resource-id`  for allocator vacate and improves wording within the command

## Motivation and Context
As we move away from the clusters api, the correct term is "resource" instead of "cluster"

## How Has This Been Tested?
Unit tests

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
