### PR TITLE
deployment: create flags reenabled and Enterprise Search support

### DIFF
--- a/cmd/deployment/create.go
+++ b/cmd/deployment/create.go
@@ -211,17 +211,14 @@ func setDefaultTemplate(region string) string {
 		region = "gcp"
 	}
 
-	var dt string
 	switch region {
 	case "azure":
-		dt = "azure-io-optimized"
+		return "azure-io-optimized"
 	case "gcp":
-		dt = "gcp-io-optimized"
+		return "gcp-io-optimized"
 	case "ece-region":
-		dt = "default"
+		return "default"
 	default:
-		dt = "aws-io-optimized-v2"
+		return "aws-io-optimized-v2"
 	}
-
-	return dt
 }

--- a/cmd/deployment/create.go
+++ b/cmd/deployment/create.go
@@ -68,6 +68,11 @@ var createCmd = &cobra.Command{
 		var appsearchSize, _ = cmd.Flags().GetInt32("appsearch-size")
 		var appsearchRefID, _ = cmd.Flags().GetString("appsearch-ref-id")
 
+		var enterpriseSearchEnable, _ = cmd.Flags().GetBool("enterprise-search")
+		var enterpriseSearchZoneCount, _ = cmd.Flags().GetInt32("enterprise-search-zones")
+		var enterpriseSearchSize, _ = cmd.Flags().GetInt32("enterprise-search-size")
+		var enterpriseSearchRefID, _ = cmd.Flags().GetString("enterprise-search-ref-id")
+
 		var payload *models.DeploymentCreateRequest
 
 		if file != "" {
@@ -80,21 +85,24 @@ var createCmd = &cobra.Command{
 			}
 		}
 
-		dt = setDefaultTemplate(region, dt)
+		if dt == "" {
+			dt = setDefaultTemplate(region, dt)
+		}
 
 		if payload == nil {
 			var err error
-			payload, err = depresourceapi.New(depresourceapi.NewParams{
-				API:                  ecctl.Get().API,
-				Name:                 name,
-				DeploymentTemplateID: dt,
-				Version:              version,
-				Region:               region,
-				Writer:               ecctl.Get().Config.ErrorDevice,
-				Plugins:              plugin,
-				TopologyElements:     te,
-				ApmEnable:            apmEnable,
-				AppsearchEnable:      appsearchEnable,
+			payload, err = depresourceapi.NewPayload(depresourceapi.NewPayloadParams{
+				API:                    ecctl.Get().API,
+				Name:                   name,
+				DeploymentTemplateID:   dt,
+				Version:                version,
+				Region:                 region,
+				Writer:                 ecctl.Get().Config.ErrorDevice,
+				Plugins:                plugin,
+				TopologyElements:       te,
+				ApmEnable:              apmEnable,
+				AppsearchEnable:        appsearchEnable,
+				EnterpriseSearchEnable: enterpriseSearchEnable,
 				ElasticsearchInstance: depresourceapi.InstanceParams{
 					RefID:     esRefID,
 					Size:      esSize,
@@ -114,6 +122,11 @@ var createCmd = &cobra.Command{
 					RefID:     appsearchRefID,
 					Size:      appsearchSize,
 					ZoneCount: appsearchZoneCount,
+				},
+				EnterpriseSearchInstance: depresourceapi.InstanceParams{
+					RefID:     enterpriseSearchRefID,
+					Size:      enterpriseSearchSize,
+					ZoneCount: enterpriseSearchZoneCount,
 				},
 			})
 			if err != nil {
@@ -184,7 +197,7 @@ func init() {
 	createCmd.Flags().Int32("appsearch-size", 2048, "Memory (RAM) in MB that each of the App Search instances will have")
 
 	createCmd.Flags().Bool("enterprise-search", false, "Enables Enterprise Search for the deployment")
-	createCmd.Flags().String("enterprise-search-ref-id", "main-enterprise-search", "Optional RefId for the Enterprise Search deployment")
+	createCmd.Flags().String("enterprise-search-ref-id", "main-enterprise_search", "Optional RefId for the Enterprise Search deployment")
 	createCmd.Flags().Int32("enterprise-search-zones", 1, "Number of zones the Enterprise Search instances will span")
 	createCmd.Flags().Int32("enterprise-search-size", 4096, "Memory (RAM) in MB that each of the Enterprise Search instances will have")
 }

--- a/cmd/deployment/create.go
+++ b/cmd/deployment/create.go
@@ -156,7 +156,7 @@ var createCmd = &cobra.Command{
 func init() {
 	Command.AddCommand(createCmd)
 	createCmd.Flags().StringP("file", "f", "", "DeploymentCreateRequest file definition. See help for more information")
-	createCmd.Flags().String("deployment-template", "default", "Deployment template ID on which to base the deployment from")
+	createCmd.Flags().String("deployment-template", "", "Deployment template ID on which to base the deployment from")
 	createCmd.Flags().String("version", "", "Version to use, if not specified, the latest available stack version will be used")
 	createCmd.Flags().String("name", "", "Optional name for the deployment")
 	createCmd.Flags().BoolP("track", "t", false, cmdutil.TrackFlagMessage)

--- a/cmd/deployment/create.go
+++ b/cmd/deployment/create.go
@@ -86,7 +86,7 @@ var createCmd = &cobra.Command{
 		}
 
 		if dt == "" {
-			dt = setDefaultTemplate(region, dt)
+			dt = setDefaultTemplate(region)
 		}
 
 		if payload == nil {
@@ -202,7 +202,7 @@ func init() {
 	createCmd.Flags().Int32("enterprise-search-size", 4096, "Memory (RAM) in MB that each of the Enterprise Search instances will have")
 }
 
-func setDefaultTemplate(region, dt string) string {
+func setDefaultTemplate(region string) string {
 	if strings.Contains(region, "azure") {
 		region = "azure"
 	}
@@ -211,6 +211,7 @@ func setDefaultTemplate(region, dt string) string {
 		region = "gcp"
 	}
 
+	var dt string
 	switch region {
 	case "azure":
 		dt = "azure-io-optimized"

--- a/cmd/deployment/create_help.go
+++ b/cmd/deployment/create_help.go
@@ -70,20 +70,4 @@ $ ecctl deployment create --file create_example.json --track
 
 ## To retry a deployment when the previous deployment creation failed, use the request ID provided in the error response of the previous command:
 $ ecctl deployment create --request-id=GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhGUSMXrEIzVXoBykSVRsKncNb`
-
-	// Remove temporary constants when reads for deployment templates are available on ESS
-	createLongTemp = `Creates a deployment which is defined from a file definition using the --file=<file path> (shorthand: -f) flag.
-
-You can create a definition by using the sample JSON:
-  https://elastic.co/guide/en/cloud/current/ec-api-deployment-crud.html#ec_create_a_deployment`
-
-	createExampleTemp = `## To make the command wait until the resources have been created use the "--track" flag, which will output 
-the current stage on which the deployment resources are in.
-$ deployment create --file create_example.json --track
-[...]
-Deployment [b6ecbea3d5c84124b7dca457f2892086] - [Elasticsearch][b6ecbea3d5c84124b7dca457f2892086]: finished running all the plan steps (Total plan duration: 5m11.s)
-Deployment [91c4d60acb804ba0a27651fac02780ec] - [Kibana][8a9d9916cd6e46a7bb0912211d76e2af]: finished running all the plan steps (Total plan duration: 4m29.58s)
-
-## To retry a deployment when the previous deployment creation failed, use the request ID provided in the error response of the previous command:
-$ ecctl deployment create --file create_example.json --request-id=GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhGUSMXrEIzVXoBykSVRsKncNb`
 )

--- a/cmd/deployment/create_help.go
+++ b/cmd/deployment/create_help.go
@@ -41,8 +41,8 @@ Save it, update or extend the topology and create a deployment using the saved p
 
 	// nolint
 	createExample = `## Create a deployment with the default values for Elasticsearch, a Kibana instance with a modified size, 
-and a default APM instance. While Elasticsearch and Kibana come enabled by default, both APM and App Search need to be 
-enabled by using the "--apm" and "--appsearch" flags. The command will exit after the API response has been returned, without 
+and a default APM instance. While Elasticsearch and Kibana come enabled by default, APM, Enterprise Search and App Search need to be 
+enabled by using the "--apm", "--enterprise-search" and "--appsearch" flags. The command will exit after the API response has been returned, without 
 waiting until the deployment resources have been created. 
 $ ecctl deployment create --name my-deployment --zones 2 --kibana-size 2048 --apm --apm-size 1024
 

--- a/cmd/deployment/create_help.go
+++ b/cmd/deployment/create_help.go
@@ -24,7 +24,7 @@ Sane default values are provided, making the command work out of the box even wh
 When version is not specified, the latest available stack version will automatically be used. 
 These are the available options:
 
-  * Simplified flags to set size and zone count for each instance type (Elasticsearch, Kibana, APM and App Search). 
+  * Simplified flags to set size and zone count for each instance type (Elasticsearch, Kibana, APM, Enterprise Search and App Search). 
   * Advanced flag for different Elasticsearch node types: --topology-element <json obj> (shorthand: -e).
     Note that the flag can be specified multiple times for complex topologies.
     The JSON object has the following format:

--- a/cmd/deployment/create_test.go
+++ b/cmd/deployment/create_test.go
@@ -331,10 +331,10 @@ Deployment [%s] - [Apm][%s]: running step "waiting-for-some-step" (Plan duration
 						Assert: &mock.RequestAssertion{
 							Method: "GET",
 							Header: api.DefaultReadMockHeaders,
-							Path:   "/api/v1/regions/ece-region/platform/configuration/templates/deployments/default",
+							Path:   "/api/v1/deployments/templates/default",
 							Host:   api.DefaultMockHost,
 							Query: url.Values{
-								"format":                       {"deployment"},
+								"region":                       {"ece-region"},
 								"show_instance_configurations": {"true"},
 							},
 						},
@@ -361,10 +361,10 @@ Deployment [%s] - [Apm][%s]: running step "waiting-for-some-step" (Plan duration
 						Assert: &mock.RequestAssertion{
 							Method: "GET",
 							Header: api.DefaultReadMockHeaders,
-							Path:   "/api/v1/regions/ece-region/platform/configuration/templates/deployments/default",
+							Path:   "/api/v1/deployments/templates/default",
 							Host:   api.DefaultMockHost,
 							Query: url.Values{
-								"format":                       {"deployment"},
+								"region":                       {"ece-region"},
 								"show_instance_configurations": {"true"},
 							},
 						},

--- a/cmd/deployment/create_test.go
+++ b/cmd/deployment/create_test.go
@@ -30,9 +30,7 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"
 	planmock "github.com/elastic/cloud-sdk-go/pkg/plan/mock"
-	sdkcmdutil "github.com/elastic/cloud-sdk-go/pkg/util/cmdutil"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/ecctl/cmd/util/testutils"
 )
@@ -41,6 +39,9 @@ func Test_createCmd(t *testing.T) {
 	var deploymentID = ec.RandomResourceID()
 	var esID = ec.RandomResourceID()
 	var kibanaID = ec.RandomResourceID()
+	var apmID = ec.RandomResourceID()
+	var appsearchID = ec.RandomResourceID()
+	var enterprisesearchID = ec.RandomResourceID()
 	var azureCreateResponse = models.DeploymentCreateResponse{
 		Created: ec.Bool(true),
 		ID:      ec.String(deploymentID),
@@ -65,6 +66,80 @@ func Test_createCmd(t *testing.T) {
 		},
 	}
 	azureCreateResponseBytes, err := json.MarshalIndent(azureCreateResponse, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var defaultCreateResponse = models.DeploymentCreateResponse{
+		Created: ec.Bool(true),
+		ID:      ec.String(deploymentID),
+		Name:    ec.String("search-dev-ece-region"),
+		Resources: []*models.DeploymentResource{
+			{
+				ID:     ec.String(esID),
+				Kind:   ec.String("elasticsearch"),
+				RefID:  ec.String("main-elasticsearch"),
+				Region: ec.String("ece-region"),
+				Credentials: &models.ClusterCredentials{
+					Username: ec.String("myuser"),
+					Password: ec.String("mypass"),
+				},
+			},
+			{
+				ID:     ec.String(kibanaID),
+				Kind:   ec.String("kibana"),
+				RefID:  ec.String("main-kibana"),
+				Region: ec.String("ece-region"),
+			},
+		},
+	}
+	defaultCreateResponseBytes, err := json.Marshal(defaultCreateResponse)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var overrideCreateResponse = models.DeploymentCreateResponse{
+		Created: ec.Bool(true),
+		ID:      ec.String(deploymentID),
+		Name:    ec.String("search-dev-ece-region"),
+		Resources: []*models.DeploymentResource{
+			{
+				ID:     ec.String(esID),
+				Kind:   ec.String("elasticsearch"),
+				RefID:  ec.String("main-elasticsearch"),
+				Region: ec.String("ece-region"),
+				Credentials: &models.ClusterCredentials{
+					Username: ec.String("myuser"),
+					Password: ec.String("mypass"),
+				},
+			},
+			{
+				ID:     ec.String(kibanaID),
+				Kind:   ec.String("kibana"),
+				RefID:  ec.String("main-kibana"),
+				Region: ec.String("ece-region"),
+			},
+			{
+				ID:     ec.String(apmID),
+				Kind:   ec.String("apm"),
+				RefID:  ec.String("main-apm"),
+				Region: ec.String("ece-region"),
+			},
+			{
+				ID:     ec.String(appsearchID),
+				Kind:   ec.String("appsearch"),
+				RefID:  ec.String("main-appsearch"),
+				Region: ec.String("ece-region"),
+			},
+			{
+				ID:     ec.String(enterprisesearchID),
+				Kind:   ec.String("enterprise_search"),
+				RefID:  ec.String("main-enterprise_search"),
+				Region: ec.String("ece-region"),
+			},
+		},
+	}
+	overrideCreateResponseBytes, err := json.Marshal(overrideCreateResponse)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -241,6 +316,66 @@ Deployment [%s] - [Apm][%s]: running step "waiting-for-some-step" (Plan duration
 			},
 		},
 		{
+			name: "succeeds creating a deployment with default values and without tracking",
+			args: testutils.Args{
+				Cmd: createCmd,
+				Args: []string{
+					"create", "--file=", "--request-id=some_request_id",
+				},
+				Cfg: testutils.MockCfg{Responses: []mock.Response{
+					{
+						Response: http.Response{
+							StatusCode: 201,
+							Body:       mock.NewStructBody(defaultCreateResponse),
+						},
+						Assert: &mock.RequestAssertion{
+							Method: "GET",
+							Header: api.DefaultReadMockHeaders,
+							Path:   "/api/v1/regions/ece-region/platform/configuration/templates/deployments/default",
+							Host:   api.DefaultMockHost,
+							Query: url.Values{
+								"format":                       {"deployment"},
+								"show_instance_configurations": {"true"},
+							},
+						},
+					},
+				}},
+			},
+			want: testutils.Assertion{
+				Err: errors.New(string(defaultCreateResponseBytes) + "\n"),
+			},
+		},
+		{
+			name: "succeeds creating a deployment with overrides and without tracking",
+			args: testutils.Args{
+				Cmd: createCmd,
+				Args: []string{
+					"create", "--apm", "--appsearch", "--enterprise-search", "--file=", "--request-id=some_request_id",
+				},
+				Cfg: testutils.MockCfg{Responses: []mock.Response{
+					{
+						Response: http.Response{
+							StatusCode: 201,
+							Body:       mock.NewStructBody(overrideCreateResponse),
+						},
+						Assert: &mock.RequestAssertion{
+							Method: "GET",
+							Header: api.DefaultReadMockHeaders,
+							Path:   "/api/v1/regions/ece-region/platform/configuration/templates/deployments/default",
+							Host:   api.DefaultMockHost,
+							Query: url.Values{
+								"format":                       {"deployment"},
+								"show_instance_configurations": {"true"},
+							},
+						},
+					},
+				}},
+			},
+			want: testutils.Assertion{
+				Err: errors.New(string(overrideCreateResponseBytes) + "\n"),
+			},
+		},
+		{
 			name: "succeeds creating an Azure deployment with payload and without tracking",
 			args: testutils.Args{
 				Cmd: createCmd,
@@ -326,48 +461,6 @@ Deployment [%s] - [Apm][%s]: running step "waiting-for-some-step" (Plan duration
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			testutils.RunCmdAssertion(t, tt.args, tt.want)
-		})
-	}
-}
-
-func Test_returnErrOnHidden(t *testing.T) {
-	type args struct {
-		err    error
-		hidden bool
-	}
-	tests := []struct {
-		name string
-		args args
-		err  error
-	}{
-		{
-			name: "an error is returned",
-			args: args{
-				err: errors.New("some"),
-			},
-			err: errors.New("some"),
-		},
-		{
-			name: "an error is returned when hidden is false and == sdkcmdutil.ErrNodefinitionLoaded",
-			args: args{
-				err: sdkcmdutil.ErrNodefinitionLoaded,
-			},
-		},
-		{
-			name: "an error is returned when hidden is true and == sdkcmdutil.ErrNodefinitionLoaded",
-			args: args{
-				err:    sdkcmdutil.ErrNodefinitionLoaded,
-				hidden: true,
-			},
-			err: sdkcmdutil.ErrNodefinitionLoaded,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := returnErrOnHidden(tt.args.err, tt.args.hidden)
-			if !assert.Equal(t, tt.err, err) {
-				t.Error(err)
-			}
 		})
 	}
 }

--- a/docs/ecctl_deployment_create.adoc
+++ b/docs/ecctl_deployment_create.adoc
@@ -6,38 +6,90 @@ Creates a deployment
 [float]
 === Synopsis
 
-Creates a deployment which is defined from a file definition using the --file=+++<file path="">+++(shorthand: -f) flag.+++</file>+++
+Creates a deployment which can be defined through flags or from a file definition.
+Sane default values are provided, making the command work out of the box even when no parameters are set.
+When version is not specified, the latest available stack version will automatically be used.
+These are the available options:
 
-You can create a definition by using the sample JSON:
-  https://elastic.co/guide/en/cloud/current/ec-api-deployment-crud.html#ec_create_a_deployment
+* Simplified flags to set size and zone count for each instance type (Elasticsearch, Kibana, APM and App Search).
+* Advanced flag for different Elasticsearch node types: --topology-element +++<json obj="">+++(shorthand: -e). Note that the flag can be specified multiple times for complex topologies. The JSON object has the following format: { "name": "["data", "master", "ml"]" # type string "size": 1024 # type int32 "zone_count": 1 # type int32 }+++</json>+++
+* File definition: --file=+++<file path="">+++(shorthand: -f). You can create a definition by using the sample JSON seen here: https://elastic.co/guide/en/cloud/current/ec-api-deployment-crud.html#ec_create_a_deployment+++</file>+++
+
+As an option "--generate-payload" can be used in order to obtain the generated payload that would be sent as a request.
+Save it, update or extend the topology and create a deployment using the saved payload with the "--file" flag.
 
 ----
-ecctl deployment create {--file | --size <int> --zones <string> | --topology-element <obj>} [flags]
+ecctl deployment create {--file | --es-size <int> --es-zones <int> | --topology-element <obj>} [flags]
 ----
 
 [float]
 === Examples
 
 ----
+## Create a deployment with the default values for Elasticsearch, a Kibana instance with a modified size,
+and a default APM instance. While Elasticsearch and Kibana come enabled by default, both APM and App Search need to be
+enabled by using the "--apm" and "--appsearch" flags. The command will exit after the API response has been returned, without
+waiting until the deployment resources have been created.
+$ ecctl deployment create --name my-deployment --zones 2 --kibana-size 2048 --apm --apm-size 1024
+
 ## To make the command wait until the resources have been created use the "--track" flag, which will output
 the current stage on which the deployment resources are in.
-$ deployment create --file create_example.json --track
+$ deployment create --name my-deployment --track
 [...]
 Deployment [b6ecbea3d5c84124b7dca457f2892086] - [Elasticsearch][b6ecbea3d5c84124b7dca457f2892086]: finished running all the plan steps (Total plan duration: 5m11.s)
 Deployment [91c4d60acb804ba0a27651fac02780ec] - [Kibana][8a9d9916cd6e46a7bb0912211d76e2af]: finished running all the plan steps (Total plan duration: 4m29.58s)
 
+## Additionally, a more advanced topology for Elasticsearch can be created through "--topology-element" or shorthand "-e".
+The following command will create a deployment with two 1GB Elasticsearch instances of the type "data" and
+one 1GB Elasticsearch instance of the type "ml".
+$ ecctl deployment create --name my-deployment --topology-element '{"size": 1024, "zone_count": 2, "name": "data"}' --topology-element '{"size": 1024, "zone_count": 1, "name": "ml"}'
+
+## In order to use the "--deployment-template" flag, you'll need to know which deployment templates ara available to you.
+You'll need to run the following command to view your deployment templates:
+$ ecctl platform deployment-template list
+
+## Use the "--generate-payload" flag to save the definition to a file for later use.
+$ ecctl deployment create --name my-deployment --size 1024 --track --generate-payload --zones 2 > create_example.json
+
+## Create a deployment through the file definition.
+$ ecctl deployment create --file create_example.json --track
+
 ## To retry a deployment when the previous deployment creation failed, use the request ID provided in the error response of the previous command:
-$ ecctl deployment create --file create_example.json --request-id=GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhGUSMXrEIzVXoBykSVRsKncNb
+$ ecctl deployment create --request-id=GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhGUSMXrEIzVXoBykSVRsKncNb
 ----
 
 [float]
 === Options
 
 ----
-  -f, --file string         DeploymentCreateRequest file definition. See help for more information
-  -h, --help                help for create
-      --request-id string   Optional request ID - Can be found in the Stderr device when a previous deployment creation failed. For more information see the examples in the help command page
-  -t, --track               Tracks the progress of the performed task
+      --apm                               Enables APM for the deployment
+      --apm-ref-id string                 Optional RefId for the APM deployment (default "main-apm")
+      --apm-size int32                    Memory (RAM) in MB that each of the APM instances will have (default 512)
+      --apm-zones int32                   Number of zones the APM instances will span (default 1)
+      --appsearch                         Enables App Search for the deployment
+      --appsearch-ref-id string           Optional RefId for the App Search deployment (default "main-appsearch")
+      --appsearch-size int32              Memory (RAM) in MB that each of the App Search instances will have (default 2048)
+      --appsearch-zones int32             Number of zones the App Search instances will span (default 1)
+      --deployment-template string        Deployment template ID on which to base the deployment from (default "default")
+      --enterprise-search                 Enables Enterprise Search for the deployment
+      --enterprise-search-ref-id string   Optional RefId for the Enterprise Search deployment (default "main-enterprise-search")
+      --enterprise-search-size int32      Memory (RAM) in MB that each of the Enterprise Search instances will have (default 4096)
+      --enterprise-search-zones int32     Number of zones the Enterprise Search instances will span (default 1)
+      --es-ref-id string                  Optional RefId for the Elasticsearch deployment (default "main-elasticsearch")
+      --es-size int32                     Memory (RAM) in MB that each of the Elasticsearch instances will have (default 4096)
+      --es-zones int32                    Number of zones the Elasticsearch instances will span (default 1)
+  -f, --file string                       DeploymentCreateRequest file definition. See help for more information
+      --generate-payload                  Returns the deployment payload without actually creating the deployment resources
+  -h, --help                              help for create
+      --kibana-ref-id string              Optional RefId for the Kibana deployment (default "main-kibana")
+      --kibana-size int32                 Memory (RAM) in MB that each of the Kibana instances will have (default 1024)
+      --kibana-zones int32                Number of zones the Kibana instances will span (default 1)
+      --name string                       Optional name for the deployment
+      --plugin strings                    Additional plugins to add to the Elasticsearch deployment
+      --request-id string                 Optional request ID - Can be found in the Stderr device when a previous deployment creation failed. For more information see the examples in the help command page
+  -e, --topology-element stringArray      Optional Elasticsearch topology element definition. See help for more information
+  -t, --track                             Tracks the progress of the performed task
+      --version string                    Version to use, if not specified, the latest available stack version will be used
 ----
 
 [float]

--- a/docs/ecctl_deployment_create.adoc
+++ b/docs/ecctl_deployment_create.adoc
@@ -11,7 +11,7 @@ Sane default values are provided, making the command work out of the box even wh
 When version is not specified, the latest available stack version will automatically be used.
 These are the available options:
 
-* Simplified flags to set size and zone count for each instance type (Elasticsearch, Kibana, APM and App Search).
+* Simplified flags to set size and zone count for each instance type (Elasticsearch, Kibana, APM, Enterprise Search and App Search).
 * Advanced flag for different Elasticsearch node types: --topology-element +++<json obj="">+++(shorthand: -e). Note that the flag can be specified multiple times for complex topologies. The JSON object has the following format: { "name": "["data", "master", "ml"]" # type string "size": 1024 # type int32 "zone_count": 1 # type int32 }+++</json>+++
 * File definition: --file=+++<file path="">+++(shorthand: -f). You can create a definition by using the sample JSON seen here: https://elastic.co/guide/en/cloud/current/ec-api-deployment-crud.html#ec_create_a_deployment+++</file>+++
 

--- a/docs/ecctl_deployment_create.adoc
+++ b/docs/ecctl_deployment_create.adoc
@@ -70,7 +70,7 @@ $ ecctl deployment create --request-id=GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhG
       --appsearch-ref-id string           Optional RefId for the App Search deployment (default "main-appsearch")
       --appsearch-size int32              Memory (RAM) in MB that each of the App Search instances will have (default 2048)
       --appsearch-zones int32             Number of zones the App Search instances will span (default 1)
-      --deployment-template string        Deployment template ID on which to base the deployment from (default "default")
+      --deployment-template string        Deployment template ID on which to base the deployment from
       --enterprise-search                 Enables Enterprise Search for the deployment
       --enterprise-search-ref-id string   Optional RefId for the Enterprise Search deployment (default "main-enterprise-search")
       --enterprise-search-size int32      Memory (RAM) in MB that each of the Enterprise Search instances will have (default 4096)

--- a/docs/ecctl_deployment_create.adoc
+++ b/docs/ecctl_deployment_create.adoc
@@ -27,8 +27,8 @@ ecctl deployment create {--file | --es-size <int> --es-zones <int> | --topology-
 
 ----
 ## Create a deployment with the default values for Elasticsearch, a Kibana instance with a modified size,
-and a default APM instance. While Elasticsearch and Kibana come enabled by default, both APM and App Search need to be
-enabled by using the "--apm" and "--appsearch" flags. The command will exit after the API response has been returned, without
+and a default APM instance. While Elasticsearch and Kibana come enabled by default, APM, Enterprise Search and App Search need to be
+enabled by using the "--apm", "--enterprise-search" and "--appsearch" flags. The command will exit after the API response has been returned, without
 waiting until the deployment resources have been created.
 $ ecctl deployment create --name my-deployment --zones 2 --kibana-size 2048 --apm --apm-size 1024
 
@@ -72,7 +72,7 @@ $ ecctl deployment create --request-id=GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhG
       --appsearch-zones int32             Number of zones the App Search instances will span (default 1)
       --deployment-template string        Deployment template ID on which to base the deployment from
       --enterprise-search                 Enables Enterprise Search for the deployment
-      --enterprise-search-ref-id string   Optional RefId for the Enterprise Search deployment (default "main-enterprise-search")
+      --enterprise-search-ref-id string   Optional RefId for the Enterprise Search deployment (default "main-enterprise_search")
       --enterprise-search-size int32      Memory (RAM) in MB that each of the Enterprise Search instances will have (default 4096)
       --enterprise-search-zones int32     Number of zones the Enterprise Search instances will span (default 1)
       --es-ref-id string                  Optional RefId for the Elasticsearch deployment (default "main-elasticsearch")

--- a/docs/ecctl_deployment_create.md
+++ b/docs/ecctl_deployment_create.md
@@ -9,7 +9,7 @@ Sane default values are provided, making the command work out of the box even wh
 When version is not specified, the latest available stack version will automatically be used. 
 These are the available options:
 
-  * Simplified flags to set size and zone count for each instance type (Elasticsearch, Kibana, APM and App Search). 
+  * Simplified flags to set size and zone count for each instance type (Elasticsearch, Kibana, APM, Enterprise Search and App Search). 
   * Advanced flag for different Elasticsearch node types: --topology-element <json obj> (shorthand: -e).
     Note that the flag can be specified multiple times for complex topologies.
     The JSON object has the following format:

--- a/docs/ecctl_deployment_create.md
+++ b/docs/ecctl_deployment_create.md
@@ -74,7 +74,7 @@ $ ecctl deployment create --request-id=GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhG
       --appsearch-ref-id string           Optional RefId for the App Search deployment (default "main-appsearch")
       --appsearch-size int32              Memory (RAM) in MB that each of the App Search instances will have (default 2048)
       --appsearch-zones int32             Number of zones the App Search instances will span (default 1)
-      --deployment-template string        Deployment template ID on which to base the deployment from (default "default")
+      --deployment-template string        Deployment template ID on which to base the deployment from
       --enterprise-search                 Enables Enterprise Search for the deployment
       --enterprise-search-ref-id string   Optional RefId for the Enterprise Search deployment (default "main-enterprise-search")
       --enterprise-search-size int32      Memory (RAM) in MB that each of the Enterprise Search instances will have (default 4096)

--- a/docs/ecctl_deployment_create.md
+++ b/docs/ecctl_deployment_create.md
@@ -32,8 +32,8 @@ ecctl deployment create {--file | --es-size <int> --es-zones <int> | --topology-
 
 ```
 ## Create a deployment with the default values for Elasticsearch, a Kibana instance with a modified size, 
-and a default APM instance. While Elasticsearch and Kibana come enabled by default, both APM and App Search need to be 
-enabled by using the "--apm" and "--appsearch" flags. The command will exit after the API response has been returned, without 
+and a default APM instance. While Elasticsearch and Kibana come enabled by default, APM, Enterprise Search and App Search need to be 
+enabled by using the "--apm", "--enterprise-search" and "--appsearch" flags. The command will exit after the API response has been returned, without 
 waiting until the deployment resources have been created. 
 $ ecctl deployment create --name my-deployment --zones 2 --kibana-size 2048 --apm --apm-size 1024
 
@@ -76,7 +76,7 @@ $ ecctl deployment create --request-id=GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhG
       --appsearch-zones int32             Number of zones the App Search instances will span (default 1)
       --deployment-template string        Deployment template ID on which to base the deployment from
       --enterprise-search                 Enables Enterprise Search for the deployment
-      --enterprise-search-ref-id string   Optional RefId for the Enterprise Search deployment (default "main-enterprise-search")
+      --enterprise-search-ref-id string   Optional RefId for the Enterprise Search deployment (default "main-enterprise_search")
       --enterprise-search-size int32      Memory (RAM) in MB that each of the Enterprise Search instances will have (default 4096)
       --enterprise-search-zones int32     Number of zones the Enterprise Search instances will span (default 1)
       --es-ref-id string                  Optional RefId for the Elasticsearch deployment (default "main-elasticsearch")

--- a/docs/ecctl_deployment_create.md
+++ b/docs/ecctl_deployment_create.md
@@ -4,36 +4,96 @@ Creates a deployment
 
 ### Synopsis
 
-Creates a deployment which is defined from a file definition using the --file=<file path> (shorthand: -f) flag.
+Creates a deployment which can be defined through flags or from a file definition.
+Sane default values are provided, making the command work out of the box even when no parameters are set. 
+When version is not specified, the latest available stack version will automatically be used. 
+These are the available options:
 
-You can create a definition by using the sample JSON:
-  https://elastic.co/guide/en/cloud/current/ec-api-deployment-crud.html#ec_create_a_deployment
+  * Simplified flags to set size and zone count for each instance type (Elasticsearch, Kibana, APM and App Search). 
+  * Advanced flag for different Elasticsearch node types: --topology-element <json obj> (shorthand: -e).
+    Note that the flag can be specified multiple times for complex topologies.
+    The JSON object has the following format:
+    {
+      "name": "["data", "master", "ml"]" # type string
+      "size": 1024 # type int32
+      "zone_count": 1 # type int32
+    }
+  * File definition: --file=<file path> (shorthand: -f). You can create a definition by using the sample JSON seen here:
+    https://elastic.co/guide/en/cloud/current/ec-api-deployment-crud.html#ec_create_a_deployment
+
+As an option "--generate-payload" can be used in order to obtain the generated payload that would be sent as a request. 
+Save it, update or extend the topology and create a deployment using the saved payload with the "--file" flag.
 
 ```
-ecctl deployment create {--file | --size <int> --zones <string> | --topology-element <obj>} [flags]
+ecctl deployment create {--file | --es-size <int> --es-zones <int> | --topology-element <obj>} [flags]
 ```
 
 ### Examples
 
 ```
+## Create a deployment with the default values for Elasticsearch, a Kibana instance with a modified size, 
+and a default APM instance. While Elasticsearch and Kibana come enabled by default, both APM and App Search need to be 
+enabled by using the "--apm" and "--appsearch" flags. The command will exit after the API response has been returned, without 
+waiting until the deployment resources have been created. 
+$ ecctl deployment create --name my-deployment --zones 2 --kibana-size 2048 --apm --apm-size 1024
+
 ## To make the command wait until the resources have been created use the "--track" flag, which will output 
 the current stage on which the deployment resources are in.
-$ deployment create --file create_example.json --track
+$ deployment create --name my-deployment --track
 [...]
 Deployment [b6ecbea3d5c84124b7dca457f2892086] - [Elasticsearch][b6ecbea3d5c84124b7dca457f2892086]: finished running all the plan steps (Total plan duration: 5m11.s)
 Deployment [91c4d60acb804ba0a27651fac02780ec] - [Kibana][8a9d9916cd6e46a7bb0912211d76e2af]: finished running all the plan steps (Total plan duration: 4m29.58s)
 
+## Additionally, a more advanced topology for Elasticsearch can be created through "--topology-element" or shorthand "-e".
+The following command will create a deployment with two 1GB Elasticsearch instances of the type "data" and 
+one 1GB Elasticsearch instance of the type "ml".
+$ ecctl deployment create --name my-deployment --topology-element '{"size": 1024, "zone_count": 2, "name": "data"}' --topology-element '{"size": 1024, "zone_count": 1, "name": "ml"}'
+
+## In order to use the "--deployment-template" flag, you'll need to know which deployment templates ara available to you.
+You'll need to run the following command to view your deployment templates:
+$ ecctl platform deployment-template list
+
+## Use the "--generate-payload" flag to save the definition to a file for later use.
+$ ecctl deployment create --name my-deployment --size 1024 --track --generate-payload --zones 2 > create_example.json
+
+## Create a deployment through the file definition.
+$ ecctl deployment create --file create_example.json --track
+
 ## To retry a deployment when the previous deployment creation failed, use the request ID provided in the error response of the previous command:
-$ ecctl deployment create --file create_example.json --request-id=GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhGUSMXrEIzVXoBykSVRsKncNb
+$ ecctl deployment create --request-id=GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhGUSMXrEIzVXoBykSVRsKncNb
 ```
 
 ### Options
 
 ```
-  -f, --file string         DeploymentCreateRequest file definition. See help for more information
-  -h, --help                help for create
-      --request-id string   Optional request ID - Can be found in the Stderr device when a previous deployment creation failed. For more information see the examples in the help command page
-  -t, --track               Tracks the progress of the performed task
+      --apm                               Enables APM for the deployment
+      --apm-ref-id string                 Optional RefId for the APM deployment (default "main-apm")
+      --apm-size int32                    Memory (RAM) in MB that each of the APM instances will have (default 512)
+      --apm-zones int32                   Number of zones the APM instances will span (default 1)
+      --appsearch                         Enables App Search for the deployment
+      --appsearch-ref-id string           Optional RefId for the App Search deployment (default "main-appsearch")
+      --appsearch-size int32              Memory (RAM) in MB that each of the App Search instances will have (default 2048)
+      --appsearch-zones int32             Number of zones the App Search instances will span (default 1)
+      --deployment-template string        Deployment template ID on which to base the deployment from (default "default")
+      --enterprise-search                 Enables Enterprise Search for the deployment
+      --enterprise-search-ref-id string   Optional RefId for the Enterprise Search deployment (default "main-enterprise-search")
+      --enterprise-search-size int32      Memory (RAM) in MB that each of the Enterprise Search instances will have (default 4096)
+      --enterprise-search-zones int32     Number of zones the Enterprise Search instances will span (default 1)
+      --es-ref-id string                  Optional RefId for the Elasticsearch deployment (default "main-elasticsearch")
+      --es-size int32                     Memory (RAM) in MB that each of the Elasticsearch instances will have (default 4096)
+      --es-zones int32                    Number of zones the Elasticsearch instances will span (default 1)
+  -f, --file string                       DeploymentCreateRequest file definition. See help for more information
+      --generate-payload                  Returns the deployment payload without actually creating the deployment resources
+  -h, --help                              help for create
+      --kibana-ref-id string              Optional RefId for the Kibana deployment (default "main-kibana")
+      --kibana-size int32                 Memory (RAM) in MB that each of the Kibana instances will have (default 1024)
+      --kibana-zones int32                Number of zones the Kibana instances will span (default 1)
+      --name string                       Optional name for the deployment
+      --plugin strings                    Additional plugins to add to the Elasticsearch deployment
+      --request-id string                 Optional request ID - Can be found in the Stderr device when a previous deployment creation failed. For more information see the examples in the help command page
+  -e, --topology-element stringArray      Optional Elasticsearch topology element definition. See help for more information
+  -t, --track                             Tracks the progress of the performed task
+      --version string                    Version to use, if not specified, the latest available stack version will be used
 ```
 
 ### Options inherited from parent commands

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535
-	github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200701041110-74b71347640c
+	github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200716075727-c649b4a8399d
 	github.com/go-openapi/runtime v0.19.19
 	github.com/go-openapi/strfmt v0.19.5
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDD
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200701041110-74b71347640c h1:NNbyLA77/nElOfHzKMmzuj6ONYeNEX2O2IpAT++S3SU=
 github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200701041110-74b71347640c/go.mod h1:vN6Owi70SFcovUDWAgBQ9QQ/A+zTphbMApA4IXxWhvM=
+github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200716075727-c649b4a8399d h1:BNL+QYlHykDKoOQU6ssC+DG2R+d0rtuSHVw9rnMwl9s=
+github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200716075727-c649b4a8399d/go.mod h1:vN6Owi70SFcovUDWAgBQ9QQ/A+zTphbMApA4IXxWhvM=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=


### PR DESCRIPTION
**Requires https://github.com/elastic/cloud-sdk-go/pull/168 to be merged**

## Description
Re-enables `ecctl deployment create` flags (https://github.com/elastic/ecctl/pull/239)

Also, there is now support for Enterprise Search and the default deployment 
template is chosen based on cloud provider.

## Related Issues
Closes https://github.com/elastic/ecctl/issues/334

## How Has This Been Tested?
tests and manually running the command many times

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
