### PR TITLE
deployment: Fix create command against ESS

### DIFF
--- a/cmd/deployment/create.go
+++ b/cmd/deployment/create.go
@@ -89,20 +89,22 @@ var createCmd = &cobra.Command{
 			dt = setDefaultTemplate(region)
 		}
 
+		dtAsList, _ := cmd.Flags().GetBool("dt-as-list")
 		if payload == nil {
 			var err error
 			payload, err = depresourceapi.NewPayload(depresourceapi.NewPayloadParams{
-				API:                    ecctl.Get().API,
-				Name:                   name,
-				DeploymentTemplateID:   dt,
-				Version:                version,
-				Region:                 region,
-				Writer:                 ecctl.Get().Config.ErrorDevice,
-				Plugins:                plugin,
-				TopologyElements:       te,
-				ApmEnable:              apmEnable,
-				AppsearchEnable:        appsearchEnable,
-				EnterpriseSearchEnable: enterpriseSearchEnable,
+				DeploymentTemplateAsList: dtAsList,
+				API:                      ecctl.Get().API,
+				Name:                     name,
+				DeploymentTemplateID:     dt,
+				Version:                  version,
+				Region:                   region,
+				Writer:                   ecctl.Get().Config.ErrorDevice,
+				Plugins:                  plugin,
+				TopologyElements:         te,
+				ApmEnable:                apmEnable,
+				AppsearchEnable:          appsearchEnable,
+				EnterpriseSearchEnable:   enterpriseSearchEnable,
 				ElasticsearchInstance: depresourceapi.InstanceParams{
 					RefID:     esRefID,
 					Size:      esSize,
@@ -167,6 +169,10 @@ var createCmd = &cobra.Command{
 }
 
 func init() {
+	initFlags()
+}
+
+func initFlags() {
 	Command.AddCommand(createCmd)
 	createCmd.Flags().StringP("file", "f", "", "DeploymentCreateRequest file definition. See help for more information")
 	createCmd.Flags().String("deployment-template", "", "Deployment template ID on which to base the deployment from")
@@ -200,6 +206,10 @@ func init() {
 	createCmd.Flags().String("enterprise-search-ref-id", "main-enterprise_search", "Optional RefId for the Enterprise Search deployment")
 	createCmd.Flags().Int32("enterprise-search-zones", 1, "Number of zones the Enterprise Search instances will span")
 	createCmd.Flags().Int32("enterprise-search-size", 4096, "Memory (RAM) in MB that each of the Enterprise Search instances will have")
+
+	// Remove in the next version.
+	createCmd.Flags().Bool("dt-as-list", true, "")
+	createCmd.Flags().MarkHidden("dt-as-list")
 }
 
 func setDefaultTemplate(region string) string {

--- a/cmd/deployment/create_test.go
+++ b/cmd/deployment/create_test.go
@@ -35,6 +35,114 @@ import (
 	"github.com/elastic/ecctl/cmd/util/testutils"
 )
 
+var defaultTemplateResponse = models.DeploymentTemplateInfoV2{
+	ID: ec.String("default"),
+	DeploymentTemplate: &models.DeploymentCreateRequest{
+		Resources: &models.DeploymentCreateResources{
+			Apm: []*models.ApmPayload{
+				{
+					Plan: &models.ApmPlan{
+						ClusterTopology: []*models.ApmTopologyElement{
+							{
+								Size: &models.TopologySize{
+									Resource: ec.String("memory"),
+									Value:    ec.Int32(1024),
+								},
+								ZoneCount: 1,
+							},
+						},
+					},
+				},
+			},
+			EnterpriseSearch: []*models.EnterpriseSearchPayload{
+				{
+					Plan: &models.EnterpriseSearchPlan{
+						ClusterTopology: []*models.EnterpriseSearchTopologyElement{
+							{
+								Size: &models.TopologySize{
+									Resource: ec.String("memory"),
+									Value:    ec.Int32(1024),
+								},
+								ZoneCount: 1,
+							},
+						},
+					},
+				},
+			},
+			Appsearch: []*models.AppSearchPayload{
+				{
+					Plan: &models.AppSearchPlan{
+						ClusterTopology: []*models.AppSearchTopologyElement{
+							{
+								Size: &models.TopologySize{
+									Resource: ec.String("memory"),
+									Value:    ec.Int32(1024),
+								},
+								ZoneCount: 1,
+							},
+						},
+					},
+				},
+			},
+			Kibana: []*models.KibanaPayload{
+				{
+					Plan: &models.KibanaClusterPlan{
+						ClusterTopology: []*models.KibanaClusterTopologyElement{
+							{
+								Size: &models.TopologySize{
+									Resource: ec.String("memory"),
+									Value:    ec.Int32(1024),
+								},
+								ZoneCount: 1,
+							},
+						},
+					},
+				},
+			},
+			Elasticsearch: []*models.ElasticsearchPayload{
+				{
+					Plan: &models.ElasticsearchClusterPlan{
+						ClusterTopology: defaultESTopologies,
+					},
+				},
+			},
+		},
+	},
+}
+
+var defaultESTopologies = []*models.ElasticsearchClusterTopologyElement{
+	{
+		InstanceConfigurationID: "default.data",
+		Size: &models.TopologySize{
+			Resource: ec.String("memory"),
+			Value:    ec.Int32(1024),
+		},
+		NodeType: &models.ElasticsearchNodeType{
+			Data: ec.Bool(true),
+		},
+	},
+	{
+		InstanceConfigurationID: "default.master",
+		Size: &models.TopologySize{
+			Resource: ec.String("memory"),
+			Value:    ec.Int32(1024),
+		},
+		NodeType: &models.ElasticsearchNodeType{
+			Master: ec.Bool(true),
+		},
+	},
+	{
+		InstanceConfigurationID: "default.ml",
+		Size: &models.TopologySize{
+			Resource: ec.String("memory"),
+			Value:    ec.Int32(1024),
+		},
+		NodeType: &models.ElasticsearchNodeType{
+			Ml: ec.Bool(true),
+		},
+	},
+}
+
 func Test_createCmd(t *testing.T) {
 	var deploymentID = ec.RandomResourceID()
 	var esID = ec.RandomResourceID()
@@ -73,7 +181,7 @@ func Test_createCmd(t *testing.T) {
 	var defaultCreateResponse = models.DeploymentCreateResponse{
 		Created: ec.Bool(true),
 		ID:      ec.String(deploymentID),
-		Name:    ec.String("search-dev-ece-region"),
+		Name:    ec.String("some-deployment"),
 		Resources: []*models.DeploymentResource{
 			{
 				ID:     ec.String(esID),
@@ -93,15 +201,16 @@ func Test_createCmd(t *testing.T) {
 			},
 		},
 	}
-	defaultCreateResponseBytes, err := json.Marshal(defaultCreateResponse)
+	defaultCreateResponseBytes, err := json.MarshalIndent(defaultCreateResponse, "", "  ")
 	if err != nil {
 		t.Fatal(err)
 	}
+	defaultCreateResponseBytes = append(defaultCreateResponseBytes, []byte("\n")...)
 
 	var overrideCreateResponse = models.DeploymentCreateResponse{
 		Created: ec.Bool(true),
 		ID:      ec.String(deploymentID),
-		Name:    ec.String("search-dev-ece-region"),
+		Name:    ec.String("some-deployment-with-overrides"),
 		Resources: []*models.DeploymentResource{
 			{
 				ID:     ec.String(esID),
@@ -139,10 +248,11 @@ func Test_createCmd(t *testing.T) {
 			},
 		},
 	}
-	overrideCreateResponseBytes, err := json.Marshal(overrideCreateResponse)
+	overrideCreateResponseBytes, err := json.MarshalIndent(overrideCreateResponse, "", "  ")
 	if err != nil {
 		t.Fatal(err)
 	}
+	overrideCreateResponseBytes = append(overrideCreateResponseBytes, []byte("\n")...)
 
 	var awsDeploymentID = ec.RandomResourceID()
 	var awsESID = ec.RandomResourceID()
@@ -320,13 +430,83 @@ Deployment [%s] - [Apm][%s]: running step "waiting-for-some-step" (Plan duration
 			args: testutils.Args{
 				Cmd: createCmd,
 				Args: []string{
-					"create", "--file=", "--request-id=some_request_id",
+					"create", "--request-id=some_request_id",
 				},
 				Cfg: testutils.MockCfg{Responses: []mock.Response{
 					{
 						Response: http.Response{
+							StatusCode: 200,
+							Body: mock.NewStructBody([]models.DeploymentTemplateInfoV2{
+								defaultTemplateResponse,
+							}),
+						},
+						Assert: &mock.RequestAssertion{
+							Method: "GET",
+							Header: api.DefaultReadMockHeaders,
+							Path:   "/api/v1/deployments/templates",
+							Host:   api.DefaultMockHost,
+							Query: url.Values{
+								"region":                       {"ece-region"},
+								"show_hidden":                  {"false"},
+								"show_instance_configurations": {"true"},
+							},
+						},
+					},
+					{
+						Response: http.Response{
+							StatusCode: 200,
+							Body: mock.NewStructBody(models.StackVersionConfigs{
+								Stacks: []*models.StackVersionConfig{{Version: "7.8.0"}},
+							}),
+						},
+						Assert: &mock.RequestAssertion{
+							Host:   api.DefaultMockHost,
+							Header: api.DefaultReadMockHeaders,
+							Path:   "/api/v1/regions/ece-region/stack/versions",
+							Method: "GET",
+							Query: url.Values{
+								"show_deleted":  {"false"},
+								"show_unusable": {"false"},
+							},
+						},
+					},
+					{
+						Response: http.Response{
 							StatusCode: 201,
 							Body:       mock.NewStructBody(defaultCreateResponse),
+						},
+						Assert: &mock.RequestAssertion{
+							Method: "POST",
+							Header: api.DefaultWriteMockHeaders,
+							Body:   mock.NewStringBody(`{"resources":{"apm":null,"appsearch":null,"elasticsearch":[{"plan":{"cluster_topology":[{"instance_configuration_id":"default.data","node_type":{"data":true},"size":{"resource":"memory","value":4096},"zone_count":1}],"deployment_template":{"id":"default"},"elasticsearch":{"version":"7.8.0"}},"ref_id":"main-elasticsearch","region":"ece-region"}],"enterprise_search":null,"kibana":[{"elasticsearch_cluster_ref_id":"main-elasticsearch","plan":{"cluster_topology":[{"size":{"resource":"memory","value":1024},"zone_count":1}],"kibana":{"version":"7.8.0"}},"ref_id":"main-kibana","region":"ece-region"}]}}` + "\n"),
+							Path:   "/api/v1/deployments",
+							Host:   api.DefaultMockHost,
+							Query: url.Values{
+								"request_id":    {"some_request_id"},
+								"validate_only": {"false"},
+							},
+						},
+					},
+				}},
+			},
+			want: testutils.Assertion{
+				Stderr: "Obtained latest stack version: 7.8.0\n",
+				Stdout: string(defaultCreateResponseBytes),
+			},
+		},
+		{
+			name: "succeeds creating a deployment with default values and without tracking (Normal GetCall)",
+			args: testutils.Args{
+				Cmd: createCmd,
+				Args: []string{
+					"create", "--request-id=some_request_id", "--version=7.8.0",
+					"--dt-as-list=false",
+				},
+				Cfg: testutils.MockCfg{Responses: []mock.Response{
+					{
+						Response: http.Response{
+							StatusCode: 200,
+							Body:       mock.NewStructBody(defaultTemplateResponse),
 						},
 						Assert: &mock.RequestAssertion{
 							Method: "GET",
@@ -339,10 +519,27 @@ Deployment [%s] - [Apm][%s]: running step "waiting-for-some-step" (Plan duration
 							},
 						},
 					},
+					{
+						Response: http.Response{
+							StatusCode: 201,
+							Body:       mock.NewStructBody(defaultCreateResponse),
+						},
+						Assert: &mock.RequestAssertion{
+							Method: "POST",
+							Header: api.DefaultWriteMockHeaders,
+							Body:   mock.NewStringBody(`{"resources":{"apm":null,"appsearch":null,"elasticsearch":[{"plan":{"cluster_topology":[{"instance_configuration_id":"default.data","node_type":{"data":true},"size":{"resource":"memory","value":4096},"zone_count":1}],"deployment_template":{"id":"default"},"elasticsearch":{"version":"7.8.0"}},"ref_id":"main-elasticsearch","region":"ece-region"}],"enterprise_search":null,"kibana":[{"elasticsearch_cluster_ref_id":"main-elasticsearch","plan":{"cluster_topology":[{"size":{"resource":"memory","value":1024},"zone_count":1}],"kibana":{"version":"7.8.0"}},"ref_id":"main-kibana","region":"ece-region"}]}}` + "\n"),
+							Path:   "/api/v1/deployments",
+							Host:   api.DefaultMockHost,
+							Query: url.Values{
+								"request_id":    {"some_request_id"},
+								"validate_only": {"false"},
+							},
+						},
+					},
 				}},
 			},
 			want: testutils.Assertion{
-				Err: errors.New(string(defaultCreateResponseBytes) + "\n"),
+				Stdout: string(defaultCreateResponseBytes),
 			},
 		},
 		{
@@ -350,29 +547,49 @@ Deployment [%s] - [Apm][%s]: running step "waiting-for-some-step" (Plan duration
 			args: testutils.Args{
 				Cmd: createCmd,
 				Args: []string{
-					"create", "--apm", "--appsearch", "--enterprise-search", "--file=", "--request-id=some_request_id",
+					"create", "--apm", "--appsearch", "--enterprise-search", "--request-id=some_request_id", "--version=7.8.0",
 				},
 				Cfg: testutils.MockCfg{Responses: []mock.Response{
+					{
+						Response: http.Response{
+							StatusCode: 200,
+							Body: mock.NewStructBody([]models.DeploymentTemplateInfoV2{
+								defaultTemplateResponse,
+							}),
+						},
+						Assert: &mock.RequestAssertion{
+							Method: "GET",
+							Header: api.DefaultReadMockHeaders,
+							Path:   "/api/v1/deployments/templates",
+							Host:   api.DefaultMockHost,
+							Query: url.Values{
+								"region":                       {"ece-region"},
+								"show_hidden":                  {"false"},
+								"show_instance_configurations": {"true"},
+							},
+						},
+					},
 					{
 						Response: http.Response{
 							StatusCode: 201,
 							Body:       mock.NewStructBody(overrideCreateResponse),
 						},
 						Assert: &mock.RequestAssertion{
-							Method: "GET",
-							Header: api.DefaultReadMockHeaders,
-							Path:   "/api/v1/deployments/templates/default",
+							Method: "POST",
+							Header: api.DefaultWriteMockHeaders,
+							Body:   mock.NewStringBody(`{"resources":{"apm":[{"elasticsearch_cluster_ref_id":"main-elasticsearch","plan":{"apm":{"version":"7.8.0"},"cluster_topology":[{"size":{"resource":"memory","value":512},"zone_count":1}]},"ref_id":"main-apm","region":"ece-region"}],"appsearch":[{"elasticsearch_cluster_ref_id":"main-elasticsearch","plan":{"appsearch":{"version":"7.8.0"},"cluster_topology":[{"size":{"resource":"memory","value":2048},"zone_count":1}]},"ref_id":"main-appsearch","region":"ece-region"}],"elasticsearch":[{"plan":{"cluster_topology":[{"instance_configuration_id":"default.data","node_type":{"data":true},"size":{"resource":"memory","value":4096},"zone_count":1}],"deployment_template":{"id":"default"},"elasticsearch":{"version":"7.8.0"}},"ref_id":"main-elasticsearch","region":"ece-region"}],"enterprise_search":[{"elasticsearch_cluster_ref_id":"main-elasticsearch","plan":{"cluster_topology":[{"size":{"resource":"memory","value":4096},"zone_count":1}],"enterprise_search":{"version":"7.8.0"}},"ref_id":"main-enterprise_search","region":"ece-region"}],"kibana":[{"elasticsearch_cluster_ref_id":"main-elasticsearch","plan":{"cluster_topology":[{"size":{"resource":"memory","value":1024},"zone_count":1}],"kibana":{"version":"7.8.0"}},"ref_id":"main-kibana","region":"ece-region"}]}}` + "\n"),
+							Path:   "/api/v1/deployments",
 							Host:   api.DefaultMockHost,
 							Query: url.Values{
-								"region":                       {"ece-region"},
-								"show_instance_configurations": {"true"},
+								"request_id":    {"some_request_id"},
+								"validate_only": {"false"},
 							},
 						},
 					},
 				}},
 			},
 			want: testutils.Assertion{
-				Err: errors.New(string(overrideCreateResponseBytes) + "\n"),
+				Stdout: string(overrideCreateResponseBytes),
 			},
 		},
 		{
@@ -461,6 +678,8 @@ Deployment [%s] - [Apm][%s]: running step "waiting-for-some-step" (Plan duration
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			testutils.RunCmdAssertion(t, tt.args, tt.want)
+			tt.args.Cmd.ResetFlags()
+			defer initFlags()
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535
-	github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200717020648-70be0dfdaf15
+	github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200722001835-e81a08e9ee6e
 	github.com/go-openapi/runtime v0.19.20
 	github.com/go-openapi/strfmt v0.19.5
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200717020648-70be0dfdaf15 h1:2mFeCZidbbCAoaopIaiXosNrMi/+EGFoeCYsSOUkGf8=
-github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200717020648-70be0dfdaf15/go.mod h1:vN6Owi70SFcovUDWAgBQ9QQ/A+zTphbMApA4IXxWhvM=
+github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200722001835-e81a08e9ee6e h1:0/5K0jfesaU/uN+ddk5iIIah3s1mADEbVCOnPK/Aeb8=
+github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200722001835-e81a08e9ee6e/go.mod h1:Lh6StXmfcUQj5TGl53rAmSjryzYEiOW6IjyAvHcuBLk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
@@ -122,8 +122,6 @@ github.com/go-openapi/runtime v0.19.0/go.mod h1:OwNfisksmmaZse4+gpV3Ne9AyMOlP1lt
 github.com/go-openapi/runtime v0.19.4/go.mod h1:X277bwSUBxVlCYR3r7xgZZGKVvBd/29gLDlFGtJ8NL4=
 github.com/go-openapi/runtime v0.19.15 h1:2GIefxs9Rx1vCDNghRtypRq+ig8KSLrjHbAYI/gCLCM=
 github.com/go-openapi/runtime v0.19.15/go.mod h1:dhGWCTKRXlAfGnQG0ONViOZpjfg0m2gUt9nTQPQZuoo=
-github.com/go-openapi/runtime v0.19.19 h1:PCaQSqG0HiCgpekchPrHO9AEc5ZUaAclOUp9T3RSKoQ=
-github.com/go-openapi/runtime v0.19.19/go.mod h1:Lm9YGCeecBnUUkFTxPC4s1+lwrkJ0pthx8YvyjCfkgk=
 github.com/go-openapi/runtime v0.19.20 h1:J/t+QIjbcoq8WJvjGxRKiFBhqUE8slS9SbmD0Oi/raQ=
 github.com/go-openapi/runtime v0.19.20/go.mod h1:Lm9YGCeecBnUUkFTxPC4s1+lwrkJ0pthx8YvyjCfkgk=
 github.com/go-openapi/spec v0.17.0/go.mod h1:XkF/MOi14NmjsfZ8VtAKf8pIlbZzyoTvZsdfssdxcBI=


### PR DESCRIPTION


## Description
<!--- Describe your changes in detail. -->
Fixes the `deployment create` command to be able to pull the deployment
templates by listing them using the API.

Additionally fixes the missing version on statless resources when the
version flag is not specified and it's a flag-based create.

Last, fixes the create tests which weren't testing the create workflow
on the flag-based scenario.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Requires elastic/cloud-sdk-go#178 to be merged.
Part of #335 
