### PR TITLE
instance-configuration: Add region to commands

### DIFF
--- a/cmd/platform/instance-configuration/create.go
+++ b/cmd/platform/instance-configuration/create.go
@@ -1,0 +1,76 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmdinstanceconfig
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/instanceconfigapi"
+	"github.com/elastic/cloud-sdk-go/pkg/input"
+	sdkcmdutil "github.com/elastic/cloud-sdk-go/pkg/util/cmdutil"
+	"github.com/spf13/cobra"
+
+	"github.com/elastic/ecctl/pkg/ecctl"
+)
+
+var createCmd = &cobra.Command{
+	Use:     "create -f <config.json>",
+	Short:   "Creates a new instance configuration",
+	PreRunE: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := sdkcmdutil.FileOrStdin(cmd, "file"); err != nil {
+			return err
+		}
+
+		file, err := input.NewFileOrReader(os.Stdin, cmd.Flag("file").Value.String())
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		config, err := instanceconfigapi.NewConfig(file)
+		if err != nil {
+			return err
+		}
+
+		if id := cmd.Flag("id").Value.String(); id != "" {
+			config.ID = id
+		}
+
+		res, err := instanceconfigapi.Create(instanceconfigapi.CreateParams{
+			API:    ecctl.Get().API,
+			Region: ecctl.Get().Config.Region,
+			Config: config,
+		})
+
+		if err != nil {
+			return err
+		}
+
+		return ecctl.Get().Formatter.Format(filepath.Join("instance-configuration", "create"), res)
+	},
+}
+
+func init() {
+	Command.AddCommand(createCmd)
+
+	createCmd.Flags().StringP("file", "f", "", "Instance configuration JSON file definition")
+	createCmd.Flags().String("id", "", "Optional ID to set for the instance configuration (Overrides id if present)")
+	createCmd.MarkFlagRequired("file")
+}

--- a/cmd/platform/instance-configuration/delete.go
+++ b/cmd/platform/instance-configuration/delete.go
@@ -18,15 +18,25 @@
 package cmdinstanceconfig
 
 import (
+	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/instanceconfigapi"
 	"github.com/spf13/cobra"
 
-	cmdutil "github.com/elastic/ecctl/cmd/util"
+	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
-// Command is the top instance-config subcommand.
-var Command = &cobra.Command{
-	Use:     "instance-configuration",
-	Short:   cmdutil.AdminReqDescription("Manages instance configurations"),
-	PreRunE: cobra.NoArgs,
-	Run:     func(cmd *cobra.Command, args []string) { cmd.Help() },
+var deleteCmd = &cobra.Command{
+	Use:     "delete <config id>",
+	Short:   "Deletes an instance configuration",
+	PreRunE: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return instanceconfigapi.Delete(instanceconfigapi.DeleteParams{
+			API:    ecctl.Get().API,
+			Region: ecctl.Get().Config.Region,
+			ID:     args[0],
+		})
+	},
+}
+
+func init() {
+	Command.AddCommand(deleteCmd)
 }

--- a/cmd/platform/instance-configuration/list.go
+++ b/cmd/platform/instance-configuration/list.go
@@ -18,15 +18,32 @@
 package cmdinstanceconfig
 
 import (
+	"path/filepath"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/instanceconfigapi"
 	"github.com/spf13/cobra"
 
-	cmdutil "github.com/elastic/ecctl/cmd/util"
+	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
-// Command is the top instance-config subcommand.
-var Command = &cobra.Command{
-	Use:     "instance-configuration",
-	Short:   cmdutil.AdminReqDescription("Manages instance configurations"),
-	PreRunE: cobra.NoArgs,
-	Run:     func(cmd *cobra.Command, args []string) { cmd.Help() },
+var listCmd = &cobra.Command{
+	Use:     "list",
+	Short:   "Lists the instance configurations",
+	PreRunE: cobra.MaximumNArgs(0),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := instanceconfigapi.List(instanceconfigapi.ListParams{
+			API:    ecctl.Get().API,
+			Region: ecctl.Get().Config.Region,
+		})
+
+		if err != nil {
+			return err
+		}
+
+		return ecctl.Get().Formatter.Format(filepath.Join("instance-configuration", "list"), res)
+	},
+}
+
+func init() {
+	Command.AddCommand(listCmd)
 }

--- a/cmd/platform/instance-configuration/pull.go
+++ b/cmd/platform/instance-configuration/pull.go
@@ -18,15 +18,28 @@
 package cmdinstanceconfig
 
 import (
+	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/instanceconfigapi"
 	"github.com/spf13/cobra"
 
-	cmdutil "github.com/elastic/ecctl/cmd/util"
+	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
-// Command is the top instance-config subcommand.
-var Command = &cobra.Command{
-	Use:     "instance-configuration",
-	Short:   cmdutil.AdminReqDescription("Manages instance configurations"),
+var pullCmd = &cobra.Command{
+	Use:     "pull --path <path>",
+	Short:   "Downloads instance configuration into a local folder",
 	PreRunE: cobra.NoArgs,
-	Run:     func(cmd *cobra.Command, args []string) { cmd.Help() },
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return instanceconfigapi.PullToDirectory(instanceconfigapi.PullToDirectoryParams{
+			API:       ecctl.Get().API,
+			Region:    ecctl.Get().Config.Region,
+			Directory: cmd.Flag("path").Value.String(),
+		})
+	},
+}
+
+func init() {
+	Command.AddCommand(pullCmd)
+
+	pullCmd.Flags().StringP("path", "p", "", "Local path with instance configuration.")
+	pullCmd.MarkFlagRequired("path")
 }

--- a/cmd/platform/instance-configuration/show.go
+++ b/cmd/platform/instance-configuration/show.go
@@ -18,15 +18,33 @@
 package cmdinstanceconfig
 
 import (
+	"path/filepath"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/instanceconfigapi"
 	"github.com/spf13/cobra"
 
-	cmdutil "github.com/elastic/ecctl/cmd/util"
+	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
-// Command is the top instance-config subcommand.
-var Command = &cobra.Command{
-	Use:     "instance-configuration",
-	Short:   cmdutil.AdminReqDescription("Manages instance configurations"),
-	PreRunE: cobra.NoArgs,
-	Run:     func(cmd *cobra.Command, args []string) { cmd.Help() },
+var showCmd = &cobra.Command{
+	Use:     "show <config id>",
+	Short:   "Shows an instance configuration",
+	PreRunE: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := instanceconfigapi.Get(instanceconfigapi.GetParams{
+			API:    ecctl.Get().API,
+			Region: ecctl.Get().Config.Region,
+			ID:     args[0],
+		})
+
+		if err != nil {
+			return err
+		}
+
+		return ecctl.Get().Formatter.Format(filepath.Join("instance-configuration", "show"), res)
+	},
+}
+
+func init() {
+	Command.AddCommand(showCmd)
 }

--- a/cmd/platform/instance-configuration/update.go
+++ b/cmd/platform/instance-configuration/update.go
@@ -1,0 +1,65 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmdinstanceconfig
+
+import (
+	"os"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/instanceconfigapi"
+	"github.com/elastic/cloud-sdk-go/pkg/input"
+	sdkcmdutil "github.com/elastic/cloud-sdk-go/pkg/util/cmdutil"
+	"github.com/spf13/cobra"
+
+	"github.com/elastic/ecctl/pkg/ecctl"
+)
+
+var updateCmd = &cobra.Command{
+	Use:     "update <config id> -f <config.json>",
+	Short:   "Overwrites an instance configuration",
+	PreRunE: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := sdkcmdutil.FileOrStdin(cmd, "file"); err != nil {
+			return err
+		}
+
+		file, err := input.NewFileOrReader(os.Stdin, cmd.Flag("file").Value.String())
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		config, err := instanceconfigapi.NewConfig(file)
+		if err != nil {
+			return err
+		}
+
+		return instanceconfigapi.Update(instanceconfigapi.UpdateParams{
+			API:    ecctl.Get().API,
+			Region: ecctl.Get().Config.Region,
+			ID:     args[0],
+			Config: config,
+		})
+	},
+}
+
+func init() {
+	Command.AddCommand(updateCmd)
+
+	updateCmd.Flags().StringP("file", "f", "", "Instance configuration JSON file definition")
+	updateCmd.MarkFlagRequired("file")
+}


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail. -->
Splits `command.go` into individual command files, populating the Region
property on each of the commands.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Depends on the open PRs to update `go.mod`
