### PR TITLE
deployment create: Remove region value on non-ESS

### DIFF
--- a/cmd/deployment/create.go
+++ b/cmd/deployment/create.go
@@ -65,11 +65,6 @@ var createCmd = &cobra.Command{
 		var appsearchSize, _ = cmd.Flags().GetInt32("appsearch-size")
 		var appsearchRefID, _ = cmd.Flags().GetString("appsearch-ref-id")
 
-		region := ecctl.Get().Config.Region
-		if region == "" {
-			region = cmdutil.DefaultECERegion
-		}
-
 		var payload *models.DeploymentCreateRequest
 		if err := sdkcmdutil.FileOrStdin(cmd, "file"); err == nil {
 			err := sdkcmdutil.DecodeDefinition(cmd, "file", &payload)
@@ -85,7 +80,7 @@ var createCmd = &cobra.Command{
 				Name:                 name,
 				DeploymentTemplateID: dt,
 				Version:              version,
-				Region:               region,
+				Region:               ecctl.Get().Config.Region,
 				Writer:               ecctl.Get().Config.ErrorDevice,
 				Plugins:              plugin,
 				TopologyElements:     te,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -184,6 +184,7 @@ func initApp(cmd *cobra.Command, client *http.Client, v *viper.Viper) error {
 		return err
 	}
 
+	// Set the default region to `ece-region` when the endpoint is not the ESS endpoint.
 	if c.Region == "" && c.Host != api.ESSEndpoint {
 		c.Region = cmdutil.DefaultECERegion
 	}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Removes the default "ece-region" assignment on the deployment create cmd
layer when the region is empty and the endpoint is not targetting ESS.

It only affects a flag-based creation and not the payload.

The assignment is already taken care of here: https://github.com/elastic/ecctl/blob/master/cmd/root.go#L187-L189