### PR TITLE
Docs: Fix links to ECE API APM payload definition (v1.0.0-beta2)

### DIFF
--- a/docs/ecctl_deployment_apm_create.adoc
+++ b/docs/ecctl_deployment_apm_create.adoc
@@ -6,13 +6,13 @@ Creates an Apm instance
 [float]
 === Synopsis
 
-Creates an APM deployment, limitting the creation scope to APM resources.
+Creates an APM deployment, limiting the creation scope to APM resources.
 There are a few ways to create an APM deployment, sane default values are provided, making
 the command work out of the box even when no parameters are set. When version is not specified,
 the matching elasticsearch deployment version will be used. These are the available options:
 
 * Simplified flags: --zones +++<zone count="">+++--size +++<node memory="" in="" MB="">++++++</node>++++++</zone>+++
-* File definition: --file=+++<file path="">+++(shorthand: -f). The definition can be found in: https://www.elastic.co/guide/en/cloud-enterprise/current/definitions.html#ApmPayload+++</file>+++
+* File definition: --file=+++<file path="">+++(shorthand: -f). The definition can be found in: https://www.elastic.co/guide/en/cloud-enterprise/current/ApmPayload.html+++</file>+++
 
 As an option, "--generate-payload" can be used in order to obtain the generated ApmPayload
 that would be sent as a request, save it, update or extend the topology and create an Apm


### PR DESCRIPTION
We're doing some reorganization of the ECE book, so this fixes the APM link that will break as a result of that change. I believe we'll have to merge this at the same time as the ECE changes to avoid a docs build break.
