### PR TITLE
useragent: Add ecctl/<version> UserAgent header

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api"
@@ -179,6 +180,7 @@ func initApp(cmd *cobra.Command, client *http.Client, v *viper.Viper) error {
 		Client:       client,
 		OutputDevice: output.NewDevice(defaultOutput),
 		ErrorDevice:  defaultError,
+		UserAgent:    strings.Join([]string{"ecctl", versionInfo.Version}, "/"),
 	}
 	if err := v.Unmarshal(&c); err != nil {
 		return err

--- a/pkg/ecctl/app.go
+++ b/pkg/ecctl/app.go
@@ -56,6 +56,7 @@ func NewApplication(c Config) (*App, error) {
 		},
 		SkipLogin:   c.SkipLogin,
 		ErrorDevice: c.ErrorDevice,
+		UserAgent:   c.UserAgent,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail. -->
Instead of relying on the `cloud-sdk-go/<version>` default, use ecctl's
current version with an `ecctl/` prefix.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Resolves #333 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added some unit tests and also tested manually:

```console
$ ./bin/ecctl --config=ess deployment list --verbose
Using config file: /Users/marc/.ecctl/ess.yml
==================== Start of Request #0 ====================
GET /api/v1/deployments HTTP/1.1
Host: api.elastic-cloud.com
User-Agent: ecctl/v1.0.0-beta3-dev
Accept: application/json
Authorization: ApiKey [REDACTED]
Accept-Encoding: gzip


====================  End of Request #0  ====================

```

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)