### PR TITLE
docs: Update deployment create help wording

### DIFF
--- a/cmd/deployment/create_help.go
+++ b/cmd/deployment/create_help.go
@@ -79,8 +79,8 @@ $ ecctl deployment create --request-id=GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhG
 	// Remove temporary constants when reads for deployment templates are available on ESS
 	createLongTemp = `Creates a deployment which is defined from a file definition using the --file=<file path> (shorthand: -f) flag.
 
-//You can create a definition by using the sample JSON seen here:
-//  https://elastic.co/guide/en/cloud/current/ec-api-deployment-crud.html#ec_create_a_deployment`
+You can create a definition by using the sample JSON seen here:
+  https://elastic.co/guide/en/cloud/current/ec-api-deployment-crud.html#ec_create_a_deployment`
 
 	createExampleTemp = `## To make the command wait until the resources have been created use the "--track" flag, which will output 
 the current stage on which the deployment resources are in.

--- a/cmd/deployment/create_help.go
+++ b/cmd/deployment/create_help.go
@@ -79,7 +79,7 @@ $ ecctl deployment create --request-id=GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhG
 	// Remove temporary constants when reads for deployment templates are available on ESS
 	createLongTemp = `Creates a deployment which is defined from a file definition using the --file=<file path> (shorthand: -f) flag.
 
-You can create a definition by using the sample JSON seen here:
+You can create a definition by using the sample JSON:
   https://elastic.co/guide/en/cloud/current/ec-api-deployment-crud.html#ec_create_a_deployment`
 
 	createExampleTemp = `## To make the command wait until the resources have been created use the "--track" flag, which will output 

--- a/docs/ecctl_deployment_create.adoc
+++ b/docs/ecctl_deployment_create.adoc
@@ -8,7 +8,7 @@ Creates a deployment
 
 Creates a deployment which is defined from a file definition using the --file=+++<file path="">+++(shorthand: -f) flag.+++</file>+++
 
-You can create a definition by using the sample JSON seen here:
+You can create a definition by using the sample JSON:
   https://elastic.co/guide/en/cloud/current/ec-api-deployment-crud.html#ec_create_a_deployment
 
 ----

--- a/docs/ecctl_deployment_create.adoc
+++ b/docs/ecctl_deployment_create.adoc
@@ -8,8 +8,8 @@ Creates a deployment
 
 Creates a deployment which is defined from a file definition using the --file=+++<file path="">+++(shorthand: -f) flag.+++</file>+++
 
-//You can create a definition by using the sample JSON seen here:
-//  https://elastic.co/guide/en/cloud/current/ec-api-deployment-crud.html#ec_create_a_deployment
+You can create a definition by using the sample JSON seen here:
+  https://elastic.co/guide/en/cloud/current/ec-api-deployment-crud.html#ec_create_a_deployment
 
 ----
 ecctl deployment create {--file | --size <int> --zones <string> | --topology-element <obj>} [flags]

--- a/docs/ecctl_deployment_create.md
+++ b/docs/ecctl_deployment_create.md
@@ -6,8 +6,8 @@ Creates a deployment
 
 Creates a deployment which is defined from a file definition using the --file=<file path> (shorthand: -f) flag.
 
-//You can create a definition by using the sample JSON seen here:
-//  https://elastic.co/guide/en/cloud/current/ec-api-deployment-crud.html#ec_create_a_deployment
+You can create a definition by using the sample JSON seen here:
+  https://elastic.co/guide/en/cloud/current/ec-api-deployment-crud.html#ec_create_a_deployment
 
 ```
 ecctl deployment create {--file | --size <int> --zones <string> | --topology-element <obj>} [flags]

--- a/docs/ecctl_deployment_create.md
+++ b/docs/ecctl_deployment_create.md
@@ -6,7 +6,7 @@ Creates a deployment
 
 Creates a deployment which is defined from a file definition using the --file=<file path> (shorthand: -f) flag.
 
-You can create a definition by using the sample JSON seen here:
+You can create a definition by using the sample JSON:
   https://elastic.co/guide/en/cloud/current/ec-api-deployment-crud.html#ec_create_a_deployment
 
 ```


### PR DESCRIPTION
**DO NOT MERGE until current release cycle has finalised and the following link works: https://elastic.co/guide/en/cloud/current/ec-api-deployment-crud.html#ec_create_a_deployment**

## Description
In preparations to the upcoming release, this PR updates the output of the `ecctl deployment create --help` command to include a link to our official documentation.

## Related Issues
Related: https://github.com/elastic/ecctl/issues/161

## How Has This Been Tested?
By running `make docs`

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

