### PR TITLE
enrollment-token: Populate Region field API calls

### DIFF
--- a/cmd/platform/enrollment-token/create.go
+++ b/cmd/platform/enrollment-token/create.go
@@ -31,6 +31,7 @@ const (
 	validityFlag = "validity"
 )
 
+// nolint for G101: Potential hardcoded credentials
 const tokenCreateExamples = `  ecctl [globalFlags] enrollment-token create --role coordinator
   ecctl [globalFlags] enrollment-token create --role coordinator --role proxy
   ecctl [globalFlags] enrollment-token create --role allocator --validity 120s

--- a/cmd/platform/enrollment-token/create.go
+++ b/cmd/platform/enrollment-token/create.go
@@ -1,0 +1,67 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmdenrollmenttoken
+
+import (
+	"path/filepath"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/enrollmenttokenapi"
+	"github.com/spf13/cobra"
+
+	"github.com/elastic/ecctl/pkg/ecctl"
+)
+
+const (
+	roleFlag     = "role"
+	validityFlag = "validity"
+)
+
+const tokenCreateExamples = `  ecctl [globalFlags] enrollment-token create --role coordinator
+  ecctl [globalFlags] enrollment-token create --role coordinator --role proxy
+  ecctl [globalFlags] enrollment-token create --role allocator --validity 120s
+  ecctl [globalFlags] enrollment-token create --role allocator --validity 2h`
+
+var createTokenCmd = &cobra.Command{
+	Use:     "create --role <ROLE>",
+	Short:   "Creates an enrollment token for role(s)",
+	Example: tokenCreateExamples,
+	PreRunE: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		roles, _ := cmd.Flags().GetStringArray(roleFlag)
+		validity, _ := cmd.Flags().GetDuration(validityFlag)
+
+		res, err := enrollmenttokenapi.Create(enrollmenttokenapi.CreateParams{
+			API:      ecctl.Get().API,
+			Region:   ecctl.Get().Config.Region,
+			Roles:    roles,
+			Duration: validity,
+		})
+		if err != nil {
+			return err
+		}
+		return ecctl.Get().Formatter.Format(filepath.Join("token", "create"), res)
+	},
+}
+
+func init() {
+	Command.AddCommand(createTokenCmd)
+
+	createTokenCmd.Flags().StringArrayP(roleFlag, "r", nil, "Role(s) to associate the tokens with.")
+	createTokenCmd.Flags().DurationP(validityFlag, "v", 0, "Time in seconds for which this token is valid. Currently this will make the token ephemeral (persistent: false)")
+	cobra.MarkFlagRequired(createTokenCmd.Flags(), "role")
+}

--- a/cmd/platform/enrollment-token/delete.go
+++ b/cmd/platform/enrollment-token/delete.go
@@ -18,17 +18,32 @@
 package cmdenrollmenttoken
 
 import (
+	"fmt"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/enrollmenttokenapi"
 	"github.com/spf13/cobra"
 
-	cmdutil "github.com/elastic/ecctl/cmd/util"
+	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
-// Command represents the enrollment-token subcomand.
-var Command = &cobra.Command{
-	Use:     "enrollment-token",
-	Short:   cmdutil.AdminReqDescription("Manages tokens"),
-	PreRunE: cobra.NoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
-		cmd.Help()
+var deleteTokenCmd = &cobra.Command{
+	Use:     "delete <enrollment-token>",
+	Short:   "Deletes an enrollment token",
+	PreRunE: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		err := enrollmenttokenapi.Delete(enrollmenttokenapi.DeleteParams{
+			API:    ecctl.Get().API,
+			Region: ecctl.Get().Config.Region,
+			Token:  args[0],
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Token %s deleted.\n", args[0])
+		return nil
 	},
+}
+
+func init() {
+	Command.AddCommand(deleteTokenCmd)
 }

--- a/cmd/platform/enrollment-token/list.go
+++ b/cmd/platform/enrollment-token/list.go
@@ -18,17 +18,32 @@
 package cmdenrollmenttoken
 
 import (
+	"path/filepath"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/enrollmenttokenapi"
 	"github.com/spf13/cobra"
 
-	cmdutil "github.com/elastic/ecctl/cmd/util"
+	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
-// Command represents the enrollment-token subcomand.
-var Command = &cobra.Command{
-	Use:     "enrollment-token",
-	Short:   cmdutil.AdminReqDescription("Manages tokens"),
+var listTokensCmd = &cobra.Command{
+	Use:     "list",
+	Short:   "Retrieves a list of persistent enrollment tokens",
 	PreRunE: cobra.NoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
-		cmd.Help()
-	},
+	RunE:    listTokens,
+}
+
+func listTokens(cmd *cobra.Command, args []string) error {
+	res, err := enrollmenttokenapi.List(enrollmenttokenapi.ListParams{
+		API:    ecctl.Get().API,
+		Region: ecctl.Get().Config.Region,
+	})
+	if err != nil {
+		return err
+	}
+	return ecctl.Get().Formatter.Format(filepath.Join("token", "list"), res)
+}
+
+func init() {
+	Command.AddCommand(listTokensCmd)
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Updates the enrollment-token commands to use the region per API call.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Requires elastic/cloud-sdk-go#137 to be merged.
