### PR TITLE
allocator: Fix Array parsing to slice parsing

### DIFF
--- a/cmd/platform/allocator/vacate.go
+++ b/cmd/platform/allocator/vacate.go
@@ -143,8 +143,9 @@ var vacateAllocatorCmd = &cobra.Command{
 		if setAllocatorMaintenance {
 			for _, id := range args {
 				var params = allocatorapi.MaintenanceParams{
-					API: ecctl.Get().API,
-					ID:  id,
+					API:    ecctl.Get().API,
+					ID:     id,
+					Region: ecctl.Get().Config.Region,
 				}
 				if err := allocatorapi.StartMaintenance(params); err != nil {
 					merr = merr.Append(err)

--- a/cmd/platform/allocator/vacate.go
+++ b/cmd/platform/allocator/vacate.go
@@ -89,7 +89,7 @@ var vacateAllocatorCmd = &cobra.Command{
 			return err
 		}
 
-		resources, err := cmd.Flags().GetStringArray("resource-id")
+		resources, err := cmd.Flags().GetStringSlice("resource-id")
 		if err != nil {
 			return err
 		}
@@ -197,8 +197,8 @@ func init() {
 	Command.AddCommand(vacateAllocatorCmd)
 	vacateAllocatorCmd.Flags().Bool("skip-tracking", false, "Skips tracking the vacate progress causing the command to return after the move operation has been executed. Not recommended.")
 	vacateAllocatorCmd.Flags().StringP("kind", "k", "", "Kind of workload to vacate (elasticsearch|kibana|apm|appsearch|enterprise_search)")
-	vacateAllocatorCmd.Flags().StringArrayP("resource-id", "r", nil, "Resource IDs to include in the vacate")
-	vacateAllocatorCmd.Flags().StringArrayP("target", "t", nil, "Target allocator(s) on which to place the vacated workload")
+	vacateAllocatorCmd.Flags().StringSliceP("resource-id", "r", nil, "Resource IDs to include in the vacate")
+	vacateAllocatorCmd.Flags().StringSliceP("target", "t", nil, "Target allocator(s) on which to place the vacated workload")
 	vacateAllocatorCmd.Flags().BoolP("maintenance", "m", false, "Whether to set the allocator(s) in maintenance before performing the vacate")
 	vacateAllocatorCmd.Flags().Uint("concurrency", 8, "Maximum number of concurrent moves to perform at any time")
 	vacateAllocatorCmd.Flags().String("allocator-down", "", "Disables the allocator health auto-discovery, setting the allocator-down to either [true|false]")

--- a/docs/ecctl_platform_allocator_vacate.adoc
+++ b/docs/ecctl_platform_allocator_vacate.adoc
@@ -63,11 +63,11 @@ ecctl platform allocator vacate <allocator-id> [flags]
       --move-only                    Keeps the resource in its current -possibly broken- state and just does the bare minimum to move the requested instances across to another allocator. [true|false] (default true)
       --override-failsafe            If false (the default) then the plan will fail out if it believes the requested sequence of operations can result in data loss - this flag will override some of these restraints. [true|false]
       --poll-frequency duration      Optional polling frequency to check for plan change updates (default 10s)
-  -r, --resource-id stringArray      Resource IDs to include in the vacate
+  -r, --resource-id strings          Resource IDs to include in the vacate
       --skip-data-migration string   Skips the data-migration operation on the specified resource IDs. ONLY available when the resource IDs are specified and --move-only is true. [true|false]
       --skip-snapshot string         Skips the snapshot operation on the specified resource IDs. ONLY available when the resource IDs are specified. [true|false]
       --skip-tracking                Skips tracking the vacate progress causing the command to return after the move operation has been executed. Not recommended.
-  -t, --target stringArray           Target allocator(s) on which to place the vacated workload
+  -t, --target strings               Target allocator(s) on which to place the vacated workload
 ----
 
 [float]

--- a/docs/ecctl_platform_allocator_vacate.md
+++ b/docs/ecctl_platform_allocator_vacate.md
@@ -60,11 +60,11 @@ ecctl platform allocator vacate <allocator-id> [flags]
       --move-only                    Keeps the resource in its current -possibly broken- state and just does the bare minimum to move the requested instances across to another allocator. [true|false] (default true)
       --override-failsafe            If false (the default) then the plan will fail out if it believes the requested sequence of operations can result in data loss - this flag will override some of these restraints. [true|false]
       --poll-frequency duration      Optional polling frequency to check for plan change updates (default 10s)
-  -r, --resource-id stringArray      Resource IDs to include in the vacate
+  -r, --resource-id strings          Resource IDs to include in the vacate
       --skip-data-migration string   Skips the data-migration operation on the specified resource IDs. ONLY available when the resource IDs are specified and --move-only is true. [true|false]
       --skip-snapshot string         Skips the snapshot operation on the specified resource IDs. ONLY available when the resource IDs are specified. [true|false]
       --skip-tracking                Skips tracking the vacate progress causing the command to return after the move operation has been executed. Not recommended.
-  -t, --target stringArray           Target allocator(s) on which to place the vacated workload
+  -t, --target strings               Target allocator(s) on which to place the vacated workload
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail. -->
Fixes a bug where the `--target` parameter was being ignored due to the
flag parsing using `GetStringSlice` when the flag decaration is `Array`.

The bug changes the type from an ArrayString to SliceString.

Additionally, fixes `--maintenance` call which is missing a region value.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`--target` flag was being incorrectly parsed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
