### PR TITLE
cmd/util/testutils: Add RunCmdAssertion test function

### DIFF
--- a/cmd/deployment/create_test.go
+++ b/cmd/deployment/create_test.go
@@ -1,0 +1,343 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmddeployment
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+	planmock "github.com/elastic/cloud-sdk-go/pkg/plan/mock"
+	sdkcmdutil "github.com/elastic/cloud-sdk-go/pkg/util/cmdutil"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/ecctl/cmd/util/testutils"
+)
+
+func Test_createCmd(t *testing.T) {
+	var deploymentID = ec.RandomResourceID()
+	var esID = ec.RandomResourceID()
+	var kibanaID = ec.RandomResourceID()
+	var azureCreateResponse = models.DeploymentCreateResponse{
+		Created: ec.Bool(true),
+		ID:      ec.String(deploymentID),
+		Name:    ec.String("search-dev-azure-westeurope"),
+		Resources: []*models.DeploymentResource{
+			{
+				ID:     ec.String(esID),
+				Kind:   ec.String("elasticsearch"),
+				RefID:  ec.String("main-elasticsearch"),
+				Region: ec.String("azure-westeurope"),
+				Credentials: &models.ClusterCredentials{
+					Username: ec.String("myuser"),
+					Password: ec.String("mypass"),
+				},
+			},
+			{
+				ID:     ec.String(kibanaID),
+				Kind:   ec.String("kibana"),
+				RefID:  ec.String("main-kibana"),
+				Region: ec.String("azure-westeurope"),
+			},
+		},
+	}
+	azureCreateResponseBytes, err := json.MarshalIndent(azureCreateResponse, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var awsDeploymentID = ec.RandomResourceID()
+	var awsESID = ec.RandomResourceID()
+	var awsKibanaID = ec.RandomResourceID()
+	var awsCreateResponse = models.DeploymentCreateResponse{
+		Created: ec.Bool(true),
+		ID:      ec.String(awsDeploymentID),
+		Name:    ec.String("test-create-aws"),
+		Resources: []*models.DeploymentResource{
+			{
+				ID:     ec.String(awsESID),
+				Kind:   ec.String("elasticsearch"),
+				RefID:  ec.String("main-elasticsearch"),
+				Region: ec.String("us-east-1"),
+				Credentials: &models.ClusterCredentials{
+					Username: ec.String("myuser"),
+					Password: ec.String("mypass"),
+				},
+			},
+			{
+				ID:     ec.String(awsKibanaID),
+				Kind:   ec.String("kibana"),
+				RefID:  ec.String("main-kibana"),
+				Region: ec.String("us-east-1"),
+			},
+		},
+	}
+	awsCreateResponseBytes, err := json.MarshalIndent(awsCreateResponse, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var awsTrackOutput = fmt.Sprintf(`Deployment [%s] - [Elasticsearch][%s]: running step "waiting-for-some-step" (Plan duration )...
+Deployment [%s] - [Kibana][%s]: running step "waiting-for-some-step" (Plan duration )...`+"\n"+
+		"\x1b[92;mDeployment [%s] - [Elasticsearch][%s]: finished running all the plan steps\x1b[0m (Total plan duration )\n"+
+		"\x1b[92;mDeployment [%s] - [Kibana][%s]: finished running all the plan steps\x1b[0m (Total plan duration )\n",
+		awsDeploymentID, awsESID, awsDeploymentID, awsKibanaID,
+		awsDeploymentID, awsESID, awsDeploymentID, awsKibanaID,
+	)
+
+	var awsCreateResponses = []mock.Response{
+		{
+			Response: http.Response{
+				StatusCode: 201,
+				Body:       mock.NewStructBody(awsCreateResponse),
+			},
+			Assert: &mock.RequestAssertion{
+				Method: "POST",
+				Header: api.DefaultWriteMockHeaders,
+				Body:   mock.NewStringBody(`{"name":"test-create-aws","resources":{"apm":null,"appsearch":null,"elasticsearch":[{"plan":{"cluster_topology":[{"instance_configuration_id":"aws.data.highio.i3","node_type":{"data":true,"ingest":true,"master":true},"size":{"resource":"memory","value":1024},"zone_count":2}],"deployment_template":{"id":"aws-io-optimized"},"elasticsearch":{"version":"7.8.0"}},"ref_id":"main-elasticsearch","region":"us-east-1","settings":{"dedicated_masters_threshold":6}}],"enterprise_search":null,"kibana":[{"elasticsearch_cluster_ref_id":"main-elasticsearch","plan":{"cluster_topology":[{"instance_configuration_id":"aws.kibana.r4","size":{"resource":"memory","value":1024},"zone_count":1}],"kibana":{"version":"7.8.0"}},"ref_id":"main-kibana","region":"us-east-1"}]}}` + "\n"),
+				Path:   "/api/v1/deployments",
+				Host:   api.DefaultMockHost,
+				Query: url.Values{
+					"request_id":    {"some_other_request_id"},
+					"validate_only": {"false"},
+				},
+			},
+		},
+		mock.New200StructResponse(planmock.Generate(planmock.GenerateConfig{
+			ID: awsDeploymentID,
+			Elasticsearch: []planmock.GeneratedResourceConfig{
+				{
+					ID: awsESID,
+					PendingLog: planmock.NewPlanStepLog(
+						planmock.NewPlanStep("waiting-for-some-step", "pending"),
+					),
+				},
+			},
+			Kibana: []planmock.GeneratedResourceConfig{
+				{
+					ID: awsKibanaID,
+					PendingLog: planmock.NewPlanStepLog(
+						planmock.NewPlanStep("waiting-for-some-step", "pending"),
+					),
+				},
+			},
+		})),
+		mock.New500Response(mock.NewStringBody("some error")),
+		mock.New200StructResponse(planmock.Generate(planmock.GenerateConfig{
+			ID: awsDeploymentID,
+			Elasticsearch: []planmock.GeneratedResourceConfig{
+				{
+					ID: awsESID,
+					CurrentLog: planmock.NewPlanStepLog(
+						planmock.NewPlanStep("plan-completed", "success"),
+					),
+				},
+			},
+			Kibana: []planmock.GeneratedResourceConfig{
+				{
+					ID: awsKibanaID,
+					CurrentLog: planmock.NewPlanStepLog(
+						planmock.NewPlanStep("plan-completed", "success"),
+					),
+				},
+			},
+		})),
+		mock.New200StructResponse(planmock.Generate(planmock.GenerateConfig{
+			ID: awsDeploymentID,
+			Elasticsearch: []planmock.GeneratedResourceConfig{
+				{
+					ID: awsESID,
+					CurrentLog: planmock.NewPlanStepLog(
+						planmock.NewPlanStep("plan-completed", "success"),
+					),
+				},
+			},
+			Kibana: []planmock.GeneratedResourceConfig{
+				{
+					ID: awsKibanaID,
+					CurrentLog: planmock.NewPlanStepLog(
+						planmock.NewPlanStep("plan-completed", "success"),
+					),
+				},
+			},
+		})),
+	}
+
+	tests := []struct {
+		name string
+		args testutils.Args
+		want testutils.Assertion
+	}{
+		{
+			name: "unexisting file returns invalid argument",
+			args: testutils.Args{
+				Cmd: createCmd,
+				Args: []string{
+					"create", "--file=unexisting.json",
+				},
+			},
+			want: testutils.Assertion{
+				Err: multierror.NewPrefixed("failed reading the file definition",
+					errors.New("invalid argument"),
+					errors.New("could not read the specified file, please make sure it exists"),
+				),
+				Stderr: `http transport warning: failed converting *mock.RoundTripper to *http.Transport` + "\n",
+			},
+		},
+		{
+			name: "succeeds creating an Azure deployment with payload and without tracking",
+			args: testutils.Args{
+				Cmd: createCmd,
+				Args: []string{
+					"create", "--file=testdata/create-azure.json",
+					"--request-id=some_request_id",
+				},
+				Cfg: testutils.MockCfg{Responses: []mock.Response{
+					{
+						Response: http.Response{
+							StatusCode: 201,
+							Body:       mock.NewStructBody(azureCreateResponse),
+						},
+						Assert: &mock.RequestAssertion{
+							Method: "POST",
+							Header: api.DefaultWriteMockHeaders,
+							Body:   mock.NewStringBody(`{"name":"search-dev-azure-westeurope","resources":{"apm":null,"appsearch":null,"elasticsearch":[{"plan":{"cluster_topology":[{"elasticsearch":{},"instance_configuration_id":"azure.data.highio.l32sv2","node_type":{"data":true,"ingest":true,"master":true},"size":{"resource":"memory","value":1024},"zone_count":2}],"deployment_template":{"id":"azure-io-optimized"},"elasticsearch":{"version":"7.8.0"}},"ref_id":"main-elasticsearch","region":"azure-westeurope","settings":{"dedicated_masters_threshold":6}}],"enterprise_search":null,"kibana":[{"elasticsearch_cluster_ref_id":"main-elasticsearch","plan":{"cluster_topology":[{"instance_configuration_id":"azure.kibana.e32sv3","size":{"resource":"memory","value":1024},"zone_count":1}],"kibana":{"version":"7.8.0"}},"ref_id":"main-kibana","region":"azure-westeurope"}]}}` + "\n"),
+							Path:   "/api/v1/deployments",
+							Host:   api.DefaultMockHost,
+							Query: url.Values{
+								"request_id":    {"some_request_id"},
+								"validate_only": {"false"},
+							},
+						},
+					},
+				}},
+			},
+			want: testutils.Assertion{
+				Stderr: `http transport warning: failed converting *mock.RoundTripper to *http.Transport` + "\n",
+				Stdout: string(azureCreateResponseBytes) + "\n",
+			},
+		},
+		{
+			name: "succeeds creating an AWS deployment with payload with tracking",
+			args: testutils.Args{
+				Cmd: createCmd,
+				Args: []string{
+					"create", "--file=testdata/create-aws.json", "--track",
+					"--request-id=some_other_request_id",
+				},
+				Cfg: testutils.MockCfg{Responses: awsCreateResponses, OutputFormat: "text"},
+			},
+			want: testutils.Assertion{
+				Stderr: `http transport warning: failed converting *mock.RoundTripper to *http.Transport` + "\n",
+				Stdout: string(awsCreateResponseBytes) + "\n" + awsTrackOutput,
+			},
+		},
+		{
+			name: "existing file tries to create deployment with payload and fails without tracking",
+			args: testutils.Args{
+				Cmd: createCmd,
+				Args: []string{
+					"create", "--file=testdata/create-azure.json",
+					"--request-id=some_request_id",
+				},
+				Cfg: testutils.MockCfg{
+					Responses: []mock.Response{
+						{
+							Response: http.Response{
+								StatusCode: 404,
+								Body:       mock.NewStringBody(`{"error": "some"}`),
+							},
+							Assert: &mock.RequestAssertion{
+								Method: "POST",
+								Header: api.DefaultWriteMockHeaders,
+								Body:   mock.NewStringBody(`{"name":"search-dev-azure-westeurope","resources":{"apm":null,"appsearch":null,"elasticsearch":[{"plan":{"cluster_topology":[{"elasticsearch":{},"instance_configuration_id":"azure.data.highio.l32sv2","node_type":{"data":true,"ingest":true,"master":true},"size":{"resource":"memory","value":1024},"zone_count":2}],"deployment_template":{"id":"azure-io-optimized"},"elasticsearch":{"version":"7.8.0"}},"ref_id":"main-elasticsearch","region":"azure-westeurope","settings":{"dedicated_masters_threshold":6}}],"enterprise_search":null,"kibana":[{"elasticsearch_cluster_ref_id":"main-elasticsearch","plan":{"cluster_topology":[{"instance_configuration_id":"azure.kibana.e32sv3","size":{"resource":"memory","value":1024},"zone_count":1}],"kibana":{"version":"7.8.0"}},"ref_id":"main-kibana","region":"azure-westeurope"}]}}` + "\n"),
+								Path:   "/api/v1/deployments",
+								Host:   api.DefaultMockHost,
+								Query: url.Values{
+									"request_id":    {"some_request_id"},
+									"validate_only": {"false"},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: testutils.Assertion{
+				Err: errors.New(`{"error": "some"}`),
+				Stderr: `http transport warning: failed converting *mock.RoundTripper to *http.Transport` + "\n" +
+					"The deployment creation returned with an error. Use the displayed request ID to recreate the deployment resources" +
+					"\n" + "Request ID: some_request_id" + "\n",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testutils.TestCommand(t, tt.args, tt.want)
+		})
+	}
+}
+
+func Test_returnErrOnHidden(t *testing.T) {
+	type args struct {
+		err    error
+		hidden bool
+	}
+	tests := []struct {
+		name string
+		args args
+		err  error
+	}{
+		{
+			name: "an error is returned",
+			args: args{
+				err: errors.New("some"),
+			},
+			err: errors.New("some"),
+		},
+		{
+			name: "an error is returned when hidden is false and == sdkcmdutil.ErrNodefinitionLoaded",
+			args: args{
+				err: sdkcmdutil.ErrNodefinitionLoaded,
+			},
+		},
+		{
+			name: "an error is returned when hidden is true and == sdkcmdutil.ErrNodefinitionLoaded",
+			args: args{
+				err:    sdkcmdutil.ErrNodefinitionLoaded,
+				hidden: true,
+			},
+			err: sdkcmdutil.ErrNodefinitionLoaded,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := returnErrOnHidden(tt.args.err, tt.args.hidden)
+			if !assert.Equal(t, tt.err, err) {
+				t.Error(err)
+			}
+		})
+	}
+}

--- a/cmd/deployment/create_test.go
+++ b/cmd/deployment/create_test.go
@@ -238,7 +238,6 @@ Deployment [%s] - [Apm][%s]: running step "waiting-for-some-step" (Plan duration
 					errors.New("invalid argument"),
 					errors.New("could not read the specified file, please make sure it exists"),
 				),
-				Stderr: `http transport warning: failed converting *mock.RoundTripper to *http.Transport` + "\n",
 			},
 		},
 		{
@@ -270,7 +269,6 @@ Deployment [%s] - [Apm][%s]: running step "waiting-for-some-step" (Plan duration
 				}},
 			},
 			want: testutils.Assertion{
-				Stderr: `http transport warning: failed converting *mock.RoundTripper to *http.Transport` + "\n",
 				Stdout: string(azureCreateResponseBytes) + "\n",
 			},
 		},
@@ -285,7 +283,6 @@ Deployment [%s] - [Apm][%s]: running step "waiting-for-some-step" (Plan duration
 				Cfg: testutils.MockCfg{Responses: awsCreateResponses, OutputFormat: "text"},
 			},
 			want: testutils.Assertion{
-				Stderr: `http transport warning: failed converting *mock.RoundTripper to *http.Transport` + "\n",
 				Stdout: string(awsCreateResponseBytes) + "\n" + awsTrackOutput,
 			},
 		},
@@ -321,8 +318,7 @@ Deployment [%s] - [Apm][%s]: running step "waiting-for-some-step" (Plan duration
 			},
 			want: testutils.Assertion{
 				Err: errors.New(`{"error": "some"}`),
-				Stderr: `http transport warning: failed converting *mock.RoundTripper to *http.Transport` + "\n" +
-					"The deployment creation returned with an error. Use the displayed request ID to recreate the deployment resources" +
+				Stderr: "The deployment creation returned with an error. Use the displayed request ID to recreate the deployment resources" +
 					"\n" + "Request ID: some_request_id" + "\n",
 			},
 		},

--- a/cmd/deployment/testdata/create-aws.json
+++ b/cmd/deployment/testdata/create-aws.json
@@ -1,59 +1,81 @@
 {
     "name": "test-create-aws",
     "resources": {
-      "elasticsearch": [
-        {
-          "region": "us-east-1",
-          "ref_id": "main-elasticsearch",
-          "plan": {
-            "cluster_topology": [
-              {
-                "node_type": {
-                  "data": true,
-                  "master": true,
-                  "ingest": true
+        "elasticsearch": [
+            {
+                "region": "us-east-1",
+                "ref_id": "main-elasticsearch",
+                "plan": {
+                    "cluster_topology": [
+                        {
+                            "node_type": {
+                                "data": true,
+                                "master": true,
+                                "ingest": true
+                            },
+                            "instance_configuration_id": "aws.data.highio.i3",
+                            "zone_count": 2,
+                            "size": {
+                                "resource": "memory",
+                                "value": 1024
+                            }
+                        }
+                    ],
+                    "elasticsearch": {
+                        "version": "7.8.0"
+                    },
+                    "deployment_template": {
+                        "id": "aws-io-optimized"
+                    }
                 },
-                "instance_configuration_id": "aws.data.highio.i3",
-                "zone_count": 2,
-                "size": {
-                  "resource": "memory",
-                  "value": 1024
+                "settings": {
+                    "dedicated_masters_threshold": 6
                 }
-              }
-            ],
-            "elasticsearch": {
-              "version": "7.8.0"
-            },
-            "deployment_template": {
-              "id": "aws-io-optimized"
             }
-          },
-          "settings": {
-            "dedicated_masters_threshold": 6
-          }
-        }
-      ],
-      "kibana": [
-        {
-          "region": "us-east-1",
-          "elasticsearch_cluster_ref_id": "main-elasticsearch",
-          "ref_id": "main-kibana",
-          "plan": {
-            "cluster_topology": [
-              {
-                "instance_configuration_id": "aws.kibana.r4",
-                "zone_count": 1,
-                "size": {
-                  "resource": "memory",
-                  "value": 1024
+        ],
+        "kibana": [
+            {
+                "region": "us-east-1",
+                "elasticsearch_cluster_ref_id": "main-elasticsearch",
+                "ref_id": "main-kibana",
+                "plan": {
+                    "cluster_topology": [
+                        {
+                            "instance_configuration_id": "aws.kibana.r4",
+                            "zone_count": 1,
+                            "size": {
+                                "resource": "memory",
+                                "value": 1024
+                            }
+                        }
+                    ],
+                    "kibana": {
+                        "version": "7.8.0"
+                    }
                 }
-              }
-            ],
-            "kibana": {
-              "version": "7.8.0"
             }
-          }
-        }
-      ]
+        ],
+        "apm": [
+            {
+                "region": "us-east-1",
+                "elasticsearch_cluster_ref_id": "main-elasticsearch",
+                "ref_id": "main-apm",
+                "plan": {
+                    "cluster_topology": [
+                        {
+                            "instance_configuration_id": "aws.apm.r4",
+                            "zone_count": 1,
+                            "size": {
+                                "resource": "memory",
+                                "value": 512
+                            }
+                        }
+                    ],
+                    "apm": {
+                        "version": "7.8.0"
+                    }
+                }
+            }
+        ]
     }
-  }
+}

--- a/cmd/deployment/testdata/create-aws.json
+++ b/cmd/deployment/testdata/create-aws.json
@@ -1,0 +1,59 @@
+{
+    "name": "test-create-aws",
+    "resources": {
+      "elasticsearch": [
+        {
+          "region": "us-east-1",
+          "ref_id": "main-elasticsearch",
+          "plan": {
+            "cluster_topology": [
+              {
+                "node_type": {
+                  "data": true,
+                  "master": true,
+                  "ingest": true
+                },
+                "instance_configuration_id": "aws.data.highio.i3",
+                "zone_count": 2,
+                "size": {
+                  "resource": "memory",
+                  "value": 1024
+                }
+              }
+            ],
+            "elasticsearch": {
+              "version": "7.8.0"
+            },
+            "deployment_template": {
+              "id": "aws-io-optimized"
+            }
+          },
+          "settings": {
+            "dedicated_masters_threshold": 6
+          }
+        }
+      ],
+      "kibana": [
+        {
+          "region": "us-east-1",
+          "elasticsearch_cluster_ref_id": "main-elasticsearch",
+          "ref_id": "main-kibana",
+          "plan": {
+            "cluster_topology": [
+              {
+                "instance_configuration_id": "aws.kibana.r4",
+                "zone_count": 1,
+                "size": {
+                  "resource": "memory",
+                  "value": 1024
+                }
+              }
+            ],
+            "kibana": {
+              "version": "7.8.0"
+            }
+          }
+        }
+      ]
+    }
+  }

--- a/cmd/deployment/testdata/create-azure.json
+++ b/cmd/deployment/testdata/create-azure.json
@@ -1,62 +1,62 @@
 {
     "name": "search-dev-azure-westeurope",
     "resources": {
-      "elasticsearch": [
-        {
-          "region": "azure-westeurope",
-          "ref_id": "main-elasticsearch",
-          "plan": {
-            "cluster_topology": [
-              {
-                "node_type": {
-                  "data": true,
-                  "master": true,
-                  "ingest": true
+        "elasticsearch": [
+            {
+                "region": "azure-westeurope",
+                "ref_id": "main-elasticsearch",
+                "plan": {
+                    "cluster_topology": [
+                        {
+                            "node_type": {
+                                "data": true,
+                                "master": true,
+                                "ingest": true
+                            },
+                            "instance_configuration_id": "azure.data.highio.l32sv2",
+                            "zone_count": 2,
+                            "size": {
+                                "resource": "memory",
+                                "value": 1024
+                            },
+                            "elasticsearch": {
+                                "enabled_built_in_plugins": []
+                            }
+                        }
+                    ],
+                    "elasticsearch": {
+                        "version": "7.8.0"
+                    },
+                    "deployment_template": {
+                        "id": "azure-io-optimized"
+                    }
                 },
-                "instance_configuration_id": "azure.data.highio.l32sv2",
-                "zone_count": 2,
-                "size": {
-                  "resource": "memory",
-                  "value": 1024
-                },
-                "elasticsearch": {
-                  "enabled_built_in_plugins": []
+                "settings": {
+                    "dedicated_masters_threshold": 6
                 }
-              }
-            ],
-            "elasticsearch": {
-              "version": "7.8.0"
-            },
-            "deployment_template": {
-              "id": "azure-io-optimized"
             }
-          },
-          "settings": {
-            "dedicated_masters_threshold": 6
-          }
-        }
-      ],
-      "kibana": [
-        {
-          "region": "azure-westeurope",
-          "elasticsearch_cluster_ref_id": "main-elasticsearch",
-          "ref_id": "main-kibana",
-          "plan": {
-            "cluster_topology": [
-              {
-                "instance_configuration_id": "azure.kibana.e32sv3",
-                "zone_count": 1,
-                "size": {
-                  "resource": "memory",
-                  "value": 1024
+        ],
+        "kibana": [
+            {
+                "region": "azure-westeurope",
+                "elasticsearch_cluster_ref_id": "main-elasticsearch",
+                "ref_id": "main-kibana",
+                "plan": {
+                    "cluster_topology": [
+                        {
+                            "instance_configuration_id": "azure.kibana.e32sv3",
+                            "zone_count": 1,
+                            "size": {
+                                "resource": "memory",
+                                "value": 1024
+                            }
+                        }
+                    ],
+                    "kibana": {
+                        "version": "7.8.0"
+                    }
                 }
-              }
-            ],
-            "kibana": {
-              "version": "7.8.0"
             }
-          }
-        }
-      ]
+        ]
     }
-  }
+}

--- a/cmd/deployment/testdata/create-azure.json
+++ b/cmd/deployment/testdata/create-azure.json
@@ -1,0 +1,62 @@
+{
+    "name": "search-dev-azure-westeurope",
+    "resources": {
+      "elasticsearch": [
+        {
+          "region": "azure-westeurope",
+          "ref_id": "main-elasticsearch",
+          "plan": {
+            "cluster_topology": [
+              {
+                "node_type": {
+                  "data": true,
+                  "master": true,
+                  "ingest": true
+                },
+                "instance_configuration_id": "azure.data.highio.l32sv2",
+                "zone_count": 2,
+                "size": {
+                  "resource": "memory",
+                  "value": 1024
+                },
+                "elasticsearch": {
+                  "enabled_built_in_plugins": []
+                }
+              }
+            ],
+            "elasticsearch": {
+              "version": "7.8.0"
+            },
+            "deployment_template": {
+              "id": "azure-io-optimized"
+            }
+          },
+          "settings": {
+            "dedicated_masters_threshold": 6
+          }
+        }
+      ],
+      "kibana": [
+        {
+          "region": "azure-westeurope",
+          "elasticsearch_cluster_ref_id": "main-elasticsearch",
+          "ref_id": "main-kibana",
+          "plan": {
+            "cluster_topology": [
+              {
+                "instance_configuration_id": "azure.kibana.e32sv3",
+                "zone_count": 1,
+                "size": {
+                  "resource": "memory",
+                  "value": 1024
+                }
+              }
+            ],
+            "kibana": {
+              "version": "7.8.0"
+            }
+          }
+        }
+      ]
+    }
+  }

--- a/cmd/util/testutils/cmd.go
+++ b/cmd/util/testutils/cmd.go
@@ -1,0 +1,94 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package testutils
+
+import (
+	"bytes"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	durationExpr = `duration.*\)`
+	durationRepl = "duration )"
+)
+
+// Args represent are required args to test a command.
+type Args struct {
+	Cmd  *cobra.Command
+	Args []string
+	Cfg  MockCfg
+}
+
+// Assertion to use for tests.
+type Assertion struct {
+	Err    error
+	Stdout string
+	Stderr string
+}
+
+// TestCommand tests a `*cobra.Command` and uses the testing.T struct to
+// return any unmatched assertions.
+func TestCommand(t *testing.T, args Args, assertion Assertion) {
+	cfg := fillDefaults(args.Cfg)
+	cfg.Out = new(bytes.Buffer)
+	cfg.Err = new(bytes.Buffer)
+
+	defer MockApp(t, cfg)()
+
+	// Set the command arguments.
+	args.Cmd.Root().SetArgs(args.Args)
+
+	// Necessary to reduce the clutter on the output
+	args.Cmd.SilenceUsage = true
+	args.Cmd.SilenceErrors = true
+
+	// Set the Out and Err to the mocked devices.
+	args.Cmd.SetOutput(cfg.Out)
+	args.Cmd.SetErr(cfg.Err)
+
+	if err := args.Cmd.Execute(); !assert.Equal(t, assertion.Err, err) {
+		t.Error(err)
+	}
+
+	if buf, ok := args.Cmd.OutOrStdout().(*bytes.Buffer); ok {
+		var got = buf.String()
+
+		// When the output contains the `--track` flag, removes the non-
+		// assertable duration time.
+		if strings.Contains(strings.Join(args.Args, " "), "--track") {
+			got = regexp.MustCompile(durationExpr).ReplaceAllString(
+				got, durationRepl,
+			)
+		}
+
+		if got != assertion.Stdout {
+			t.Errorf(`"Got stdout "%s" != want "%s"`, got, assertion.Stdout)
+		}
+	}
+
+	if buf, ok := args.Cmd.ErrOrStderr().(*bytes.Buffer); ok {
+		if got := buf.String(); got != assertion.Stderr {
+			t.Errorf(`"Got stderr "%s" != want "%s"`, got, assertion.Stderr)
+		}
+	}
+}

--- a/cmd/util/testutils/testutils.go
+++ b/cmd/util/testutils/testutils.go
@@ -18,25 +18,78 @@
 package testutils
 
 import (
-	"net/http"
-	"os"
+	"bytes"
+	"fmt"
+	"io"
+	"testing"
 
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/output"
 
 	"github.com/elastic/ecctl/pkg/ecctl"
-	"github.com/elastic/ecctl/pkg/util"
 )
 
-// MockInitApp initiates a mocked app
-func MockInitApp() error {
-	var config = ecctl.Config{
-		Client:       new(http.Client),
-		OutputDevice: output.NewDevice(os.Stdout),
-		ErrorDevice:  os.Stderr,
-		Output:       "json",
-		Host:         "http://somehost",
-		APIKey:       "helloiamakey",
+const (
+	defaultOutputFormat = "json"
+	defaultAPIKey       = "dummy"
+	defaultRegion       = "ece-region"
+)
+
+// MockCfg represents a small and targeted amount of `ecctl.Config` options
+// aimed at making mocking convenient and easy.
+type MockCfg struct {
+	Responses    []mock.Response
+	Out          io.Writer
+	Err          io.Writer
+	OutputFormat string
+	Format       string
+	Region       string
+
+	Force   bool
+	Verbose bool
+}
+
+func fillDefaults(cfg MockCfg) MockCfg {
+	if cfg.OutputFormat == "" {
+		cfg.OutputFormat = defaultOutputFormat
 	}
 
-	return util.ReturnErrOnly(ecctl.Instance(config))
+	if cfg.Region == "" {
+		cfg.Region = defaultRegion
+	}
+
+	if cfg.Err == nil {
+		cfg.Err = new(bytes.Buffer)
+	}
+
+	if cfg.Out == nil {
+		cfg.Out = new(bytes.Buffer)
+	}
+
+	return cfg
+}
+
+func newConfig(cfg MockCfg) ecctl.Config {
+	cfg = fillDefaults(cfg)
+	return ecctl.Config{
+		Client:       mock.NewClient(cfg.Responses...),
+		OutputDevice: output.NewDevice(cfg.Out),
+		ErrorDevice:  cfg.Err,
+		Output:       cfg.OutputFormat,
+		Format:       cfg.Format,
+		Host:         fmt.Sprintf("https://%s", api.DefaultMockHost),
+		APIKey:       defaultAPIKey,
+		Force:        cfg.Force,
+		Verbose:      cfg.Verbose,
+	}
+}
+
+// MockApp initiates a mocked app from a MockCfg.
+func MockApp(t *testing.T, cfg MockCfg) func() {
+	if _, err := ecctl.Instance(newConfig(cfg)); err != nil {
+		t.Error(err)
+	}
+
+	return ecctl.Cleanup
 }

--- a/cmd/util/testutils/testutils.go
+++ b/cmd/util/testutils/testutils.go
@@ -85,8 +85,8 @@ func newConfig(cfg MockCfg) ecctl.Config {
 	}
 }
 
-// MockApp initiates a mocked app from a MockCfg.
-func MockApp(t *testing.T, cfg MockCfg) func() {
+// mockApp initiates a mocked app from a MockCfg.
+func mockApp(t *testing.T, cfg MockCfg) func() {
 	if _, err := ecctl.Instance(newConfig(cfg)); err != nil {
 		t.Error(err)
 	}

--- a/cmd/util/testutils/testutils_test.go
+++ b/cmd/util/testutils/testutils_test.go
@@ -18,25 +18,78 @@
 package testutils
 
 import (
-	"reflect"
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
 	"testing"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/output"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
-func TestMockInitApp(t *testing.T) {
+func Test_newConfig(t *testing.T) {
+	type args struct {
+		cfg MockCfg
+	}
 	tests := []struct {
 		name string
-		err  error
+		args args
+		want ecctl.Config
 	}{
 		{
-			name: "Succeeds mocking initApp",
+			name: "empty params succeed",
+			args: args{cfg: MockCfg{}},
+			want: ecctl.Config{
+				Client:       mock.NewClient(),
+				OutputDevice: output.NewDevice(new(bytes.Buffer)),
+				ErrorDevice:  new(bytes.Buffer),
+				Output:       "json",
+				Host:         fmt.Sprintf("https://%s", api.DefaultMockHost),
+				APIKey:       defaultAPIKey,
+				Force:        false,
+			},
+		},
+		{
+			name: "overriding params succeed",
+			args: args{cfg: MockCfg{
+				Responses: []mock.Response{
+					{Error: errors.New("some error")},
+				},
+				Out:          os.Stdout,
+				Err:          os.Stderr,
+				OutputFormat: "text",
+				Region:       "us-east-1",
+				Force:        true,
+				Verbose:      true,
+			}},
+			want: ecctl.Config{
+				Client:       mock.NewClient(mock.Response{Error: errors.New("some error")}),
+				OutputDevice: output.NewDevice(os.Stdout),
+				ErrorDevice:  os.Stderr,
+				Output:       "text",
+				Host:         fmt.Sprintf("https://%s", api.DefaultMockHost),
+				APIKey:       defaultAPIKey,
+				Force:        true,
+				Verbose:      true,
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := MockInitApp(); !reflect.DeepEqual(err, tt.err) {
-				t.Errorf("MockInitApp() error = %v, wantErr %v", err, tt.err)
-				return
-			}
+			got := newConfig(tt.args.cfg)
+			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestMockApp(t *testing.T) {
+	cleanup := MockApp(t, MockCfg{})
+	assert.NotNil(t, ecctl.Get())
+	cleanup()
+	assert.Nil(t, ecctl.Get())
 }

--- a/cmd/util/testutils/testutils_test.go
+++ b/cmd/util/testutils/testutils_test.go
@@ -88,7 +88,7 @@ func Test_newConfig(t *testing.T) {
 }
 
 func TestMockApp(t *testing.T) {
-	cleanup := MockApp(t, MockCfg{})
+	cleanup := mockApp(t, MockCfg{})
 	assert.NotNil(t, ecctl.Get())
 	cleanup()
 	assert.Nil(t, ecctl.Get())

--- a/cmd/util/track_params.go
+++ b/cmd/util/track_params.go
@@ -18,8 +18,10 @@
 package cmdutil
 
 import (
+	"strings"
 	"time"
 
+	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/plan"
 	"github.com/elastic/cloud-sdk-go/pkg/plan/planutil"
 
@@ -30,6 +32,12 @@ import (
 var DefaultTrackFrequencyConfig = plan.TrackFrequencyConfig{
 	PollFrequency: time.Second * 5,
 	MaxRetries:    3,
+}
+
+// DefaultTestFrequency provides sane defaults for testing Plan change tracking.
+var DefaultTestFrequency = plan.TrackFrequencyConfig{
+	PollFrequency: time.Millisecond,
+	MaxRetries:    1,
 }
 
 // TrackParamsConfig is used to create TrackParams which print the output / track.
@@ -52,6 +60,10 @@ func NewTrackParams(params TrackParamsConfig) TrackParams {
 
 	if params.App == nil {
 		params.App = ecctl.Get()
+	}
+
+	if strings.Contains(params.App.Config.Host, api.DefaultMockHost) {
+		params.FrequencyConfig = &DefaultTestFrequency
 	}
 
 	return TrackParams{

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/spf13/cobra v0.0.7
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.0
+	github.com/stretchr/testify v1.6.1
 	golang.org/x/crypto v0.0.0-20190829043050-9756ffdc2472
 )
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds a new function to the `testutils` package which allow easier
testing to be written on the `cmd` layer.

All the heavy lifting is done by `testutils.RunCmdAssertion` on the test
function, namely it:

    1. Initializes the `ecctl.App` singleton from a `testutils.MockCfg`.
    2. Sets the cobra `cmd.Command` Err and Out to `*Bytes.Buffer`s.
    3. Executes the command with the specified Args.
    4. Asserts the returned errors by `cmd.Execute()`
    5. Asserts the written data to both the `Err` and `Out` buffers.
    6. `ecctl.Cleanup` is called before returning so no instance is set.

It is important to note that global flags won't be parsed and instead,
must be provided as values to `testutils.MockCfg`. As new global flags
are added, the structure should be maintained to contain these.

Interaction with the `stdin` hasn't been written yet, but it will be a
follow-up patch.

Last, the tracker utils have been modified to use `DefaultTestFrequency`
when the host equals `api.DefaultMockHost` for ease of testing.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Easier cmd layer testing!

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`make unit`

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Refactoring (improves code quality but has no user-facing effect)
