### PR TITLE
deployment-template: Update commands with region

### DIFF
--- a/cmd/platform/deployment-template/create.go
+++ b/cmd/platform/deployment-template/create.go
@@ -1,0 +1,69 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmddeploymentdemplate
+
+import (
+	"fmt"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/configurationtemplateapi"
+	sdkcmdutil "github.com/elastic/cloud-sdk-go/pkg/util/cmdutil"
+	"github.com/spf13/cobra"
+
+	"github.com/elastic/ecctl/pkg/ecctl"
+)
+
+var createCmd = &cobra.Command{
+	Use:     "create -f <template file>.json",
+	Short:   "Creates a platform deployment template",
+	PreRunE: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := sdkcmdutil.FileOrStdin(cmd, "file-template"); err != nil {
+			return err
+		}
+
+		tc, err := parseTemplateFile(cmd.Flag("file-template").Value.String())
+		if err != nil {
+			return err
+		}
+
+		if id := cmd.Flag("id").Value.String(); id != "" {
+			tc.ID = id
+		}
+
+		tid, err := configurationtemplateapi.CreateTemplate(configurationtemplateapi.CreateTemplateParams{
+			Region:                 ecctl.Get().Config.Region,
+			API:                    ecctl.Get().API,
+			ID:                     tc.ID,
+			DeploymentTemplateInfo: tc,
+		})
+
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Successfully created deployment template %v \n", tid)
+		return nil
+
+	},
+}
+
+func init() {
+	Command.AddCommand(createCmd)
+	createCmd.Flags().StringP("file-template", "f", "", "YAML or JSON file that contains the deployment template configuration")
+	createCmd.Flags().String("id", "", "Optional ID to set for the deployment template (Overrides ID if present)")
+}

--- a/cmd/platform/deployment-template/delete.go
+++ b/cmd/platform/deployment-template/delete.go
@@ -1,0 +1,51 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmddeploymentdemplate
+
+import (
+	"fmt"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/configurationtemplateapi"
+	"github.com/spf13/cobra"
+
+	"github.com/elastic/ecctl/pkg/ecctl"
+)
+
+var deleteCmd = &cobra.Command{
+	Use:     "delete <template id>",
+	Short:   "Deletes a specific platform deployment template",
+	PreRunE: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		err := configurationtemplateapi.DeleteTemplate(configurationtemplateapi.DeleteTemplateParams{
+			API:    ecctl.Get().API,
+			Region: ecctl.Get().Config.Region,
+			ID:     args[0],
+		})
+
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Successfully deleted deployment template %v \n", args[0])
+		return nil
+	},
+}
+
+func init() {
+	Command.AddCommand(deleteCmd)
+}

--- a/cmd/platform/deployment-template/list.go
+++ b/cmd/platform/deployment-template/list.go
@@ -1,0 +1,59 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmddeploymentdemplate
+
+import (
+	"path/filepath"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/configurationtemplateapi"
+	"github.com/spf13/cobra"
+
+	"github.com/elastic/ecctl/pkg/ecctl"
+)
+
+var listCmd = &cobra.Command{
+	Use:     "list",
+	Short:   "Lists the platform deployment templates",
+	PreRunE: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		showInstanceConfig, _ := cmd.Flags().GetBool(showInstanceConfigurations)
+		stackVersion, _ := cmd.Flags().GetString(stackVersion)
+		metadataFilter, _ := cmd.Flags().GetString(filter)
+
+		res, err := configurationtemplateapi.ListTemplates(configurationtemplateapi.ListTemplateParams{
+			API:                ecctl.Get().API,
+			Region:             ecctl.Get().Config.Region,
+			ShowInstanceConfig: showInstanceConfig,
+			StackVersion:       stackVersion,
+			Metadata:           metadataFilter,
+		})
+
+		if err != nil {
+			return err
+		}
+
+		return ecctl.Get().Formatter.Format(filepath.Join("deployment-template", "list"), res)
+	},
+}
+
+func init() {
+	Command.AddCommand(listCmd)
+	listCmd.Flags().BoolP(showInstanceConfigurations, "", false, "Shows instance configurations - only visible when using the JSON output")
+	listCmd.Flags().String(stackVersion, "", "If present, it will cause the returned deployment templates to be adapted to return only the elements allowed in that version.")
+	listCmd.Flags().String(filter, "", "Optional key/value pair in the form of key:value that will act as a filter and exclude any templates that do not have a matching metadata item associated")
+}

--- a/cmd/platform/deployment-template/pull.go
+++ b/cmd/platform/deployment-template/pull.go
@@ -1,0 +1,45 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmddeploymentdemplate
+
+import (
+	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/configurationtemplateapi"
+
+	"github.com/spf13/cobra"
+
+	"github.com/elastic/ecctl/pkg/ecctl"
+)
+
+var pullCmd = &cobra.Command{
+	Use:     "pull --path <path>",
+	Short:   "Downloads deployment template into a local folder",
+	PreRunE: cobra.MaximumNArgs(0),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return configurationtemplateapi.PullToFolder(configurationtemplateapi.PullToFolderParams{
+			API:    ecctl.Get().API,
+			Region: ecctl.Get().Config.Region,
+			Folder: cmd.Flag("path").Value.String(),
+		})
+	},
+}
+
+func init() {
+	Command.AddCommand(pullCmd)
+	pullCmd.Flags().StringP("path", "p", "", "Local path where to store deployment templates")
+	pullCmd.MarkFlagRequired("path")
+}

--- a/cmd/platform/deployment-template/show.go
+++ b/cmd/platform/deployment-template/show.go
@@ -1,0 +1,53 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmddeploymentdemplate
+
+import (
+	"path/filepath"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/configurationtemplateapi"
+	"github.com/spf13/cobra"
+
+	"github.com/elastic/ecctl/pkg/ecctl"
+)
+
+var showCmd = &cobra.Command{
+	Use:     "show <template id>",
+	Short:   "Shows information about a specific platform deployment template",
+	PreRunE: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		show, _ := cmd.Flags().GetBool("show-instance-configurations")
+		res, err := configurationtemplateapi.GetTemplate(configurationtemplateapi.GetTemplateParams{
+			API:                ecctl.Get().API,
+			Region:             ecctl.Get().Config.Region,
+			ID:                 args[0],
+			ShowInstanceConfig: show,
+		})
+
+		if err != nil {
+			return err
+		}
+
+		return ecctl.Get().Formatter.Format(filepath.Join("deployment-template", "show"), res)
+	},
+}
+
+func init() {
+	Command.AddCommand(showCmd)
+	showCmd.Flags().BoolP(showInstanceConfigurations, "", false, "Shows instance configurations")
+}

--- a/cmd/platform/deployment-template/update.go
+++ b/cmd/platform/deployment-template/update.go
@@ -1,0 +1,63 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmddeploymentdemplate
+
+import (
+	"fmt"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/configurationtemplateapi"
+	sdkcmdutil "github.com/elastic/cloud-sdk-go/pkg/util/cmdutil"
+	"github.com/spf13/cobra"
+
+	"github.com/elastic/ecctl/pkg/ecctl"
+)
+
+var updateCmd = &cobra.Command{
+	Use:     "update <template id> -f <template file>.json",
+	Short:   "Updates a platform deployment template",
+	PreRunE: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := sdkcmdutil.FileOrStdin(cmd, "file-template"); err != nil {
+			return err
+		}
+		tc, err := parseTemplateFile(cmd.Flag("file-template").Value.String())
+		if err != nil {
+			return err
+		}
+
+		if err := configurationtemplateapi.UpdateTemplate(
+			configurationtemplateapi.UpdateTemplateParams{
+				API:                    ecctl.Get().API,
+				Region:                 ecctl.Get().Config.Region,
+				ID:                     args[0],
+				DeploymentTemplateInfo: tc,
+			},
+		); err != nil {
+			return err
+		}
+
+		fmt.Printf("Successfully updated deployment template %v \n", args[0])
+		return nil
+
+	},
+}
+
+func init() {
+	Command.AddCommand(updateCmd)
+	updateCmd.Flags().StringP("file-template", "f", "", "YAML or JSON file that contains the deployment template configuration")
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
-	github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200615055322-c662e41de769
+	github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200623011303-1e53d46b11d8
 	github.com/go-openapi/runtime v0.19.15
 	github.com/go-openapi/strfmt v0.19.5
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200615055322-c662e41de769 h1:XoJx1X8VJQFlgvfeHGqLdWz0NJAEYuZzZixEXu6V3wQ=
-github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200615055322-c662e41de769/go.mod h1:+0Q5izB9Upzmolj6Pq4AkTsBwgDbQnNpODp3qFK7erQ=
+github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200623011303-1e53d46b11d8 h1:1X/M7KeBGO/I7t65Mo+VC9R9hWxDSgO4A7kTmpJQfWg=
+github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200623011303-1e53d46b11d8/go.mod h1:+0Q5izB9Upzmolj6Pq4AkTsBwgDbQnNpODp3qFK7erQ=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Updates the `deployment-template` commands to use a `region` on the API
calls to the SDK.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Requires elastic/cloud-sdk-go#146 to be merged.
