### PR TITLE
docs: Add all vacate kinds to `--kind` flag

### DIFF
--- a/cmd/platform/allocator/vacate.go
+++ b/cmd/platform/allocator/vacate.go
@@ -196,7 +196,7 @@ func validateSkipDataMigration(resources []string, moveOnly bool) error {
 func init() {
 	Command.AddCommand(vacateAllocatorCmd)
 	vacateAllocatorCmd.Flags().Bool("skip-tracking", false, "Skips tracking the vacate progress causing the command to return after the move operation has been executed. Not recommended.")
-	vacateAllocatorCmd.Flags().StringP("kind", "k", "", "Kind of workload to vacate (elasticsearch|kibana)")
+	vacateAllocatorCmd.Flags().StringP("kind", "k", "", "Kind of workload to vacate (elasticsearch|kibana|apm|appsearch|enterprise_search)")
 	vacateAllocatorCmd.Flags().StringArrayP("resource-id", "r", nil, "Resource IDs to include in the vacate")
 	vacateAllocatorCmd.Flags().StringArrayP("target", "t", nil, "Target allocator(s) on which to place the vacated workload")
 	vacateAllocatorCmd.Flags().BoolP("maintenance", "m", false, "Whether to set the allocator(s) in maintenance before performing the vacate")

--- a/docs/ecctl_platform_allocator_vacate.adoc
+++ b/docs/ecctl_platform_allocator_vacate.adoc
@@ -57,7 +57,7 @@ ecctl platform allocator vacate <allocator-id> [flags]
       --allocator-down string        Disables the allocator health auto-discovery, setting the allocator-down to either [true|false]
       --concurrency uint             Maximum number of concurrent moves to perform at any time (default 8)
   -h, --help                         help for vacate
-  -k, --kind string                  Kind of workload to vacate (elasticsearch|kibana)
+  -k, --kind string                  Kind of workload to vacate (elasticsearch|kibana|apm|appsearch|enterprise_search)
   -m, --maintenance                  Whether to set the allocator(s) in maintenance before performing the vacate
       --max-poll-retries int         Optional maximum plan tracking retries (default 2)
       --move-only                    Keeps the resource in its current -possibly broken- state and just does the bare minimum to move the requested instances across to another allocator. [true|false] (default true)

--- a/docs/ecctl_platform_allocator_vacate.md
+++ b/docs/ecctl_platform_allocator_vacate.md
@@ -54,7 +54,7 @@ ecctl platform allocator vacate <allocator-id> [flags]
       --allocator-down string        Disables the allocator health auto-discovery, setting the allocator-down to either [true|false]
       --concurrency uint             Maximum number of concurrent moves to perform at any time (default 8)
   -h, --help                         help for vacate
-  -k, --kind string                  Kind of workload to vacate (elasticsearch|kibana)
+  -k, --kind string                  Kind of workload to vacate (elasticsearch|kibana|apm|appsearch|enterprise_search)
   -m, --maintenance                  Whether to set the allocator(s) in maintenance before performing the vacate
       --max-poll-retries int         Optional maximum plan tracking retries (default 2)
       --move-only                    Keeps the resource in its current -possibly broken- state and just does the bare minimum to move the requested instances across to another allocator. [true|false] (default true)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds all the available vacate kinds to the allocator vacate `--kind`
flag and modifies the doc generation command to use volumes (compatible)
with docker remote engines.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
#335 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`make docs`

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Documentation
