### PR TITLE
cmd: fix deployment shutdown command

### DIFF
--- a/cmd/deployment/shutdown.go
+++ b/cmd/deployment/shutdown.go
@@ -40,13 +40,11 @@ var shutdownCmd = &cobra.Command{
 		}
 
 		skipSnapshot, _ := cmd.Flags().GetBool("skip-snapshot")
-		hide, _ := cmd.Flags().GetBool("hide")
 
 		res, err := deployment.Shutdown(deployment.ShutdownParams{
 			API:          ecctl.Get().API,
 			DeploymentID: args[0],
 			SkipSnapshot: skipSnapshot,
-			Hide:         hide,
 		})
 		if err != nil {
 			return err
@@ -67,5 +65,4 @@ func init() {
 	Command.AddCommand(shutdownCmd)
 	shutdownCmd.Flags().BoolP("track", "t", false, cmdutil.TrackFlagMessage)
 	shutdownCmd.Flags().Bool("skip-snapshot", false, "Skips taking an Elasticsearch snapshot prior to shutting down the deployment")
-	shutdownCmd.Flags().Bool("hide", false, "Hides the deployment and its resources after it has been shut down")
 }

--- a/docs/ecctl_deployment_shutdown.adoc
+++ b/docs/ecctl_deployment_shutdown.adoc
@@ -17,7 +17,6 @@ ecctl deployment shutdown <deployment-id> [flags]
 
 ----
   -h, --help            help for shutdown
-      --hide            Hides the deployment and its resources after it has been shut down
       --skip-snapshot   Skips taking an Elasticsearch snapshot prior to shutting down the deployment
   -t, --track           Tracks the progress of the performed task
 ----

--- a/docs/ecctl_deployment_shutdown.md
+++ b/docs/ecctl_deployment_shutdown.md
@@ -14,7 +14,6 @@ ecctl deployment shutdown <deployment-id> [flags]
 
 ```
   -h, --help            help for shutdown
-      --hide            Hides the deployment and its resources after it has been shut down
       --skip-snapshot   Skips taking an Elasticsearch snapshot prior to shutting down the deployment
   -t, --track           Tracks the progress of the performed task
 ```

--- a/pkg/deployment/shutdown.go
+++ b/pkg/deployment/shutdown.go
@@ -33,7 +33,6 @@ type ShutdownParams struct {
 	DeploymentID string
 
 	SkipSnapshot bool
-	Hide         bool
 }
 
 // Validate ensures the parameters are usable by Shutdown.
@@ -61,8 +60,7 @@ func Shutdown(params ShutdownParams) (*models.DeploymentShutdownResponse, error)
 	res, err := params.V1API.Deployments.ShutdownDeployment(
 		deployments.NewShutdownDeploymentParams().
 			WithDeploymentID(params.DeploymentID).
-			WithSkipSnapshot(ec.Bool(params.SkipSnapshot)).
-			WithHide(ec.Bool(params.Hide)),
+			WithSkipSnapshot(ec.Bool(params.SkipSnapshot)),
 		params.AuthWriter,
 	)
 	if err != nil {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
This patch removes the `--hide` flag from the `ecctl deployment shutdown` command.

There was an issue where even if set to false, the API would return the following error if your user role was anything but "platform administrator": `"Parameter [hide] is restricted and can only be set by a Platform administrator"`.

As the shut down deployments are now hidden by default anyway, there is no need for the `--hide` flag anymore.

```console
$ go run main.go --config ess deployment shutdown 6abe0439ac766e4903faa1dbcb38e904
This action will delete the specified deployment ID and its associated sub-resources, do you want to continue? [y/n]: y
{
  "id": "6abe0439ac766e4903faa1dbcb38e904",
  "name": "6abe0439ac766e4903faa1dbcb38e904",
<...>
}
$ go run main.go --config ess deployment list --output json
{
  "deployments": []
}
```

## Related Issues
Related: https://github.com/elastic/ecctl/pull/277

## Motivation and Context
bug

## How Has This Been Tested?
Manually and unit tests

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
