### PR TITLE
release: Fix git config and changelog format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,3 +62,6 @@ jobs:
           VERSION: ${{ steps.get_version.outputs.VERSION }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          GIT_COMMITTER_EMAIL: cloud-delivery@elastic.co
+          GIT_AUTHOR_EMAIL: cloud-delivery@elastic.co
+          GIT_AUTHOR_NAME: elasticcloudmachine

--- a/notes/v1.0.0-beta3.md
+++ b/notes/v1.0.0-beta3.md
@@ -1,3 +1,5 @@
+v1.0.0-beta3
+
 # Changelog
 
 Download the release binaries:

--- a/scripts/changelog.tpl.md
+++ b/scripts/changelog.tpl.md
@@ -1,3 +1,5 @@
+vVERSION_REPLACE
+
 # Changelog
 
 Download the release binaries:

--- a/scripts/goreleaser-post-actions.sh
+++ b/scripts/goreleaser-post-actions.sh
@@ -17,6 +17,14 @@ for f in dist/*.{tar.gz,deb,rpm,txt}; do
 done
 
 # Create the actual Github Release.
+if [[ -z $(git config --get user.email) ]]; then
+    git config user.email "cloud-delivery@elastic.co"
+fi
+
+if [[ -z $(git config --get user.name) ]]; then
+    git config user.name "elasticcloudmachine"
+fi
+
 hub release create -F notes/${VERSION}.md ${VERSION}
 
 # Update the brew tap formula

--- a/scripts/goreleaser-post-actions.sh
+++ b/scripts/goreleaser-post-actions.sh
@@ -16,15 +16,18 @@ for f in dist/*.{tar.gz,deb,rpm,txt}; do
     ${f} s3://download.elasticsearch.org/downloads/ecctl/$(echo ${VERSION}| sed 's/^v//')/
 done
 
+# If in the CI environment and the user credentials aren't set, set them.
+if [[ ${CI} ]]; then
+    if [[ -z $(git config --get user.email) ]]; then
+        git config user.email "cloud-delivery@elastic.co"
+    fi
+
+    if [[ -z $(git config --get user.name) ]]; then
+        git config user.name "elasticcloudmachine"
+    fi
+fi
+
 # Create the actual Github Release.
-if [[ -z $(git config --get user.email) ]]; then
-    git config user.email "cloud-delivery@elastic.co"
-fi
-
-if [[ -z $(git config --get user.name) ]]; then
-    git config user.name "elasticcloudmachine"
-fi
-
 hub release create -F notes/${VERSION}.md ${VERSION}
 
 # Update the brew tap formula

--- a/scripts/goreleaser-post-actions.sh
+++ b/scripts/goreleaser-post-actions.sh
@@ -16,17 +16,6 @@ for f in dist/*.{tar.gz,deb,rpm,txt}; do
     ${f} s3://download.elasticsearch.org/downloads/ecctl/$(echo ${VERSION}| sed 's/^v//')/
 done
 
-# If in the CI environment and the user credentials aren't set, set them.
-if [[ ${CI} ]]; then
-    if [[ -z $(git config --get user.email) ]]; then
-        git config user.email "cloud-delivery@elastic.co"
-    fi
-
-    if [[ -z $(git config --get user.name) ]]; then
-        git config user.name "elasticcloudmachine"
-    fi
-fi
-
 # Create the actual Github Release.
 hub release create -F notes/${VERSION}.md ${VERSION}
 

--- a/scripts/update-brew-tap.sh
+++ b/scripts/update-brew-tap.sh
@@ -28,11 +28,12 @@ mv /tmp/ecctl.rb ${FORMULA_FILE}
 # If in the CI environment and the user credentials aren't set, set them.
 if [[ ${CI} ]]; then
     if [[ -z $(git config --get user.email) ]]; then
-        git config user.email "cloud-delivery@elastic.co"
+        export GIT_AUTHOR_EMAIL="cloud-delivery@elastic.co"
+        export GIT_COMMITTER_EMAIL="cloud-delivery@elastic.co"
     fi
 
     if [[ -z $(git config --get user.name) ]]; then
-        git config user.name "elasticcloudmachine"
+        export GIT_AUTHOR_NAME="${GITHUB_USER}"
     fi
 fi
 

--- a/scripts/update-brew-tap.sh
+++ b/scripts/update-brew-tap.sh
@@ -7,7 +7,9 @@ VERSION=$(echo ${1}| sed 's/^v//')
 
 # Globals
 FORMULA_FILE=/tmp/homebrew-tap/Formula/ecctl.rb
-GITHUB_USER=marclop
+if [[ -z ${GITHUB_USER} ]]; then
+    export GITHUB_USER=elasticcloudmachine
+fi
 
 # Execution
 

--- a/scripts/update-brew-tap.sh
+++ b/scripts/update-brew-tap.sh
@@ -25,18 +25,6 @@ OLD_VERSION=$(grep 'version \"' ${FORMULA_FILE} | awk '{print $2}' | tr -d '"' |
 sed "s/${OLD_VERSION}/${VERSION}/g" ${FORMULA_FILE} | sed "s/${OLD_DARWIN_CHECKSUM}/${DARWIN_CHECKSUM}/" | sed "s/${OLD_LINUX_CHECKSUM}/${LINUX_CHECKSUM}/" > /tmp/ecctl.rb
 mv /tmp/ecctl.rb ${FORMULA_FILE}
 
-# If in the CI environment and the user credentials aren't set, set them.
-if [[ ${CI} ]]; then
-    if [[ -z $(git config --get user.email) ]]; then
-        export GIT_AUTHOR_EMAIL="cloud-delivery@elastic.co"
-        export GIT_COMMITTER_EMAIL="cloud-delivery@elastic.co"
-    fi
-
-    if [[ -z $(git config --get user.name) ]]; then
-        export GIT_AUTHOR_NAME="${GITHUB_USER}"
-    fi
-fi
-
 cd /tmp/homebrew-tap
 hub fork --no-remote
 hub remote add fork https://github.com/${GITHUB_USER}/homebrew-tap

--- a/scripts/update-brew-tap.sh
+++ b/scripts/update-brew-tap.sh
@@ -23,6 +23,17 @@ OLD_VERSION=$(grep 'version \"' ${FORMULA_FILE} | awk '{print $2}' | tr -d '"' |
 sed "s/${OLD_VERSION}/${VERSION}/g" ${FORMULA_FILE} | sed "s/${OLD_DARWIN_CHECKSUM}/${DARWIN_CHECKSUM}/" | sed "s/${OLD_LINUX_CHECKSUM}/${LINUX_CHECKSUM}/" > /tmp/ecctl.rb
 mv /tmp/ecctl.rb ${FORMULA_FILE}
 
+# If in the CI environment and the user credentials aren't set, set them.
+if [[ ${CI} ]]; then
+    if [[ -z $(git config --get user.email) ]]; then
+        git config user.email "cloud-delivery@elastic.co"
+    fi
+
+    if [[ -z $(git config --get user.name) ]]; then
+        git config user.name "elasticcloudmachine"
+    fi
+fi
+
 cd /tmp/homebrew-tap
 hub fork --no-remote
 hub remote add fork https://github.com/${GITHUB_USER}/homebrew-tap


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Fixes the Changelog notes to have the version in the first line as it's
the title that GitHub will use for the release.

Additionally, fixes the issue where the git config doesn't have any user
set, now the script configures it when the settings are missing.

Last, corrects the `GITHUB_USER` to `elasticcloudmachine` when
updating the home-brew tap.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Failing release action.
