### PR TITLE
cmd: Remove sdkcmdutil.FileOrStdin use

### DIFF
--- a/cmd/deployment/create.go
+++ b/cmd/deployment/create.go
@@ -163,7 +163,6 @@ func init() {
 	Command.AddCommand(createCmd)
 	createCmd.Flags().StringP("file", "f", "", "DeploymentCreateRequest file definition. See help for more information")
 	// Remove when reads for deployment templates are available on ESS
-	createCmd.MarkFlagRequired("file")
 	createCmd.Flags().String("deployment-template", "default", "Deployment template ID on which to base the deployment from")
 	createCmd.Flags().String("version", "", "Version to use, if not specified, the latest available stack version will be used")
 	createCmd.Flags().String("name", "", "Optional name for the deployment")

--- a/cmd/deployment/create.go
+++ b/cmd/deployment/create.go
@@ -69,9 +69,6 @@ var createCmd = &cobra.Command{
 		var skipFlagBased = cmd.Flag("deployment-template").Hidden
 
 		var payload *models.DeploymentCreateRequest
-		if err := sdkcmdutil.FileOrStdin(cmd, "file"); err != nil && skipFlagBased {
-			return err
-		}
 
 		err := sdkcmdutil.DecodeDefinition(cmd, "file", &payload)
 		if err := returnErrOnHidden(err, skipFlagBased); err != nil {

--- a/cmd/platform/deployment-template/create.go
+++ b/cmd/platform/deployment-template/create.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/configurationtemplateapi"
-	sdkcmdutil "github.com/elastic/cloud-sdk-go/pkg/util/cmdutil"
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/ecctl/pkg/ecctl"
@@ -32,10 +31,6 @@ var createCmd = &cobra.Command{
 	Short:   "Creates a platform deployment template",
 	PreRunE: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := sdkcmdutil.FileOrStdin(cmd, "file-template"); err != nil {
-			return err
-		}
-
 		tc, err := parseTemplateFile(cmd.Flag("file-template").Value.String())
 		if err != nil {
 			return err

--- a/cmd/platform/deployment-template/update.go
+++ b/cmd/platform/deployment-template/update.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/configurationtemplateapi"
-	sdkcmdutil "github.com/elastic/cloud-sdk-go/pkg/util/cmdutil"
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/ecctl/pkg/ecctl"
@@ -32,9 +31,6 @@ var updateCmd = &cobra.Command{
 	Short:   "Updates a platform deployment template",
 	PreRunE: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := sdkcmdutil.FileOrStdin(cmd, "file-template"); err != nil {
-			return err
-		}
 		tc, err := parseTemplateFile(cmd.Flag("file-template").Value.String())
 		if err != nil {
 			return err

--- a/cmd/platform/instance-configuration/create.go
+++ b/cmd/platform/instance-configuration/create.go
@@ -67,5 +67,4 @@ func init() {
 
 	createCmd.Flags().StringP("file", "f", "", "Instance configuration JSON file definition")
 	createCmd.Flags().String("id", "", "Optional ID to set for the instance configuration (Overrides id if present)")
-	createCmd.MarkFlagRequired("file")
 }

--- a/cmd/platform/instance-configuration/create.go
+++ b/cmd/platform/instance-configuration/create.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/instanceconfigapi"
 	"github.com/elastic/cloud-sdk-go/pkg/input"
-	sdkcmdutil "github.com/elastic/cloud-sdk-go/pkg/util/cmdutil"
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/ecctl/pkg/ecctl"
@@ -34,10 +33,6 @@ var createCmd = &cobra.Command{
 	Short:   "Creates a new instance configuration",
 	PreRunE: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := sdkcmdutil.FileOrStdin(cmd, "file"); err != nil {
-			return err
-		}
-
 		file, err := input.NewFileOrReader(os.Stdin, cmd.Flag("file").Value.String())
 		if err != nil {
 			return err

--- a/cmd/platform/instance-configuration/update.go
+++ b/cmd/platform/instance-configuration/update.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/instanceconfigapi"
 	"github.com/elastic/cloud-sdk-go/pkg/input"
-	sdkcmdutil "github.com/elastic/cloud-sdk-go/pkg/util/cmdutil"
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/ecctl/pkg/ecctl"
@@ -33,10 +32,6 @@ var updateCmd = &cobra.Command{
 	Short:   "Overwrites an instance configuration",
 	PreRunE: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := sdkcmdutil.FileOrStdin(cmd, "file"); err != nil {
-			return err
-		}
-
 		file, err := input.NewFileOrReader(os.Stdin, cmd.Flag("file").Value.String())
 		if err != nil {
 			return err

--- a/cmd/platform/instance-configuration/update.go
+++ b/cmd/platform/instance-configuration/update.go
@@ -56,5 +56,4 @@ func init() {
 	Command.AddCommand(updateCmd)
 
 	updateCmd.Flags().StringP("file", "f", "", "Instance configuration JSON file definition")
-	updateCmd.MarkFlagRequired("file")
 }

--- a/cmd/platform/repository/create.go
+++ b/cmd/platform/repository/create.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/snaprepoapi"
 	"github.com/elastic/cloud-sdk-go/pkg/input"
-	sdkcmdutil "github.com/elastic/cloud-sdk-go/pkg/util/cmdutil"
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/ecctl/pkg/ecctl"
@@ -75,10 +74,6 @@ func setSnapshot(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-	}
-
-	if err := sdkcmdutil.FileOrStdin(cmd, "settings"); err != nil {
-		return err
 	}
 
 	f, err := input.NewFileOrReader(os.Stdin, configFile)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Using the `sdkcmdutil.FileOrStdin` does not work well when coupled with
Ansible since it thinks the Stdin is always populated even when not.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Resolves #318

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Make most `ecctl` commands which have a `--file` flag work with Ansible.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Using `ansible-playbook`

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
