### PR TITLE
allocator: Remove the last hashicorp/go-multierror

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -6,19 +6,14 @@ third-party software developed by the licenses listed below.
 
 =========================================================================
 
-github.com/davecgh/go-spew            0BSD
-github.com/elastic/cloud-sdk-go       Apache-2.0
-github.com/go-openapi/runtime         Apache-2.0
-github.com/go-openapi/strfmt          Apache-2.0
-github.com/spf13/cobra                Apache-2.0
-github.com/pkg/errors                 BSD-2-Clause
-github.com/pmezard/go-difflib         BSD-3-Clause
-github.com/spf13/pflag                BSD-3-Clause
-golang.org/x/crypto                   BSD-3-Clause
-github.com/asaskevich/govalidator     MIT
-github.com/blang/semver               MIT
-github.com/spf13/viper                MIT
-github.com/hashicorp/go-multierror    MPL-2.0
-github.com/ghodss/yaml                no license file was found
+github.com/elastic/cloud-sdk-go      Apache-2.0
+github.com/go-openapi/runtime        Apache-2.0
+github.com/go-openapi/strfmt         Apache-2.0
+github.com/spf13/cobra               Apache-2.0
+github.com/pkg/errors                BSD-2-Clause
+github.com/spf13/pflag               BSD-3-Clause
+golang.org/x/crypto                  BSD-3-Clause
+github.com/asaskevich/govalidator    MIT
+github.com/spf13/viper               MIT
 
 =========================================================================

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200611025421-9b8340580ba3
 	github.com/go-openapi/runtime v0.19.15
 	github.com/go-openapi/strfmt v0.19.5
-	github.com/hashicorp/go-multierror v1.0.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v0.0.7
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -59,10 +59,6 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200610014412-d8bc0d1b9b30 h1:KlJmjQ5ZehOnYtffQ4/7vspv8rg47cckF2+etZ7MAgY=
-github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200610014412-d8bc0d1b9b30/go.mod h1:+0Q5izB9Upzmolj6Pq4AkTsBwgDbQnNpODp3qFK7erQ=
-github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200610061007-5771a049905a h1:Kt6uMlo1rtMXpHEHZBrkI1BGnTcHQhLyXloCj+jWKqI=
-github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200610061007-5771a049905a/go.mod h1:+0Q5izB9Upzmolj6Pq4AkTsBwgDbQnNpODp3qFK7erQ=
 github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200611025421-9b8340580ba3 h1:SdgBG2g5oH05SogNFHvJIRtjfye9Ay4GcEaDIr9n5YE=
 github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200611025421-9b8340580ba3/go.mod h1:+0Q5izB9Upzmolj6Pq4AkTsBwgDbQnNpODp3qFK7erQ=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail. -->
Removes the last unprefixed multierror and tidies the `go.sum` and re-
generates the NOTICE file.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Resolves #281 

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Refactoring (improves code quality but has no user-facing effect)
