### PR TITLE
allocator: Populate allocatorapi Region parameter

### DIFF
--- a/cmd/platform/allocator/list.go
+++ b/cmd/platform/allocator/list.go
@@ -68,6 +68,7 @@ func listAllocators(cmd *cobra.Command, args []string) error {
 		Query:      queryString,
 		FilterTags: cmd.Flag("filter").Value.String(),
 		ShowAll:    allFlag,
+		Region:     ecctl.Get().Config.Region,
 	})
 	if err != nil {
 		return err

--- a/cmd/platform/allocator/maintenance.go
+++ b/cmd/platform/allocator/maintenance.go
@@ -35,8 +35,9 @@ var maintenanceAllocatorCmd = &cobra.Command{
 		unset, _ := cmd.Flags().GetBool("unset")
 		fmt.Printf("Setting allocator %s maintenance to %t\n", args[0], !unset)
 		var params = allocatorapi.MaintenanceParams{
-			API: ecctl.Get().API,
-			ID:  args[0],
+			API:    ecctl.Get().API,
+			ID:     args[0],
+			Region: ecctl.Get().Config.Region,
 		}
 
 		if unset {

--- a/cmd/platform/allocator/metadata/command.go
+++ b/cmd/platform/allocator/metadata/command.go
@@ -41,10 +41,11 @@ var allocatorMetadataSetCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		var params = &allocatorapi.MetadataSetParams{
-			API:   ecctl.Get().API,
-			ID:    args[0],
-			Key:   args[1],
-			Value: args[2],
+			API:    ecctl.Get().API,
+			ID:     args[0],
+			Key:    args[1],
+			Value:  args[2],
+			Region: ecctl.Get().Config.Region,
 		}
 		err := allocatorapi.SetAllocatorMetadataItem(*params)
 

--- a/cmd/platform/allocator/search.go
+++ b/cmd/platform/allocator/search.go
@@ -44,7 +44,6 @@ var searchAllocatorCmd = &cobra.Command{
 	Long:    queryExamples,
 	PreRunE: cobra.MaximumNArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
-
 		file, _ := cmd.Flags().GetString(fileArg)
 		query, _ := cmd.Flags().GetString(queryArg)
 
@@ -73,11 +72,11 @@ var searchAllocatorCmd = &cobra.Command{
 			return err
 		}
 
-		r, err := allocatorapi.Search(
-			allocatorapi.SearchParams{
-				API:     ecctl.Get().API,
-				Request: sr,
-			})
+		r, err := allocatorapi.Search(allocatorapi.SearchParams{
+			API:     ecctl.Get().API,
+			Request: sr,
+			Region:  ecctl.Get().Config.Region,
+		})
 		if err != nil {
 			return err
 		}

--- a/cmd/platform/allocator/show.go
+++ b/cmd/platform/allocator/show.go
@@ -28,8 +28,9 @@ import (
 
 func showAllocator(cmd *cobra.Command, args []string) error {
 	a, err := allocatorapi.Get(allocatorapi.GetParams{
-		API: ecctl.Get().API,
-		ID:  args[0],
+		API:    ecctl.Get().API,
+		ID:     args[0],
+		Region: ecctl.Get().Config.Region,
 	})
 	if err != nil {
 		return err

--- a/cmd/platform/allocator/vacate.go
+++ b/cmd/platform/allocator/vacate.go
@@ -23,12 +23,11 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/allocatorapi"
 	sdkcmdutil "github.com/elastic/cloud-sdk-go/pkg/util/cmdutil"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
 	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
-
-	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/allocatorapi"
 
 	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
@@ -176,6 +175,7 @@ var vacateAllocatorCmd = &cobra.Command{
 			},
 			MaxPollRetries: uint8(maxRetries),
 			TrackFrequency: pollFrequency,
+			Region:         ecctl.Get().Config.Region,
 		}
 		if len(args) == 1 && allocatorDownRaw != "" {
 			params.AllocatorDown = &allocatorDown

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"
 	"github.com/elastic/cloud-sdk-go/pkg/output"
 	"github.com/spf13/cobra"
@@ -181,6 +182,10 @@ func initApp(cmd *cobra.Command, client *http.Client, v *viper.Viper) error {
 	}
 	if err := v.Unmarshal(&c); err != nil {
 		return err
+	}
+
+	if c.Region == "" && c.Host != api.ESSEndpoint {
+		c.Region = cmdutil.DefaultECERegion
 	}
 
 	err := util.ReturnErrOnly(ecctl.Instance(c))

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
-	github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200610014412-d8bc0d1b9b30
+	github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200610061007-5771a049905a
 	github.com/go-openapi/runtime v0.19.15
 	github.com/go-openapi/strfmt v0.19.5
 	github.com/hashicorp/go-multierror v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDD
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200610014412-d8bc0d1b9b30 h1:KlJmjQ5ZehOnYtffQ4/7vspv8rg47cckF2+etZ7MAgY=
 github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200610014412-d8bc0d1b9b30/go.mod h1:+0Q5izB9Upzmolj6Pq4AkTsBwgDbQnNpODp3qFK7erQ=
+github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200610061007-5771a049905a h1:Kt6uMlo1rtMXpHEHZBrkI1BGnTcHQhLyXloCj+jWKqI=
+github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200610061007-5771a049905a/go.mod h1:+0Q5izB9Upzmolj6Pq4AkTsBwgDbQnNpODp3qFK7erQ=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail. -->
Populates the new `Region` parameter on all of the allocatorapi calls
and their parameters, and defaults the region to `ece-region` when the
target host is not the ESS endpoint.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Requires https://github.com/elastic/cloud-sdk-go/pull/133 to be merged.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Refactoring (improves code quality but has no user-facing effect)
