### PR TITLE
docs: specify all ECE specific commands and add icons to .adoc files

### DIFF
--- a/cmd/auth/command.go
+++ b/cmd/auth/command.go
@@ -26,7 +26,7 @@ import (
 // Command is the auth subcommand
 var Command = &cobra.Command{
 	Use:     "auth",
-	Short:   "Manages authentication",
+	Short:   "Manages authentication settings",
 	PreRunE: cobra.MaximumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()

--- a/cmd/auth/command.go
+++ b/cmd/auth/command.go
@@ -26,7 +26,7 @@ import (
 // Command is the auth subcommand
 var Command = &cobra.Command{
 	Use:     "auth",
-	Short:   "Manages the platform auth",
+	Short:   "Manages authentication",
 	PreRunE: cobra.MaximumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()

--- a/cmd/platform/allocator/list.go
+++ b/cmd/platform/allocator/list.go
@@ -25,6 +25,7 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/allocatorapi"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
@@ -88,7 +89,7 @@ func listAllocators(cmd *cobra.Command, args []string) error {
 
 var listAllocatorsCmd = &cobra.Command{
 	Use:     "list",
-	Short:   allocatorListMessage,
+	Short:   cmdutil.AdminReqDescription(allocatorListMessage),
 	Long:    allocatorListMessage + allocatorQueryExample + allocatorFilterExample,
 	PreRunE: cobra.MaximumNArgs(0),
 	RunE:    listAllocators,

--- a/cmd/platform/allocator/maintenance.go
+++ b/cmd/platform/allocator/maintenance.go
@@ -23,12 +23,13 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/allocatorapi"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
 var maintenanceAllocatorCmd = &cobra.Command{
 	Use:     "maintenance <allocator id>",
-	Short:   "Sets the allocator in Maintenance mode",
+	Short:   cmdutil.AdminReqDescription("Sets the allocator in Maintenance mode"),
 	PreRunE: cobra.MinimumNArgs(1),
 
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/platform/allocator/search.go
+++ b/cmd/platform/allocator/search.go
@@ -40,7 +40,7 @@ const (
 // Command represents the allocator search command.
 var searchAllocatorCmd = &cobra.Command{
 	Use:     `search`,
-	Short:   "Performs advanced allocator searching",
+	Short:   cmdutil.AdminReqDescription("Performs advanced allocator searching"),
 	Long:    queryExamples,
 	PreRunE: cobra.MaximumNArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/platform/allocator/show.go
+++ b/cmd/platform/allocator/show.go
@@ -23,6 +23,7 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/allocatorapi"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
@@ -46,7 +47,7 @@ func showAllocator(cmd *cobra.Command, args []string) error {
 
 var showAllocatorCmd = &cobra.Command{
 	Use:     "show <allocator id>",
-	Short:   "Returns information about the allocator",
+	Short:   cmdutil.AdminReqDescription("Returns information about the allocator"),
 	PreRunE: cobra.MinimumNArgs(1),
 	RunE:    showAllocator,
 }

--- a/cmd/platform/allocator/vacate.go
+++ b/cmd/platform/allocator/vacate.go
@@ -69,7 +69,7 @@ const vacateExamples = `  ecctl platform allocator vacate i-05e245252362f7f1d
 
 var vacateAllocatorCmd = &cobra.Command{
 	Use:     "vacate <allocator-id>",
-	Short:   "Moves all the resources from the specified allocator",
+	Short:   cmdutil.AdminReqDescription("Moves all the resources from the specified allocator"),
 	Example: vacateExamples,
 	PreRunE: cobra.MinimumNArgs(1),
 	Aliases: []string{"move-nodes"},

--- a/cmd/platform/command.go
+++ b/cmd/platform/command.go
@@ -28,12 +28,13 @@ import (
 	cmdrepository "github.com/elastic/ecctl/cmd/platform/repository"
 	cmdrole "github.com/elastic/ecctl/cmd/platform/role"
 	cmdrunner "github.com/elastic/ecctl/cmd/platform/runner"
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 )
 
 // Command is the platform subcommand
 var Command = &cobra.Command{
 	Use:     "platform",
-	Short:   "Manages the platform",
+	Short:   cmdutil.AdminReqDescription("Manages the platform"),
 	PreRunE: cobra.MaximumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()

--- a/cmd/platform/constructor/list.go
+++ b/cmd/platform/constructor/list.go
@@ -23,12 +23,13 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/constructorapi"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
 var listConstructorsCmd = &cobra.Command{
 	Use:     "list",
-	Short:   `Returns all of the constructors in the platform`,
+	Short:   cmdutil.AdminReqDescription("Returns all of the constructors in the platform"),
 	PreRunE: cobra.NoArgs,
 	RunE:    listConstructors,
 }

--- a/cmd/platform/constructor/maintenance.go
+++ b/cmd/platform/constructor/maintenance.go
@@ -23,12 +23,13 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/constructorapi"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
 var maintenanceConstructorCmd = &cobra.Command{
 	Use:     "maintenance <constructor id>",
-	Short:   constructorMaintenanceMessage,
+	Short:   cmdutil.AdminReqDescription(constructorMaintenanceMessage),
 	PreRunE: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		unset, _ := cmd.Flags().GetBool("unset")

--- a/cmd/platform/constructor/resync.go
+++ b/cmd/platform/constructor/resync.go
@@ -21,16 +21,17 @@ import (
 	"fmt"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/constructorapi"
-	"github.com/elastic/cloud-sdk-go/pkg/util/cmdutil"
+	sdkcmdutil "github.com/elastic/cloud-sdk-go/pkg/util/cmdutil"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
 var resyncConstructorCmd = &cobra.Command{
 	Use:     "resync {<constructor id> | --all}",
-	Short:   "Resynchronizes the search index and cache for the selected constructor or all",
-	PreRunE: cmdutil.CheckInputHas1ArgsOr0ArgAndAll,
+	Short:   cmdutil.AdminReqDescription("Resynchronizes the search index and cache for the selected constructor or all"),
+	PreRunE: sdkcmdutil.CheckInputHas1ArgsOr0ArgAndAll,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		all, _ := cmd.Flags().GetBool("all")
 

--- a/cmd/platform/constructor/show.go
+++ b/cmd/platform/constructor/show.go
@@ -23,12 +23,13 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/constructorapi"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
 var showConstructorCmd = &cobra.Command{
 	Use:     "show <constructor id>",
-	Short:   constructorShowMessage,
+	Short:   cmdutil.AdminReqDescription(constructorShowMessage),
 	PreRunE: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		a, err := constructorapi.Get(constructorapi.GetParams{

--- a/cmd/platform/enrollment-token/create.go
+++ b/cmd/platform/enrollment-token/create.go
@@ -23,6 +23,7 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/enrollmenttokenapi"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
@@ -40,7 +41,7 @@ const tokenCreateExamples = `  ecctl [globalFlags] enrollment-token create --rol
 var createTokenCmd = &cobra.Command{
 	Use:     "create --role <ROLE>",
 	Short:   "Creates an enrollment token for role(s)",
-	Example: tokenCreateExamples,
+	Example: cmdutil.AdminReqDescription(tokenCreateExamples),
 	PreRunE: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		roles, _ := cmd.Flags().GetStringArray(roleFlag)

--- a/cmd/platform/enrollment-token/delete.go
+++ b/cmd/platform/enrollment-token/delete.go
@@ -23,12 +23,13 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/enrollmenttokenapi"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
 var deleteTokenCmd = &cobra.Command{
 	Use:     "delete <enrollment-token>",
-	Short:   "Deletes an enrollment token",
+	Short:   cmdutil.AdminReqDescription("Deletes an enrollment token"),
 	PreRunE: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		err := enrollmenttokenapi.Delete(enrollmenttokenapi.DeleteParams{

--- a/cmd/platform/enrollment-token/list.go
+++ b/cmd/platform/enrollment-token/list.go
@@ -23,12 +23,13 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/enrollmenttokenapi"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
 var listTokensCmd = &cobra.Command{
 	Use:     "list",
-	Short:   "Retrieves a list of persistent enrollment tokens",
+	Short:   cmdutil.AdminReqDescription("Retrieves a list of persistent enrollment tokens"),
 	PreRunE: cobra.NoArgs,
 	RunE:    listTokens,
 }

--- a/cmd/platform/instance-configuration/create.go
+++ b/cmd/platform/instance-configuration/create.go
@@ -25,12 +25,13 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/input"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
 var createCmd = &cobra.Command{
 	Use:     "create -f <config.json>",
-	Short:   "Creates a new instance configuration",
+	Short:   cmdutil.AdminReqDescription("Creates a new instance configuration"),
 	PreRunE: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		file, err := input.NewFileOrReader(os.Stdin, cmd.Flag("file").Value.String())

--- a/cmd/platform/instance-configuration/delete.go
+++ b/cmd/platform/instance-configuration/delete.go
@@ -21,12 +21,13 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/instanceconfigapi"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
 var deleteCmd = &cobra.Command{
 	Use:     "delete <config id>",
-	Short:   "Deletes an instance configuration",
+	Short:   cmdutil.AdminReqDescription("Deletes an instance configuration"),
 	PreRunE: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return instanceconfigapi.Delete(instanceconfigapi.DeleteParams{

--- a/cmd/platform/instance-configuration/list.go
+++ b/cmd/platform/instance-configuration/list.go
@@ -23,12 +23,13 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/instanceconfigapi"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
 var listCmd = &cobra.Command{
 	Use:     "list",
-	Short:   "Lists the instance configurations",
+	Short:   cmdutil.AdminReqDescription("Lists the instance configurations"),
 	PreRunE: cobra.MaximumNArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		res, err := instanceconfigapi.List(instanceconfigapi.ListParams{

--- a/cmd/platform/instance-configuration/pull.go
+++ b/cmd/platform/instance-configuration/pull.go
@@ -21,12 +21,13 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/instanceconfigapi"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
 var pullCmd = &cobra.Command{
 	Use:     "pull --path <path>",
-	Short:   "Downloads instance configuration into a local folder",
+	Short:   cmdutil.AdminReqDescription("Downloads instance configuration into a local folder"),
 	PreRunE: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return instanceconfigapi.PullToDirectory(instanceconfigapi.PullToDirectoryParams{

--- a/cmd/platform/instance-configuration/show.go
+++ b/cmd/platform/instance-configuration/show.go
@@ -23,12 +23,13 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/instanceconfigapi"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
 var showCmd = &cobra.Command{
 	Use:     "show <config id>",
-	Short:   "Shows an instance configuration",
+	Short:   cmdutil.AdminReqDescription("Shows an instance configuration"),
 	PreRunE: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		res, err := instanceconfigapi.Get(instanceconfigapi.GetParams{

--- a/cmd/platform/instance-configuration/update.go
+++ b/cmd/platform/instance-configuration/update.go
@@ -24,12 +24,13 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/input"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
 var updateCmd = &cobra.Command{
 	Use:     "update <config id> -f <config.json>",
-	Short:   "Overwrites an instance configuration",
+	Short:   cmdutil.AdminReqDescription("Overwrites an instance configuration"),
 	PreRunE: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		file, err := input.NewFileOrReader(os.Stdin, cmd.Flag("file").Value.String())

--- a/cmd/platform/proxy/filteredgroup/command.go
+++ b/cmd/platform/proxy/filteredgroup/command.go
@@ -19,12 +19,14 @@ package cmdfilteredgroup
 
 import (
 	"github.com/spf13/cobra"
+
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 )
 
 // Command represents the top level filtered-group command.
 var Command = &cobra.Command{
 	Use:     "filtered-group",
-	Short:   "Manages proxies filtered group",
+	Short:   cmdutil.AdminReqDescription("Manages proxies filtered group"),
 	PreRunE: cobra.MaximumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()

--- a/cmd/platform/proxy/filteredgroup/create.go
+++ b/cmd/platform/proxy/filteredgroup/create.go
@@ -23,12 +23,13 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/proxyapi/filteredgroupapi"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
 var platformProxyFilteredGroupCreateCmd = &cobra.Command{
 	Use:     "create <filtered group id> --filters <key1=value1,key2=value2> --expected-proxies-count <int>",
-	Short:   "Creates proxies filtered group",
+	Short:   cmdutil.AdminReqDescription("Creates proxies filtered group"),
 	PreRunE: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 

--- a/cmd/platform/proxy/filteredgroup/delete.go
+++ b/cmd/platform/proxy/filteredgroup/delete.go
@@ -21,12 +21,13 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/proxyapi/filteredgroupapi"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
 var platformProxyFilteredGroupDeleteCmd = &cobra.Command{
 	Use:     "delete <filtered group id>",
-	Short:   "Deletes proxies filtered group",
+	Short:   cmdutil.AdminReqDescription("Deletes proxies filtered group"),
 	PreRunE: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return filteredgroupapi.Delete(filteredgroupapi.DeleteParams{

--- a/cmd/platform/proxy/filteredgroup/list.go
+++ b/cmd/platform/proxy/filteredgroup/list.go
@@ -23,6 +23,7 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/proxyapi/filteredgroupapi"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
@@ -44,7 +45,7 @@ func listProxyFilteredGroups(cmd *cobra.Command, args []string) error {
 
 var platformProxyFilteredGroupsListCmd = &cobra.Command{
 	Use:     "list",
-	Short:   filteredGroupsUse,
+	Short:   cmdutil.AdminReqDescription(filteredGroupsUse),
 	PreRunE: cobra.MaximumNArgs(0),
 	RunE:    listProxyFilteredGroups,
 }

--- a/cmd/platform/proxy/filteredgroup/show.go
+++ b/cmd/platform/proxy/filteredgroup/show.go
@@ -23,12 +23,13 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/proxyapi/filteredgroupapi"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
 var platformProxyFilteredGroupShowCmd = &cobra.Command{
 	Use:     "show <filtered group id>",
-	Short:   "Shows details for proxies filtered group",
+	Short:   cmdutil.AdminReqDescription("Shows details for proxies filtered group"),
 	PreRunE: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		response, err := filteredgroupapi.Get(filteredgroupapi.GetParams{

--- a/cmd/platform/proxy/filteredgroup/update.go
+++ b/cmd/platform/proxy/filteredgroup/update.go
@@ -23,12 +23,13 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/proxyapi/filteredgroupapi"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
 var platformProxyFilteredGroupUpdateCmd = &cobra.Command{
 	Use:     "update <filtered group id> --filters <key1=value1,key2=value2> --expected-proxies-count <int> --version <int>",
-	Short:   "Updates proxies filtered group",
+	Short:   cmdutil.AdminReqDescription("Updates proxies filtered group"),
 	PreRunE: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 

--- a/cmd/platform/proxy/list.go
+++ b/cmd/platform/proxy/list.go
@@ -23,12 +23,13 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/proxyapi"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
 var listProxiesCmd = &cobra.Command{
 	Use:     "list",
-	Short:   "Returns all of the proxies in the platform",
+	Short:   cmdutil.AdminReqDescription("Returns all of the proxies in the platform"),
 	PreRunE: cobra.MaximumNArgs(0),
 	RunE:    listProxies,
 }

--- a/cmd/platform/proxy/show.go
+++ b/cmd/platform/proxy/show.go
@@ -23,12 +23,13 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/proxyapi"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
 var showProxyCmd = &cobra.Command{
 	Use:     "show <proxy id>",
-	Short:   "Returns information about the proxy with given id",
+	Short:   cmdutil.AdminReqDescription("Returns information about the proxy with given id"),
 	PreRunE: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		a, err := proxyapi.Get(proxyapi.GetParams{

--- a/cmd/platform/repository/create.go
+++ b/cmd/platform/repository/create.go
@@ -26,6 +26,7 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/input"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 	"github.com/elastic/ecctl/pkg/util"
 )
@@ -59,7 +60,7 @@ ecctl platform repository create custom --type fs --settings settings.yml
 var platformSnapshotCreateCmd = &cobra.Command{
 	Use:     "create <repository name> --settings <settings file>",
 	Aliases: []string{"update", "set"},
-	Short:   snapshotCreateShortHelp,
+	Short:   cmdutil.AdminReqDescription(snapshotCreateShortHelp),
 	Long:    snapshotCreateLongHelp,
 	Example: snapshotCreateExamples,
 	PreRunE: cobra.MinimumNArgs(1),

--- a/cmd/platform/repository/delete.go
+++ b/cmd/platform/repository/delete.go
@@ -21,12 +21,13 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/snaprepoapi"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
 var platformSnapshotDeleteCmd = &cobra.Command{
 	Use:     "delete <repository name>",
-	Short:   "Deletes a snapshot repositories",
+	Short:   cmdutil.AdminReqDescription("Deletes a snapshot repositories"),
 	PreRunE: cobra.MinimumNArgs(1),
 
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/platform/repository/list.go
+++ b/cmd/platform/repository/list.go
@@ -23,12 +23,13 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/snaprepoapi"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
 var platformSnapshotListCmd = &cobra.Command{
 	Use:     "list",
-	Short:   "Lists all the snapshot repositories",
+	Short:   cmdutil.AdminReqDescription("Lists all the snapshot repositories"),
 	PreRunE: cobra.MaximumNArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		repos, err := snaprepoapi.List(snaprepoapi.ListParams{

--- a/cmd/platform/repository/show.go
+++ b/cmd/platform/repository/show.go
@@ -21,12 +21,13 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/snaprepoapi"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
 var platformSnapshotShowCmd = &cobra.Command{
 	Use:     "show <repository name>",
-	Short:   "Obtains a snapshot repository config",
+	Short:   cmdutil.AdminReqDescription("Obtains a snapshot repository config"),
 	PreRunE: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		repo, err := snaprepoapi.Get(snaprepoapi.GetParams{

--- a/cmd/platform/role/create.go
+++ b/cmd/platform/role/create.go
@@ -20,9 +20,10 @@ package cmdrole
 import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/roleapi"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
-	"github.com/elastic/cloud-sdk-go/pkg/util/cmdutil"
+	sdkcmdutil "github.com/elastic/cloud-sdk-go/pkg/util/cmdutil"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
@@ -32,12 +33,12 @@ const (
 
 var createCmd = &cobra.Command{
 	Use:     "create --file <filename.json>",
-	Short:   shortCreateDesc,
+	Short:   cmdutil.AdminReqDescription(shortCreateDesc),
 	PreRunE: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		filename, _ := cmd.Flags().GetString("file")
 		var r models.RoleAggregateCreateData
-		if err := cmdutil.DecodeFile(filename, &r); err != nil {
+		if err := sdkcmdutil.DecodeFile(filename, &r); err != nil {
 			return err
 		}
 

--- a/cmd/platform/role/delete.go
+++ b/cmd/platform/role/delete.go
@@ -21,12 +21,13 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/roleapi"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
 var deleteCmd = &cobra.Command{
 	Use:     "delete <role>",
-	Short:   "Deletes an existing platform role",
+	Short:   cmdutil.AdminReqDescription("Deletes an existing platform role"),
 	PreRunE: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return roleapi.Delete(roleapi.DeleteParams{

--- a/cmd/platform/role/list.go
+++ b/cmd/platform/role/list.go
@@ -21,12 +21,13 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/roleapi"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
 var listCmd = &cobra.Command{
 	Use:     "list",
-	Short:   "Lists the existing platform roles",
+	Short:   cmdutil.AdminReqDescription("Lists the existing platform roles"),
 	PreRunE: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		res, err := roleapi.List(roleapi.ListParams{

--- a/cmd/platform/role/show.go
+++ b/cmd/platform/role/show.go
@@ -21,12 +21,13 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/roleapi"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
 var showCmd = &cobra.Command{
 	Use:     "show <role>",
-	Short:   "Shows the existing platform roles",
+	Short:   cmdutil.AdminReqDescription("Shows the existing platform roles"),
 	PreRunE: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		res, err := roleapi.Show(roleapi.ShowParams{

--- a/cmd/platform/runner/list.go
+++ b/cmd/platform/runner/list.go
@@ -21,12 +21,13 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/runnerapi"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
 var listCmd = &cobra.Command{
 	Use:     "list",
-	Short:   "Lists the existing platform runners",
+	Short:   cmdutil.AdminReqDescription("Lists the existing platform runners"),
 	PreRunE: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		res, err := runnerapi.List(runnerapi.ListParams{

--- a/cmd/platform/runner/resync.go
+++ b/cmd/platform/runner/resync.go
@@ -21,16 +21,17 @@ import (
 	"fmt"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/runnerapi"
-	"github.com/elastic/cloud-sdk-go/pkg/util/cmdutil"
+	sdkcmdutil "github.com/elastic/cloud-sdk-go/pkg/util/cmdutil"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
 var resyncRunnerCmd = &cobra.Command{
 	Use:     "resync {<runner id> | --all}",
-	Short:   "Resynchronizes the search index and cache for the selected runner or all",
-	PreRunE: cmdutil.CheckInputHas1ArgsOr0ArgAndAll,
+	Short:   cmdutil.AdminReqDescription("Resynchronizes the search index and cache for the selected runner or all"),
+	PreRunE: sdkcmdutil.CheckInputHas1ArgsOr0ArgAndAll,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		all, _ := cmd.Flags().GetBool("all")
 

--- a/cmd/platform/runner/search.go
+++ b/cmd/platform/runner/search.go
@@ -34,7 +34,7 @@ import (
 // Command represents the runner search command.
 var searchCmd = &cobra.Command{
 	Use:     "search",
-	Short:   "Performs advanced runner searching",
+	Short:   cmdutil.AdminReqDescription("Performs advanced runner searching"),
 	Long:    "Read more about Query DSL in https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html",
 	PreRunE: cobra.MaximumNArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/platform/runner/show.go
+++ b/cmd/platform/runner/show.go
@@ -21,12 +21,13 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/platformapi/runnerapi"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
 var showCmd = &cobra.Command{
 	Use:     "show <runner id>",
-	Short:   "Shows information about the specified runner",
+	Short:   cmdutil.AdminReqDescription("Shows information about the specified runner"),
 	PreRunE: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		res, err := runnerapi.Show(runnerapi.ShowParams{

--- a/cmd/user/create.go
+++ b/cmd/user/create.go
@@ -32,7 +32,7 @@ const createExample = `
 
 var createCmd = &cobra.Command{
 	Use:     "create --username <username> --role <role>",
-	Short:   "Creates a new platform user",
+	Short:   cmdutil.AdminReqDescription("Creates a new platform user"),
 	PreRunE: cobra.MinimumNArgs(0),
 	Example: createExample,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/user/delete.go
+++ b/cmd/user/delete.go
@@ -24,20 +24,21 @@ import (
 
 	"github.com/elastic/cloud-sdk-go/pkg/api/userapi"
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"
-	"github.com/elastic/cloud-sdk-go/pkg/util/cmdutil"
+	sdkcmdutil "github.com/elastic/cloud-sdk-go/pkg/util/cmdutil"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
 var deleteCmd = &cobra.Command{
 	Use:     "delete <user name> <user name>...",
-	Short:   "Deletes one or more platform users",
+	Short:   cmdutil.AdminReqDescription("Deletes one or more platform users"),
 	PreRunE: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) > 1 {
 			var msg = "Multiple users will be deleted, do you want to continue? [y/n]: "
-			if !cmdutil.ConfirmAction(msg, os.Stdin, ecctl.Get().Config.OutputDevice) {
+			if !sdkcmdutil.ConfirmAction(msg, os.Stdin, ecctl.Get().Config.OutputDevice) {
 				return nil
 			}
 		}

--- a/cmd/user/disable.go
+++ b/cmd/user/disable.go
@@ -21,12 +21,13 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/userapi"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
 var disableCmd = &cobra.Command{
 	Use:     "disable <username>",
-	Short:   "Disables a platform user",
+	Short:   cmdutil.AdminReqDescription("Disables a platform user"),
 	PreRunE: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		res, err := userapi.Enable(userapi.EnableParams{

--- a/cmd/user/enable.go
+++ b/cmd/user/enable.go
@@ -22,12 +22,13 @@ import (
 
 	"github.com/elastic/cloud-sdk-go/pkg/api/userapi"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
 var enableCmd = &cobra.Command{
 	Use:     "enable <username>",
-	Short:   "Enables a previously disabled platform user",
+	Short:   cmdutil.AdminReqDescription("Enables a previously disabled platform user"),
 	PreRunE: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		res, err := userapi.Enable(userapi.EnableParams{

--- a/cmd/user/list.go
+++ b/cmd/user/list.go
@@ -21,12 +21,13 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/userapi"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
 var listCmd = &cobra.Command{
 	Use:     "list",
-	Short:   "Lists all platform users",
+	Short:   cmdutil.AdminReqDescription("Lists all platform users"),
 	PreRunE: cobra.MaximumNArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		res, err := userapi.List(userapi.ListParams{

--- a/cmd/user/show.go
+++ b/cmd/user/show.go
@@ -23,12 +23,13 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/userapi"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
 var showCmd = &cobra.Command{
 	Use:     "show <user name>",
-	Short:   "Shows details of a specified user",
+	Short:   cmdutil.AdminReqDescription("Shows details of a specified user"),
 	PreRunE: checkInputHas1ArgOr0ArgAndCurrent,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if current, _ := cmd.Flags().GetBool("current"); current {

--- a/cmd/user/update.go
+++ b/cmd/user/update.go
@@ -35,7 +35,7 @@ const updateExample = `
 
 var updateCmd = &cobra.Command{
 	Use:     "update <username> --role <role>",
-	Short:   "Updates a platform user",
+	Short:   cmdutil.AdminReqDescription("Updates a platform user"),
 	PreRunE: checkInputHas1ArgOr0ArgAndCurrent,
 	Example: updateExample,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/docs/ecctl.adoc
+++ b/docs/ecctl.adoc
@@ -38,7 +38,7 @@ Elastic Cloud Control
 * xref:ecctl_deployment[ecctl deployment]	 - Manages deployments
 * xref:ecctl_generate[ecctl generate]	 - Generates completions and docs
 * xref:ecctl_init[ecctl init]	 - Creates an initial configuration file.
-* xref:ecctl_platform[ecctl platform]	 - Manages the platform (Available for ECE only)
+* xref:ecctl_platform[ecctl platform]	 - Manages the platform {ece-icon}
 * xref:ecctl_stack[ecctl stack]	 - Manages Elastic StackPacks
-* xref:ecctl_user[ecctl user]	 - Manages the platform users (Available for ECE only)
+* xref:ecctl_user[ecctl user]	 - Manages the platform users {ece-icon}
 * xref:ecctl_version[ecctl version]	 - Shows ecctl version

--- a/docs/ecctl.adoc
+++ b/docs/ecctl.adoc
@@ -34,7 +34,7 @@ Elastic Cloud Control
 [float]
 === SEE ALSO
 
-* xref:ecctl_auth[ecctl auth]	 - Manages authentication
+* xref:ecctl_auth[ecctl auth]	 - Manages authentication settings
 * xref:ecctl_deployment[ecctl deployment]	 - Manages deployments
 * xref:ecctl_generate[ecctl generate]	 - Generates completions and docs
 * xref:ecctl_init[ecctl init]	 - Creates an initial configuration file.

--- a/docs/ecctl.adoc
+++ b/docs/ecctl.adoc
@@ -34,11 +34,11 @@ Elastic Cloud Control
 [float]
 === SEE ALSO
 
-* xref:ecctl_auth[ecctl auth]	 - Manages the platform auth
+* xref:ecctl_auth[ecctl auth]	 - Manages authentication
 * xref:ecctl_deployment[ecctl deployment]	 - Manages deployments
 * xref:ecctl_generate[ecctl generate]	 - Generates completions and docs
 * xref:ecctl_init[ecctl init]	 - Creates an initial configuration file.
-* xref:ecctl_platform[ecctl platform]	 - Manages the platform
+* xref:ecctl_platform[ecctl platform]	 - Manages the platform (Available for ECE only)
 * xref:ecctl_stack[ecctl stack]	 - Manages Elastic StackPacks
 * xref:ecctl_user[ecctl user]	 - Manages the platform users (Available for ECE only)
 * xref:ecctl_version[ecctl version]	 - Shows ecctl version

--- a/docs/ecctl.md
+++ b/docs/ecctl.md
@@ -30,7 +30,7 @@ Elastic Cloud Control
 
 ### SEE ALSO
 
-* [ecctl auth](ecctl_auth.md)	 - Manages authentication
+* [ecctl auth](ecctl_auth.md)	 - Manages authentication settings
 * [ecctl deployment](ecctl_deployment.md)	 - Manages deployments
 * [ecctl generate](ecctl_generate.md)	 - Generates completions and docs
 * [ecctl init](ecctl_init.md)	 - Creates an initial configuration file.

--- a/docs/ecctl.md
+++ b/docs/ecctl.md
@@ -30,11 +30,11 @@ Elastic Cloud Control
 
 ### SEE ALSO
 
-* [ecctl auth](ecctl_auth.md)	 - Manages the platform auth
+* [ecctl auth](ecctl_auth.md)	 - Manages authentication
 * [ecctl deployment](ecctl_deployment.md)	 - Manages deployments
 * [ecctl generate](ecctl_generate.md)	 - Generates completions and docs
 * [ecctl init](ecctl_init.md)	 - Creates an initial configuration file.
-* [ecctl platform](ecctl_platform.md)	 - Manages the platform
+* [ecctl platform](ecctl_platform.md)	 - Manages the platform (Available for ECE only)
 * [ecctl stack](ecctl_stack.md)	 - Manages Elastic StackPacks
 * [ecctl user](ecctl_user.md)	 - Manages the platform users (Available for ECE only)
 * [ecctl version](ecctl_version.md)	 - Shows ecctl version

--- a/docs/ecctl_auth.adoc
+++ b/docs/ecctl_auth.adoc
@@ -1,12 +1,12 @@
 [#ecctl_auth]
 == ecctl auth
 
-Manages the platform auth
+Manages authentication
 
 [float]
 === Synopsis
 
-Manages the platform auth
+Manages authentication
 
 ----
 ecctl auth [flags]

--- a/docs/ecctl_auth.adoc
+++ b/docs/ecctl_auth.adoc
@@ -1,12 +1,12 @@
 [#ecctl_auth]
 == ecctl auth
 
-Manages authentication
+Manages authentication settings
 
 [float]
 === Synopsis
 
-Manages authentication
+Manages authentication settings
 
 ----
 ecctl auth [flags]

--- a/docs/ecctl_auth.md
+++ b/docs/ecctl_auth.md
@@ -1,10 +1,10 @@
 ## ecctl auth
 
-Manages authentication
+Manages authentication settings
 
 ### Synopsis
 
-Manages authentication
+Manages authentication settings
 
 ```
 ecctl auth [flags]

--- a/docs/ecctl_auth.md
+++ b/docs/ecctl_auth.md
@@ -1,10 +1,10 @@
 ## ecctl auth
 
-Manages the platform auth
+Manages authentication
 
 ### Synopsis
 
-Manages the platform auth
+Manages authentication
 
 ```
 ecctl auth [flags]

--- a/docs/ecctl_auth_key.adoc
+++ b/docs/ecctl_auth_key.adoc
@@ -44,7 +44,7 @@ ecctl auth key [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_auth[ecctl auth]	 - Manages authentication
+* xref:ecctl_auth[ecctl auth]	 - Manages authentication settings
 * xref:ecctl_auth_key_create[ecctl auth key create]	 - Creates a new API key for the current authenticated user
 * xref:ecctl_auth_key_delete[ecctl auth key delete]	 - Deletes one or more existing API keys for the specified user
 * xref:ecctl_auth_key_list[ecctl auth key list]	 - Lists the API keys for the current authenticated user

--- a/docs/ecctl_auth_key.adoc
+++ b/docs/ecctl_auth_key.adoc
@@ -44,7 +44,7 @@ ecctl auth key [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_auth[ecctl auth]	 - Manages the platform auth
+* xref:ecctl_auth[ecctl auth]	 - Manages authentication
 * xref:ecctl_auth_key_create[ecctl auth key create]	 - Creates a new API key for the current authenticated user
 * xref:ecctl_auth_key_delete[ecctl auth key delete]	 - Deletes one or more existing API keys for the specified user
 * xref:ecctl_auth_key_list[ecctl auth key list]	 - Lists the API keys for the current authenticated user

--- a/docs/ecctl_auth_key.md
+++ b/docs/ecctl_auth_key.md
@@ -39,7 +39,7 @@ ecctl auth key [flags]
 
 ### SEE ALSO
 
-* [ecctl auth](ecctl_auth.md)	 - Manages authentication
+* [ecctl auth](ecctl_auth.md)	 - Manages authentication settings
 * [ecctl auth key create](ecctl_auth_key_create.md)	 - Creates a new API key for the current authenticated user
 * [ecctl auth key delete](ecctl_auth_key_delete.md)	 - Deletes one or more existing API keys for the specified user
 * [ecctl auth key list](ecctl_auth_key_list.md)	 - Lists the API keys for the current authenticated user

--- a/docs/ecctl_auth_key.md
+++ b/docs/ecctl_auth_key.md
@@ -39,7 +39,7 @@ ecctl auth key [flags]
 
 ### SEE ALSO
 
-* [ecctl auth](ecctl_auth.md)	 - Manages the platform auth
+* [ecctl auth](ecctl_auth.md)	 - Manages authentication
 * [ecctl auth key create](ecctl_auth_key_create.md)	 - Creates a new API key for the current authenticated user
 * [ecctl auth key delete](ecctl_auth_key_delete.md)	 - Deletes one or more existing API keys for the specified user
 * [ecctl auth key list](ecctl_auth_key_list.md)	 - Lists the API keys for the current authenticated user

--- a/docs/ecctl_deployment.adoc
+++ b/docs/ecctl_deployment.adoc
@@ -46,7 +46,7 @@ ecctl deployment [flags]
 
 * xref:ecctl[ecctl]	 - Elastic Cloud Control
 * xref:ecctl_deployment_create[ecctl deployment create]	 - Creates a deployment
-* xref:ecctl_deployment_delete[ecctl deployment delete]	 - Deletes a previously shutdown deployment (Available for ECE only)
+* xref:ecctl_deployment_delete[ecctl deployment delete]	 - Deletes a previously shutdown deployment {ece-icon}
 * xref:ecctl_deployment_elasticsearch[ecctl deployment elasticsearch]	 - Manages Elasticsearch resources
 * xref:ecctl_deployment_list[ecctl deployment list]	 - Lists the platform's deployments
 * xref:ecctl_deployment_note[ecctl deployment note]	 - Manages a deployment's notes

--- a/docs/ecctl_deployment_delete.adoc
+++ b/docs/ecctl_deployment_delete.adoc
@@ -1,12 +1,12 @@
 [#ecctl_deployment_delete]
 == ecctl deployment delete
 
-Deletes a previously shutdown deployment (Available for ECE only)
+Deletes a previously shutdown deployment {ece-icon}
 
 [float]
 === Synopsis
 
-Deletes a previously shutdown deployment (Available for ECE only)
+Deletes a previously shutdown deployment {ece-icon}
 
 ----
 ecctl deployment delete <deployment-id> [flags]

--- a/docs/ecctl_deployment_template.adoc
+++ b/docs/ecctl_deployment_template.adoc
@@ -45,8 +45,8 @@ ecctl deployment template [flags]
 === SEE ALSO
 
 * xref:ecctl_deployment[ecctl deployment]	 - Manages deployments
-* xref:ecctl_deployment_template_create[ecctl deployment template create]	 - Creates a new deployment template (Available for ECE only)
-* xref:ecctl_deployment_template_delete[ecctl deployment template delete]	 - Deletes an existing deployment template (Available for ECE only)
+* xref:ecctl_deployment_template_create[ecctl deployment template create]	 - Creates a new deployment template {ece-icon}
+* xref:ecctl_deployment_template_delete[ecctl deployment template delete]	 - Deletes an existing deployment template {ece-icon}
 * xref:ecctl_deployment_template_list[ecctl deployment template list]	 - Lists deployment templates
-* xref:ecctl_deployment_template_show[ecctl deployment template show]	 - Displays a deployment template (Available for ECE only)
-* xref:ecctl_deployment_template_update[ecctl deployment template update]	 - Updates an existing deployment template (Available for ECE only)
+* xref:ecctl_deployment_template_show[ecctl deployment template show]	 - Displays a deployment template {ece-icon}
+* xref:ecctl_deployment_template_update[ecctl deployment template update]	 - Updates an existing deployment template {ece-icon}

--- a/docs/ecctl_deployment_template_create.adoc
+++ b/docs/ecctl_deployment_template_create.adoc
@@ -1,12 +1,12 @@
 [#ecctl_deployment_template_create]
 == ecctl deployment template create
 
-Creates a new deployment template (Available for ECE only)
+Creates a new deployment template {ece-icon}
 
 [float]
 === Synopsis
 
-Creates a new deployment template (Available for ECE only)
+Creates a new deployment template {ece-icon}
 
 ----
 ecctl deployment template create --file <definition.json> [flags]

--- a/docs/ecctl_deployment_template_delete.adoc
+++ b/docs/ecctl_deployment_template_delete.adoc
@@ -1,12 +1,12 @@
 [#ecctl_deployment_template_delete]
 == ecctl deployment template delete
 
-Deletes an existing deployment template (Available for ECE only)
+Deletes an existing deployment template {ece-icon}
 
 [float]
 === Synopsis
 
-Deletes an existing deployment template (Available for ECE only)
+Deletes an existing deployment template {ece-icon}
 
 ----
 ecctl deployment template delete --template-id <template id> [flags]

--- a/docs/ecctl_deployment_template_show.adoc
+++ b/docs/ecctl_deployment_template_show.adoc
@@ -1,12 +1,12 @@
 [#ecctl_deployment_template_show]
 == ecctl deployment template show
 
-Displays a deployment template (Available for ECE only)
+Displays a deployment template {ece-icon}
 
 [float]
 === Synopsis
 
-Displays a deployment template (Available for ECE only)
+Displays a deployment template {ece-icon}
 
 ----
 ecctl deployment template show --template-id <template id> [flags]

--- a/docs/ecctl_deployment_template_update.adoc
+++ b/docs/ecctl_deployment_template_update.adoc
@@ -1,12 +1,12 @@
 [#ecctl_deployment_template_update]
 == ecctl deployment template update
 
-Updates an existing deployment template (Available for ECE only)
+Updates an existing deployment template {ece-icon}
 
 [float]
 === Synopsis
 
-Updates an existing deployment template (Available for ECE only)
+Updates an existing deployment template {ece-icon}
 
 ----
 ecctl deployment template update --template-id <template id> --file <definition.json> [flags]

--- a/docs/ecctl_platform.adoc
+++ b/docs/ecctl_platform.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform]
 == ecctl platform
 
-Manages the platform (Available for ECE only)
+Manages the platform {ece-icon}
 
 [float]
 === Synopsis
 
-Manages the platform (Available for ECE only)
+Manages the platform {ece-icon}
 
 ----
 ecctl platform [flags]
@@ -45,12 +45,12 @@ ecctl platform [flags]
 === SEE ALSO
 
 * xref:ecctl[ecctl]	 - Elastic Cloud Control
-* xref:ecctl_platform_allocator[ecctl platform allocator]	 - Manages allocators (Available for ECE only)
-* xref:ecctl_platform_constructor[ecctl platform constructor]	 - Manages constructors (Available for ECE only)
-* xref:ecctl_platform_enrollment-token[ecctl platform enrollment-token]	 - Manages tokens (Available for ECE only)
-* xref:ecctl_platform_info[ecctl platform info]	 - Shows information about the platform (Available for ECE only)
-* xref:ecctl_platform_instance-configuration[ecctl platform instance-configuration]	 - Manages instance configurations (Available for ECE only)
-* xref:ecctl_platform_proxy[ecctl platform proxy]	 - Manages proxies (Available for ECE only)
-* xref:ecctl_platform_repository[ecctl platform repository]	 - Manages snapshot repositories (Available for ECE only)
-* xref:ecctl_platform_role[ecctl platform role]	 - Manages platform roles (Available for ECE only)
-* xref:ecctl_platform_runner[ecctl platform runner]	 - Manages platform runners (Available for ECE only)
+* xref:ecctl_platform_allocator[ecctl platform allocator]	 - Manages allocators {ece-icon}
+* xref:ecctl_platform_constructor[ecctl platform constructor]	 - Manages constructors {ece-icon}
+* xref:ecctl_platform_enrollment-token[ecctl platform enrollment-token]	 - Manages tokens {ece-icon}
+* xref:ecctl_platform_info[ecctl platform info]	 - Shows information about the platform {ece-icon}
+* xref:ecctl_platform_instance-configuration[ecctl platform instance-configuration]	 - Manages instance configurations {ece-icon}
+* xref:ecctl_platform_proxy[ecctl platform proxy]	 - Manages proxies {ece-icon}
+* xref:ecctl_platform_repository[ecctl platform repository]	 - Manages snapshot repositories {ece-icon}
+* xref:ecctl_platform_role[ecctl platform role]	 - Manages platform roles {ece-icon}
+* xref:ecctl_platform_runner[ecctl platform runner]	 - Manages platform runners {ece-icon}

--- a/docs/ecctl_platform.adoc
+++ b/docs/ecctl_platform.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform]
 == ecctl platform
 
-Manages the platform
+Manages the platform (Available for ECE only)
 
 [float]
 === Synopsis
 
-Manages the platform
+Manages the platform (Available for ECE only)
 
 ----
 ecctl platform [flags]

--- a/docs/ecctl_platform.md
+++ b/docs/ecctl_platform.md
@@ -1,10 +1,10 @@
 ## ecctl platform
 
-Manages the platform
+Manages the platform (Available for ECE only)
 
 ### Synopsis
 
-Manages the platform
+Manages the platform (Available for ECE only)
 
 ```
 ecctl platform [flags]

--- a/docs/ecctl_platform_allocator.adoc
+++ b/docs/ecctl_platform_allocator.adoc
@@ -44,10 +44,10 @@ ecctl platform allocator [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform[ecctl platform]	 - Manages the platform
-* xref:ecctl_platform_allocator_list[ecctl platform allocator list]	 - Returns all allocators that have instances or are connected to the platform. Use --all flag or --output json to show all. Use --query to match any of the allocators properties.
-* xref:ecctl_platform_allocator_maintenance[ecctl platform allocator maintenance]	 - Sets the allocator in Maintenance mode
+* xref:ecctl_platform[ecctl platform]	 - Manages the platform (Available for ECE only)
+* xref:ecctl_platform_allocator_list[ecctl platform allocator list]	 - Returns all allocators that have instances or are connected to the platform. Use --all flag or --output json to show all. Use --query to match any of the allocators properties. (Available for ECE only)
+* xref:ecctl_platform_allocator_maintenance[ecctl platform allocator maintenance]	 - Sets the allocator in Maintenance mode (Available for ECE only)
 * xref:ecctl_platform_allocator_metadata[ecctl platform allocator metadata]	 - Manages an allocator's metadata
-* xref:ecctl_platform_allocator_search[ecctl platform allocator search]	 - Performs advanced allocator searching
-* xref:ecctl_platform_allocator_show[ecctl platform allocator show]	 - Returns information about the allocator
-* xref:ecctl_platform_allocator_vacate[ecctl platform allocator vacate]	 - Moves all the resources from the specified allocator
+* xref:ecctl_platform_allocator_search[ecctl platform allocator search]	 - Performs advanced allocator searching (Available for ECE only)
+* xref:ecctl_platform_allocator_show[ecctl platform allocator show]	 - Returns information about the allocator (Available for ECE only)
+* xref:ecctl_platform_allocator_vacate[ecctl platform allocator vacate]	 - Moves all the resources from the specified allocator (Available for ECE only)

--- a/docs/ecctl_platform_allocator.adoc
+++ b/docs/ecctl_platform_allocator.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_allocator]
 == ecctl platform allocator
 
-Manages allocators (Available for ECE only)
+Manages allocators {ece-icon}
 
 [float]
 === Synopsis
 
-Manages allocators (Available for ECE only)
+Manages allocators {ece-icon}
 
 ----
 ecctl platform allocator [flags]
@@ -44,10 +44,10 @@ ecctl platform allocator [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform[ecctl platform]	 - Manages the platform (Available for ECE only)
-* xref:ecctl_platform_allocator_list[ecctl platform allocator list]	 - Returns all allocators that have instances or are connected to the platform. Use --all flag or --output json to show all. Use --query to match any of the allocators properties. (Available for ECE only)
-* xref:ecctl_platform_allocator_maintenance[ecctl platform allocator maintenance]	 - Sets the allocator in Maintenance mode (Available for ECE only)
+* xref:ecctl_platform[ecctl platform]	 - Manages the platform {ece-icon}
+* xref:ecctl_platform_allocator_list[ecctl platform allocator list]	 - Returns all allocators that have instances or are connected to the platform. Use --all flag or --output json to show all. Use --query to match any of the allocators properties. {ece-icon}
+* xref:ecctl_platform_allocator_maintenance[ecctl platform allocator maintenance]	 - Sets the allocator in Maintenance mode {ece-icon}
 * xref:ecctl_platform_allocator_metadata[ecctl platform allocator metadata]	 - Manages an allocator's metadata
-* xref:ecctl_platform_allocator_search[ecctl platform allocator search]	 - Performs advanced allocator searching (Available for ECE only)
-* xref:ecctl_platform_allocator_show[ecctl platform allocator show]	 - Returns information about the allocator (Available for ECE only)
-* xref:ecctl_platform_allocator_vacate[ecctl platform allocator vacate]	 - Moves all the resources from the specified allocator (Available for ECE only)
+* xref:ecctl_platform_allocator_search[ecctl platform allocator search]	 - Performs advanced allocator searching {ece-icon}
+* xref:ecctl_platform_allocator_show[ecctl platform allocator show]	 - Returns information about the allocator {ece-icon}
+* xref:ecctl_platform_allocator_vacate[ecctl platform allocator vacate]	 - Moves all the resources from the specified allocator {ece-icon}

--- a/docs/ecctl_platform_allocator.md
+++ b/docs/ecctl_platform_allocator.md
@@ -39,11 +39,11 @@ ecctl platform allocator [flags]
 
 ### SEE ALSO
 
-* [ecctl platform](ecctl_platform.md)	 - Manages the platform
-* [ecctl platform allocator list](ecctl_platform_allocator_list.md)	 - Returns all allocators that have instances or are connected to the platform. Use --all flag or --output json to show all. Use --query to match any of the allocators properties.
-* [ecctl platform allocator maintenance](ecctl_platform_allocator_maintenance.md)	 - Sets the allocator in Maintenance mode
+* [ecctl platform](ecctl_platform.md)	 - Manages the platform (Available for ECE only)
+* [ecctl platform allocator list](ecctl_platform_allocator_list.md)	 - Returns all allocators that have instances or are connected to the platform. Use --all flag or --output json to show all. Use --query to match any of the allocators properties. (Available for ECE only)
+* [ecctl platform allocator maintenance](ecctl_platform_allocator_maintenance.md)	 - Sets the allocator in Maintenance mode (Available for ECE only)
 * [ecctl platform allocator metadata](ecctl_platform_allocator_metadata.md)	 - Manages an allocator's metadata
-* [ecctl platform allocator search](ecctl_platform_allocator_search.md)	 - Performs advanced allocator searching
-* [ecctl platform allocator show](ecctl_platform_allocator_show.md)	 - Returns information about the allocator
-* [ecctl platform allocator vacate](ecctl_platform_allocator_vacate.md)	 - Moves all the resources from the specified allocator
+* [ecctl platform allocator search](ecctl_platform_allocator_search.md)	 - Performs advanced allocator searching (Available for ECE only)
+* [ecctl platform allocator show](ecctl_platform_allocator_show.md)	 - Returns information about the allocator (Available for ECE only)
+* [ecctl platform allocator vacate](ecctl_platform_allocator_vacate.md)	 - Moves all the resources from the specified allocator (Available for ECE only)
 

--- a/docs/ecctl_platform_allocator_list.adoc
+++ b/docs/ecctl_platform_allocator_list.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_allocator_list]
 == ecctl platform allocator list
 
-Returns all allocators that have instances or are connected to the platform. Use --all flag or --output json to show all. Use --query to match any of the allocators properties. (Available for ECE only)
+Returns all allocators that have instances or are connected to the platform. Use --all flag or --output json to show all. Use --query to match any of the allocators properties. {ece-icon}
 
 [float]
 === Synopsis
@@ -71,4 +71,4 @@ ecctl platform allocator list [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_allocator[ecctl platform allocator]	 - Manages allocators (Available for ECE only)
+* xref:ecctl_platform_allocator[ecctl platform allocator]	 - Manages allocators {ece-icon}

--- a/docs/ecctl_platform_allocator_list.adoc
+++ b/docs/ecctl_platform_allocator_list.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_allocator_list]
 == ecctl platform allocator list
 
-Returns all allocators that have instances or are connected to the platform. Use --all flag or --output json to show all. Use --query to match any of the allocators properties.
+Returns all allocators that have instances or are connected to the platform. Use --all flag or --output json to show all. Use --query to match any of the allocators properties. (Available for ECE only)
 
 [float]
 === Synopsis

--- a/docs/ecctl_platform_allocator_list.md
+++ b/docs/ecctl_platform_allocator_list.md
@@ -1,6 +1,6 @@
 ## ecctl platform allocator list
 
-Returns all allocators that have instances or are connected to the platform. Use --all flag or --output json to show all. Use --query to match any of the allocators properties.
+Returns all allocators that have instances or are connected to the platform. Use --all flag or --output json to show all. Use --query to match any of the allocators properties. (Available for ECE only)
 
 ### Synopsis
 

--- a/docs/ecctl_platform_allocator_maintenance.adoc
+++ b/docs/ecctl_platform_allocator_maintenance.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_allocator_maintenance]
 == ecctl platform allocator maintenance
 
-Sets the allocator in Maintenance mode
+Sets the allocator in Maintenance mode (Available for ECE only)
 
 [float]
 === Synopsis
 
-Sets the allocator in Maintenance mode
+Sets the allocator in Maintenance mode (Available for ECE only)
 
 ----
 ecctl platform allocator maintenance <allocator id> [flags]

--- a/docs/ecctl_platform_allocator_maintenance.adoc
+++ b/docs/ecctl_platform_allocator_maintenance.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_allocator_maintenance]
 == ecctl platform allocator maintenance
 
-Sets the allocator in Maintenance mode (Available for ECE only)
+Sets the allocator in Maintenance mode {ece-icon}
 
 [float]
 === Synopsis
 
-Sets the allocator in Maintenance mode (Available for ECE only)
+Sets the allocator in Maintenance mode {ece-icon}
 
 ----
 ecctl platform allocator maintenance <allocator id> [flags]
@@ -45,4 +45,4 @@ ecctl platform allocator maintenance <allocator id> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_allocator[ecctl platform allocator]	 - Manages allocators (Available for ECE only)
+* xref:ecctl_platform_allocator[ecctl platform allocator]	 - Manages allocators {ece-icon}

--- a/docs/ecctl_platform_allocator_maintenance.md
+++ b/docs/ecctl_platform_allocator_maintenance.md
@@ -1,10 +1,10 @@
 ## ecctl platform allocator maintenance
 
-Sets the allocator in Maintenance mode
+Sets the allocator in Maintenance mode (Available for ECE only)
 
 ### Synopsis
 
-Sets the allocator in Maintenance mode
+Sets the allocator in Maintenance mode (Available for ECE only)
 
 ```
 ecctl platform allocator maintenance <allocator id> [flags]

--- a/docs/ecctl_platform_allocator_metadata.adoc
+++ b/docs/ecctl_platform_allocator_metadata.adoc
@@ -44,7 +44,7 @@ ecctl platform allocator metadata [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_allocator[ecctl platform allocator]	 - Manages allocators (Available for ECE only)
+* xref:ecctl_platform_allocator[ecctl platform allocator]	 - Manages allocators {ece-icon}
 * xref:ecctl_platform_allocator_metadata_delete[ecctl platform allocator metadata delete]	 - Deletes a single metadata item from a given allocators metadata
 * xref:ecctl_platform_allocator_metadata_set[ecctl platform allocator metadata set]	 - Sets or updates a single metadata item to a given allocators metadata
 * xref:ecctl_platform_allocator_metadata_show[ecctl platform allocator metadata show]	 - Shows allocator metadata

--- a/docs/ecctl_platform_allocator_search.adoc
+++ b/docs/ecctl_platform_allocator_search.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_allocator_search]
 == ecctl platform allocator search
 
-Performs advanced allocator searching (Available for ECE only)
+Performs advanced allocator searching {ece-icon}
 
 [float]
 === Synopsis
@@ -46,4 +46,4 @@ ecctl platform allocator search [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_allocator[ecctl platform allocator]	 - Manages allocators (Available for ECE only)
+* xref:ecctl_platform_allocator[ecctl platform allocator]	 - Manages allocators {ece-icon}

--- a/docs/ecctl_platform_allocator_search.adoc
+++ b/docs/ecctl_platform_allocator_search.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_allocator_search]
 == ecctl platform allocator search
 
-Performs advanced allocator searching
+Performs advanced allocator searching (Available for ECE only)
 
 [float]
 === Synopsis

--- a/docs/ecctl_platform_allocator_search.md
+++ b/docs/ecctl_platform_allocator_search.md
@@ -1,6 +1,6 @@
 ## ecctl platform allocator search
 
-Performs advanced allocator searching
+Performs advanced allocator searching (Available for ECE only)
 
 ### Synopsis
 

--- a/docs/ecctl_platform_allocator_show.adoc
+++ b/docs/ecctl_platform_allocator_show.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_allocator_show]
 == ecctl platform allocator show
 
-Returns information about the allocator (Available for ECE only)
+Returns information about the allocator {ece-icon}
 
 [float]
 === Synopsis
 
-Returns information about the allocator (Available for ECE only)
+Returns information about the allocator {ece-icon}
 
 ----
 ecctl platform allocator show <allocator id> [flags]
@@ -45,4 +45,4 @@ ecctl platform allocator show <allocator id> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_allocator[ecctl platform allocator]	 - Manages allocators (Available for ECE only)
+* xref:ecctl_platform_allocator[ecctl platform allocator]	 - Manages allocators {ece-icon}

--- a/docs/ecctl_platform_allocator_show.adoc
+++ b/docs/ecctl_platform_allocator_show.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_allocator_show]
 == ecctl platform allocator show
 
-Returns information about the allocator
+Returns information about the allocator (Available for ECE only)
 
 [float]
 === Synopsis
 
-Returns information about the allocator
+Returns information about the allocator (Available for ECE only)
 
 ----
 ecctl platform allocator show <allocator id> [flags]

--- a/docs/ecctl_platform_allocator_show.md
+++ b/docs/ecctl_platform_allocator_show.md
@@ -1,10 +1,10 @@
 ## ecctl platform allocator show
 
-Returns information about the allocator
+Returns information about the allocator (Available for ECE only)
 
 ### Synopsis
 
-Returns information about the allocator
+Returns information about the allocator (Available for ECE only)
 
 ```
 ecctl platform allocator show <allocator id> [flags]

--- a/docs/ecctl_platform_allocator_vacate.adoc
+++ b/docs/ecctl_platform_allocator_vacate.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_allocator_vacate]
 == ecctl platform allocator vacate
 
-Moves all the resources from the specified allocator
+Moves all the resources from the specified allocator (Available for ECE only)
 
 [float]
 === Synopsis
 
-Moves all the resources from the specified allocator
+Moves all the resources from the specified allocator (Available for ECE only)
 
 ----
 ecctl platform allocator vacate <allocator-id> [flags]

--- a/docs/ecctl_platform_allocator_vacate.adoc
+++ b/docs/ecctl_platform_allocator_vacate.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_allocator_vacate]
 == ecctl platform allocator vacate
 
-Moves all the resources from the specified allocator (Available for ECE only)
+Moves all the resources from the specified allocator {ece-icon}
 
 [float]
 === Synopsis
 
-Moves all the resources from the specified allocator (Available for ECE only)
+Moves all the resources from the specified allocator {ece-icon}
 
 ----
 ecctl platform allocator vacate <allocator-id> [flags]
@@ -95,4 +95,4 @@ ecctl platform allocator vacate <allocator-id> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_allocator[ecctl platform allocator]	 - Manages allocators (Available for ECE only)
+* xref:ecctl_platform_allocator[ecctl platform allocator]	 - Manages allocators {ece-icon}

--- a/docs/ecctl_platform_allocator_vacate.md
+++ b/docs/ecctl_platform_allocator_vacate.md
@@ -1,10 +1,10 @@
 ## ecctl platform allocator vacate
 
-Moves all the resources from the specified allocator
+Moves all the resources from the specified allocator (Available for ECE only)
 
 ### Synopsis
 
-Moves all the resources from the specified allocator
+Moves all the resources from the specified allocator (Available for ECE only)
 
 ```
 ecctl platform allocator vacate <allocator-id> [flags]

--- a/docs/ecctl_platform_constructor.adoc
+++ b/docs/ecctl_platform_constructor.adoc
@@ -44,8 +44,8 @@ ecctl platform constructor [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform[ecctl platform]	 - Manages the platform
-* xref:ecctl_platform_constructor_list[ecctl platform constructor list]	 - Returns all of the constructors in the platform
-* xref:ecctl_platform_constructor_maintenance[ecctl platform constructor maintenance]	 - Sets/un-sets a constructor's maintenance mode
-* xref:ecctl_platform_constructor_resync[ecctl platform constructor resync]	 - Resynchronizes the search index and cache for the selected constructor or all
-* xref:ecctl_platform_constructor_show[ecctl platform constructor show]	 - Returns information about the constructor with given ID
+* xref:ecctl_platform[ecctl platform]	 - Manages the platform (Available for ECE only)
+* xref:ecctl_platform_constructor_list[ecctl platform constructor list]	 - Returns all of the constructors in the platform (Available for ECE only)
+* xref:ecctl_platform_constructor_maintenance[ecctl platform constructor maintenance]	 - Sets/un-sets a constructor's maintenance mode (Available for ECE only)
+* xref:ecctl_platform_constructor_resync[ecctl platform constructor resync]	 - Resynchronizes the search index and cache for the selected constructor or all (Available for ECE only)
+* xref:ecctl_platform_constructor_show[ecctl platform constructor show]	 - Returns information about the constructor with given ID (Available for ECE only)

--- a/docs/ecctl_platform_constructor.adoc
+++ b/docs/ecctl_platform_constructor.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_constructor]
 == ecctl platform constructor
 
-Manages constructors (Available for ECE only)
+Manages constructors {ece-icon}
 
 [float]
 === Synopsis
 
-Manages constructors (Available for ECE only)
+Manages constructors {ece-icon}
 
 ----
 ecctl platform constructor [flags]
@@ -44,8 +44,8 @@ ecctl platform constructor [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform[ecctl platform]	 - Manages the platform (Available for ECE only)
-* xref:ecctl_platform_constructor_list[ecctl platform constructor list]	 - Returns all of the constructors in the platform (Available for ECE only)
-* xref:ecctl_platform_constructor_maintenance[ecctl platform constructor maintenance]	 - Sets/un-sets a constructor's maintenance mode (Available for ECE only)
-* xref:ecctl_platform_constructor_resync[ecctl platform constructor resync]	 - Resynchronizes the search index and cache for the selected constructor or all (Available for ECE only)
-* xref:ecctl_platform_constructor_show[ecctl platform constructor show]	 - Returns information about the constructor with given ID (Available for ECE only)
+* xref:ecctl_platform[ecctl platform]	 - Manages the platform {ece-icon}
+* xref:ecctl_platform_constructor_list[ecctl platform constructor list]	 - Returns all of the constructors in the platform {ece-icon}
+* xref:ecctl_platform_constructor_maintenance[ecctl platform constructor maintenance]	 - Sets/un-sets a constructor's maintenance mode {ece-icon}
+* xref:ecctl_platform_constructor_resync[ecctl platform constructor resync]	 - Resynchronizes the search index and cache for the selected constructor or all {ece-icon}
+* xref:ecctl_platform_constructor_show[ecctl platform constructor show]	 - Returns information about the constructor with given ID {ece-icon}

--- a/docs/ecctl_platform_constructor.md
+++ b/docs/ecctl_platform_constructor.md
@@ -39,9 +39,9 @@ ecctl platform constructor [flags]
 
 ### SEE ALSO
 
-* [ecctl platform](ecctl_platform.md)	 - Manages the platform
-* [ecctl platform constructor list](ecctl_platform_constructor_list.md)	 - Returns all of the constructors in the platform
-* [ecctl platform constructor maintenance](ecctl_platform_constructor_maintenance.md)	 - Sets/un-sets a constructor's maintenance mode
-* [ecctl platform constructor resync](ecctl_platform_constructor_resync.md)	 - Resynchronizes the search index and cache for the selected constructor or all
-* [ecctl platform constructor show](ecctl_platform_constructor_show.md)	 - Returns information about the constructor with given ID
+* [ecctl platform](ecctl_platform.md)	 - Manages the platform (Available for ECE only)
+* [ecctl platform constructor list](ecctl_platform_constructor_list.md)	 - Returns all of the constructors in the platform (Available for ECE only)
+* [ecctl platform constructor maintenance](ecctl_platform_constructor_maintenance.md)	 - Sets/un-sets a constructor's maintenance mode (Available for ECE only)
+* [ecctl platform constructor resync](ecctl_platform_constructor_resync.md)	 - Resynchronizes the search index and cache for the selected constructor or all (Available for ECE only)
+* [ecctl platform constructor show](ecctl_platform_constructor_show.md)	 - Returns information about the constructor with given ID (Available for ECE only)
 

--- a/docs/ecctl_platform_constructor_list.adoc
+++ b/docs/ecctl_platform_constructor_list.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_constructor_list]
 == ecctl platform constructor list
 
-Returns all of the constructors in the platform (Available for ECE only)
+Returns all of the constructors in the platform {ece-icon}
 
 [float]
 === Synopsis
 
-Returns all of the constructors in the platform (Available for ECE only)
+Returns all of the constructors in the platform {ece-icon}
 
 ----
 ecctl platform constructor list [flags]
@@ -44,4 +44,4 @@ ecctl platform constructor list [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_constructor[ecctl platform constructor]	 - Manages constructors (Available for ECE only)
+* xref:ecctl_platform_constructor[ecctl platform constructor]	 - Manages constructors {ece-icon}

--- a/docs/ecctl_platform_constructor_list.adoc
+++ b/docs/ecctl_platform_constructor_list.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_constructor_list]
 == ecctl platform constructor list
 
-Returns all of the constructors in the platform
+Returns all of the constructors in the platform (Available for ECE only)
 
 [float]
 === Synopsis
 
-Returns all of the constructors in the platform
+Returns all of the constructors in the platform (Available for ECE only)
 
 ----
 ecctl platform constructor list [flags]

--- a/docs/ecctl_platform_constructor_list.md
+++ b/docs/ecctl_platform_constructor_list.md
@@ -1,10 +1,10 @@
 ## ecctl platform constructor list
 
-Returns all of the constructors in the platform
+Returns all of the constructors in the platform (Available for ECE only)
 
 ### Synopsis
 
-Returns all of the constructors in the platform
+Returns all of the constructors in the platform (Available for ECE only)
 
 ```
 ecctl platform constructor list [flags]

--- a/docs/ecctl_platform_constructor_maintenance.adoc
+++ b/docs/ecctl_platform_constructor_maintenance.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_constructor_maintenance]
 == ecctl platform constructor maintenance
 
-Sets/un-sets a constructor's maintenance mode (Available for ECE only)
+Sets/un-sets a constructor's maintenance mode {ece-icon}
 
 [float]
 === Synopsis
 
-Sets/un-sets a constructor's maintenance mode (Available for ECE only)
+Sets/un-sets a constructor's maintenance mode {ece-icon}
 
 ----
 ecctl platform constructor maintenance <constructor id> [flags]
@@ -45,4 +45,4 @@ ecctl platform constructor maintenance <constructor id> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_constructor[ecctl platform constructor]	 - Manages constructors (Available for ECE only)
+* xref:ecctl_platform_constructor[ecctl platform constructor]	 - Manages constructors {ece-icon}

--- a/docs/ecctl_platform_constructor_maintenance.adoc
+++ b/docs/ecctl_platform_constructor_maintenance.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_constructor_maintenance]
 == ecctl platform constructor maintenance
 
-Sets/un-sets a constructor's maintenance mode
+Sets/un-sets a constructor's maintenance mode (Available for ECE only)
 
 [float]
 === Synopsis
 
-Sets/un-sets a constructor's maintenance mode
+Sets/un-sets a constructor's maintenance mode (Available for ECE only)
 
 ----
 ecctl platform constructor maintenance <constructor id> [flags]

--- a/docs/ecctl_platform_constructor_maintenance.md
+++ b/docs/ecctl_platform_constructor_maintenance.md
@@ -1,10 +1,10 @@
 ## ecctl platform constructor maintenance
 
-Sets/un-sets a constructor's maintenance mode
+Sets/un-sets a constructor's maintenance mode (Available for ECE only)
 
 ### Synopsis
 
-Sets/un-sets a constructor's maintenance mode
+Sets/un-sets a constructor's maintenance mode (Available for ECE only)
 
 ```
 ecctl platform constructor maintenance <constructor id> [flags]

--- a/docs/ecctl_platform_constructor_resync.adoc
+++ b/docs/ecctl_platform_constructor_resync.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_constructor_resync]
 == ecctl platform constructor resync
 
-Resynchronizes the search index and cache for the selected constructor or all
+Resynchronizes the search index and cache for the selected constructor or all (Available for ECE only)
 
 [float]
 === Synopsis
 
-Resynchronizes the search index and cache for the selected constructor or all
+Resynchronizes the search index and cache for the selected constructor or all (Available for ECE only)
 
 ----
 ecctl platform constructor resync {<constructor id> | --all} [flags]

--- a/docs/ecctl_platform_constructor_resync.adoc
+++ b/docs/ecctl_platform_constructor_resync.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_constructor_resync]
 == ecctl platform constructor resync
 
-Resynchronizes the search index and cache for the selected constructor or all (Available for ECE only)
+Resynchronizes the search index and cache for the selected constructor or all {ece-icon}
 
 [float]
 === Synopsis
 
-Resynchronizes the search index and cache for the selected constructor or all (Available for ECE only)
+Resynchronizes the search index and cache for the selected constructor or all {ece-icon}
 
 ----
 ecctl platform constructor resync {<constructor id> | --all} [flags]
@@ -45,4 +45,4 @@ ecctl platform constructor resync {<constructor id> | --all} [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_constructor[ecctl platform constructor]	 - Manages constructors (Available for ECE only)
+* xref:ecctl_platform_constructor[ecctl platform constructor]	 - Manages constructors {ece-icon}

--- a/docs/ecctl_platform_constructor_resync.md
+++ b/docs/ecctl_platform_constructor_resync.md
@@ -1,10 +1,10 @@
 ## ecctl platform constructor resync
 
-Resynchronizes the search index and cache for the selected constructor or all
+Resynchronizes the search index and cache for the selected constructor or all (Available for ECE only)
 
 ### Synopsis
 
-Resynchronizes the search index and cache for the selected constructor or all
+Resynchronizes the search index and cache for the selected constructor or all (Available for ECE only)
 
 ```
 ecctl platform constructor resync {<constructor id> | --all} [flags]

--- a/docs/ecctl_platform_constructor_show.adoc
+++ b/docs/ecctl_platform_constructor_show.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_constructor_show]
 == ecctl platform constructor show
 
-Returns information about the constructor with given ID (Available for ECE only)
+Returns information about the constructor with given ID {ece-icon}
 
 [float]
 === Synopsis
 
-Returns information about the constructor with given ID (Available for ECE only)
+Returns information about the constructor with given ID {ece-icon}
 
 ----
 ecctl platform constructor show <constructor id> [flags]
@@ -44,4 +44,4 @@ ecctl platform constructor show <constructor id> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_constructor[ecctl platform constructor]	 - Manages constructors (Available for ECE only)
+* xref:ecctl_platform_constructor[ecctl platform constructor]	 - Manages constructors {ece-icon}

--- a/docs/ecctl_platform_constructor_show.adoc
+++ b/docs/ecctl_platform_constructor_show.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_constructor_show]
 == ecctl platform constructor show
 
-Returns information about the constructor with given ID
+Returns information about the constructor with given ID (Available for ECE only)
 
 [float]
 === Synopsis
 
-Returns information about the constructor with given ID
+Returns information about the constructor with given ID (Available for ECE only)
 
 ----
 ecctl platform constructor show <constructor id> [flags]

--- a/docs/ecctl_platform_constructor_show.md
+++ b/docs/ecctl_platform_constructor_show.md
@@ -1,10 +1,10 @@
 ## ecctl platform constructor show
 
-Returns information about the constructor with given ID
+Returns information about the constructor with given ID (Available for ECE only)
 
 ### Synopsis
 
-Returns information about the constructor with given ID
+Returns information about the constructor with given ID (Available for ECE only)
 
 ```
 ecctl platform constructor show <constructor id> [flags]

--- a/docs/ecctl_platform_enrollment-token.adoc
+++ b/docs/ecctl_platform_enrollment-token.adoc
@@ -44,7 +44,7 @@ ecctl platform enrollment-token [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform[ecctl platform]	 - Manages the platform
+* xref:ecctl_platform[ecctl platform]	 - Manages the platform (Available for ECE only)
 * xref:ecctl_platform_enrollment-token_create[ecctl platform enrollment-token create]	 - Creates an enrollment token for role(s)
-* xref:ecctl_platform_enrollment-token_delete[ecctl platform enrollment-token delete]	 - Deletes an enrollment token
-* xref:ecctl_platform_enrollment-token_list[ecctl platform enrollment-token list]	 - Retrieves a list of persistent enrollment tokens
+* xref:ecctl_platform_enrollment-token_delete[ecctl platform enrollment-token delete]	 - Deletes an enrollment token (Available for ECE only)
+* xref:ecctl_platform_enrollment-token_list[ecctl platform enrollment-token list]	 - Retrieves a list of persistent enrollment tokens (Available for ECE only)

--- a/docs/ecctl_platform_enrollment-token.adoc
+++ b/docs/ecctl_platform_enrollment-token.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_enrollment-token]
 == ecctl platform enrollment-token
 
-Manages tokens (Available for ECE only)
+Manages tokens {ece-icon}
 
 [float]
 === Synopsis
 
-Manages tokens (Available for ECE only)
+Manages tokens {ece-icon}
 
 ----
 ecctl platform enrollment-token [flags]
@@ -44,7 +44,7 @@ ecctl platform enrollment-token [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform[ecctl platform]	 - Manages the platform (Available for ECE only)
+* xref:ecctl_platform[ecctl platform]	 - Manages the platform {ece-icon}
 * xref:ecctl_platform_enrollment-token_create[ecctl platform enrollment-token create]	 - Creates an enrollment token for role(s)
-* xref:ecctl_platform_enrollment-token_delete[ecctl platform enrollment-token delete]	 - Deletes an enrollment token (Available for ECE only)
-* xref:ecctl_platform_enrollment-token_list[ecctl platform enrollment-token list]	 - Retrieves a list of persistent enrollment tokens (Available for ECE only)
+* xref:ecctl_platform_enrollment-token_delete[ecctl platform enrollment-token delete]	 - Deletes an enrollment token {ece-icon}
+* xref:ecctl_platform_enrollment-token_list[ecctl platform enrollment-token list]	 - Retrieves a list of persistent enrollment tokens {ece-icon}

--- a/docs/ecctl_platform_enrollment-token.md
+++ b/docs/ecctl_platform_enrollment-token.md
@@ -39,8 +39,8 @@ ecctl platform enrollment-token [flags]
 
 ### SEE ALSO
 
-* [ecctl platform](ecctl_platform.md)	 - Manages the platform
+* [ecctl platform](ecctl_platform.md)	 - Manages the platform (Available for ECE only)
 * [ecctl platform enrollment-token create](ecctl_platform_enrollment-token_create.md)	 - Creates an enrollment token for role(s)
-* [ecctl platform enrollment-token delete](ecctl_platform_enrollment-token_delete.md)	 - Deletes an enrollment token
-* [ecctl platform enrollment-token list](ecctl_platform_enrollment-token_list.md)	 - Retrieves a list of persistent enrollment tokens
+* [ecctl platform enrollment-token delete](ecctl_platform_enrollment-token_delete.md)	 - Deletes an enrollment token (Available for ECE only)
+* [ecctl platform enrollment-token list](ecctl_platform_enrollment-token_list.md)	 - Retrieves a list of persistent enrollment tokens (Available for ECE only)
 

--- a/docs/ecctl_platform_enrollment-token_create.adoc
+++ b/docs/ecctl_platform_enrollment-token_create.adoc
@@ -19,7 +19,7 @@ ecctl platform enrollment-token create --role <ROLE> [flags]
   ecctl [globalFlags] enrollment-token create --role coordinator
   ecctl [globalFlags] enrollment-token create --role coordinator --role proxy
   ecctl [globalFlags] enrollment-token create --role allocator --validity 120s
-  ecctl [globalFlags] enrollment-token create --role allocator --validity 2h
+  ecctl [globalFlags] enrollment-token create --role allocator --validity 2h (Available for ECE only)
 ----
 
 [float]

--- a/docs/ecctl_platform_enrollment-token_create.adoc
+++ b/docs/ecctl_platform_enrollment-token_create.adoc
@@ -19,7 +19,7 @@ ecctl platform enrollment-token create --role <ROLE> [flags]
   ecctl [globalFlags] enrollment-token create --role coordinator
   ecctl [globalFlags] enrollment-token create --role coordinator --role proxy
   ecctl [globalFlags] enrollment-token create --role allocator --validity 120s
-  ecctl [globalFlags] enrollment-token create --role allocator --validity 2h (Available for ECE only)
+  ecctl [globalFlags] enrollment-token create --role allocator --validity 2h {ece-icon}
 ----
 
 [float]
@@ -56,4 +56,4 @@ ecctl platform enrollment-token create --role <ROLE> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_enrollment-token[ecctl platform enrollment-token]	 - Manages tokens (Available for ECE only)
+* xref:ecctl_platform_enrollment-token[ecctl platform enrollment-token]	 - Manages tokens {ece-icon}

--- a/docs/ecctl_platform_enrollment-token_create.md
+++ b/docs/ecctl_platform_enrollment-token_create.md
@@ -16,7 +16,7 @@ ecctl platform enrollment-token create --role <ROLE> [flags]
   ecctl [globalFlags] enrollment-token create --role coordinator
   ecctl [globalFlags] enrollment-token create --role coordinator --role proxy
   ecctl [globalFlags] enrollment-token create --role allocator --validity 120s
-  ecctl [globalFlags] enrollment-token create --role allocator --validity 2h
+  ecctl [globalFlags] enrollment-token create --role allocator --validity 2h (Available for ECE only)
 ```
 
 ### Options

--- a/docs/ecctl_platform_enrollment-token_delete.adoc
+++ b/docs/ecctl_platform_enrollment-token_delete.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_enrollment-token_delete]
 == ecctl platform enrollment-token delete
 
-Deletes an enrollment token (Available for ECE only)
+Deletes an enrollment token {ece-icon}
 
 [float]
 === Synopsis
 
-Deletes an enrollment token (Available for ECE only)
+Deletes an enrollment token {ece-icon}
 
 ----
 ecctl platform enrollment-token delete <enrollment-token> [flags]
@@ -44,4 +44,4 @@ ecctl platform enrollment-token delete <enrollment-token> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_enrollment-token[ecctl platform enrollment-token]	 - Manages tokens (Available for ECE only)
+* xref:ecctl_platform_enrollment-token[ecctl platform enrollment-token]	 - Manages tokens {ece-icon}

--- a/docs/ecctl_platform_enrollment-token_delete.adoc
+++ b/docs/ecctl_platform_enrollment-token_delete.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_enrollment-token_delete]
 == ecctl platform enrollment-token delete
 
-Deletes an enrollment token
+Deletes an enrollment token (Available for ECE only)
 
 [float]
 === Synopsis
 
-Deletes an enrollment token
+Deletes an enrollment token (Available for ECE only)
 
 ----
 ecctl platform enrollment-token delete <enrollment-token> [flags]

--- a/docs/ecctl_platform_enrollment-token_delete.md
+++ b/docs/ecctl_platform_enrollment-token_delete.md
@@ -1,10 +1,10 @@
 ## ecctl platform enrollment-token delete
 
-Deletes an enrollment token
+Deletes an enrollment token (Available for ECE only)
 
 ### Synopsis
 
-Deletes an enrollment token
+Deletes an enrollment token (Available for ECE only)
 
 ```
 ecctl platform enrollment-token delete <enrollment-token> [flags]

--- a/docs/ecctl_platform_enrollment-token_list.adoc
+++ b/docs/ecctl_platform_enrollment-token_list.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_enrollment-token_list]
 == ecctl platform enrollment-token list
 
-Retrieves a list of persistent enrollment tokens (Available for ECE only)
+Retrieves a list of persistent enrollment tokens {ece-icon}
 
 [float]
 === Synopsis
 
-Retrieves a list of persistent enrollment tokens (Available for ECE only)
+Retrieves a list of persistent enrollment tokens {ece-icon}
 
 ----
 ecctl platform enrollment-token list [flags]
@@ -44,4 +44,4 @@ ecctl platform enrollment-token list [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_enrollment-token[ecctl platform enrollment-token]	 - Manages tokens (Available for ECE only)
+* xref:ecctl_platform_enrollment-token[ecctl platform enrollment-token]	 - Manages tokens {ece-icon}

--- a/docs/ecctl_platform_enrollment-token_list.adoc
+++ b/docs/ecctl_platform_enrollment-token_list.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_enrollment-token_list]
 == ecctl platform enrollment-token list
 
-Retrieves a list of persistent enrollment tokens
+Retrieves a list of persistent enrollment tokens (Available for ECE only)
 
 [float]
 === Synopsis
 
-Retrieves a list of persistent enrollment tokens
+Retrieves a list of persistent enrollment tokens (Available for ECE only)
 
 ----
 ecctl platform enrollment-token list [flags]

--- a/docs/ecctl_platform_enrollment-token_list.md
+++ b/docs/ecctl_platform_enrollment-token_list.md
@@ -1,10 +1,10 @@
 ## ecctl platform enrollment-token list
 
-Retrieves a list of persistent enrollment tokens
+Retrieves a list of persistent enrollment tokens (Available for ECE only)
 
 ### Synopsis
 
-Retrieves a list of persistent enrollment tokens
+Retrieves a list of persistent enrollment tokens (Available for ECE only)
 
 ```
 ecctl platform enrollment-token list [flags]

--- a/docs/ecctl_platform_info.adoc
+++ b/docs/ecctl_platform_info.adoc
@@ -44,4 +44,4 @@ ecctl platform info [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform[ecctl platform]	 - Manages the platform
+* xref:ecctl_platform[ecctl platform]	 - Manages the platform (Available for ECE only)

--- a/docs/ecctl_platform_info.adoc
+++ b/docs/ecctl_platform_info.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_info]
 == ecctl platform info
 
-Shows information about the platform (Available for ECE only)
+Shows information about the platform {ece-icon}
 
 [float]
 === Synopsis
 
-Shows information about the platform (Available for ECE only)
+Shows information about the platform {ece-icon}
 
 ----
 ecctl platform info [flags]
@@ -44,4 +44,4 @@ ecctl platform info [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform[ecctl platform]	 - Manages the platform (Available for ECE only)
+* xref:ecctl_platform[ecctl platform]	 - Manages the platform {ece-icon}

--- a/docs/ecctl_platform_info.md
+++ b/docs/ecctl_platform_info.md
@@ -39,5 +39,5 @@ ecctl platform info [flags]
 
 ### SEE ALSO
 
-* [ecctl platform](ecctl_platform.md)	 - Manages the platform
+* [ecctl platform](ecctl_platform.md)	 - Manages the platform (Available for ECE only)
 

--- a/docs/ecctl_platform_instance-configuration.adoc
+++ b/docs/ecctl_platform_instance-configuration.adoc
@@ -44,10 +44,10 @@ ecctl platform instance-configuration [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform[ecctl platform]	 - Manages the platform
-* xref:ecctl_platform_instance-configuration_create[ecctl platform instance-configuration create]	 - Creates a new instance configuration
-* xref:ecctl_platform_instance-configuration_delete[ecctl platform instance-configuration delete]	 - Deletes an instance configuration
-* xref:ecctl_platform_instance-configuration_list[ecctl platform instance-configuration list]	 - Lists the instance configurations
-* xref:ecctl_platform_instance-configuration_pull[ecctl platform instance-configuration pull]	 - Downloads instance configuration into a local folder
-* xref:ecctl_platform_instance-configuration_show[ecctl platform instance-configuration show]	 - Shows an instance configuration
-* xref:ecctl_platform_instance-configuration_update[ecctl platform instance-configuration update]	 - Overwrites an instance configuration
+* xref:ecctl_platform[ecctl platform]	 - Manages the platform (Available for ECE only)
+* xref:ecctl_platform_instance-configuration_create[ecctl platform instance-configuration create]	 - Creates a new instance configuration (Available for ECE only)
+* xref:ecctl_platform_instance-configuration_delete[ecctl platform instance-configuration delete]	 - Deletes an instance configuration (Available for ECE only)
+* xref:ecctl_platform_instance-configuration_list[ecctl platform instance-configuration list]	 - Lists the instance configurations (Available for ECE only)
+* xref:ecctl_platform_instance-configuration_pull[ecctl platform instance-configuration pull]	 - Downloads instance configuration into a local folder (Available for ECE only)
+* xref:ecctl_platform_instance-configuration_show[ecctl platform instance-configuration show]	 - Shows an instance configuration (Available for ECE only)
+* xref:ecctl_platform_instance-configuration_update[ecctl platform instance-configuration update]	 - Overwrites an instance configuration (Available for ECE only)

--- a/docs/ecctl_platform_instance-configuration.adoc
+++ b/docs/ecctl_platform_instance-configuration.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_instance-configuration]
 == ecctl platform instance-configuration
 
-Manages instance configurations (Available for ECE only)
+Manages instance configurations {ece-icon}
 
 [float]
 === Synopsis
 
-Manages instance configurations (Available for ECE only)
+Manages instance configurations {ece-icon}
 
 ----
 ecctl platform instance-configuration [flags]
@@ -44,10 +44,10 @@ ecctl platform instance-configuration [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform[ecctl platform]	 - Manages the platform (Available for ECE only)
-* xref:ecctl_platform_instance-configuration_create[ecctl platform instance-configuration create]	 - Creates a new instance configuration (Available for ECE only)
-* xref:ecctl_platform_instance-configuration_delete[ecctl platform instance-configuration delete]	 - Deletes an instance configuration (Available for ECE only)
-* xref:ecctl_platform_instance-configuration_list[ecctl platform instance-configuration list]	 - Lists the instance configurations (Available for ECE only)
-* xref:ecctl_platform_instance-configuration_pull[ecctl platform instance-configuration pull]	 - Downloads instance configuration into a local folder (Available for ECE only)
-* xref:ecctl_platform_instance-configuration_show[ecctl platform instance-configuration show]	 - Shows an instance configuration (Available for ECE only)
-* xref:ecctl_platform_instance-configuration_update[ecctl platform instance-configuration update]	 - Overwrites an instance configuration (Available for ECE only)
+* xref:ecctl_platform[ecctl platform]	 - Manages the platform {ece-icon}
+* xref:ecctl_platform_instance-configuration_create[ecctl platform instance-configuration create]	 - Creates a new instance configuration {ece-icon}
+* xref:ecctl_platform_instance-configuration_delete[ecctl platform instance-configuration delete]	 - Deletes an instance configuration {ece-icon}
+* xref:ecctl_platform_instance-configuration_list[ecctl platform instance-configuration list]	 - Lists the instance configurations {ece-icon}
+* xref:ecctl_platform_instance-configuration_pull[ecctl platform instance-configuration pull]	 - Downloads instance configuration into a local folder {ece-icon}
+* xref:ecctl_platform_instance-configuration_show[ecctl platform instance-configuration show]	 - Shows an instance configuration {ece-icon}
+* xref:ecctl_platform_instance-configuration_update[ecctl platform instance-configuration update]	 - Overwrites an instance configuration {ece-icon}

--- a/docs/ecctl_platform_instance-configuration.md
+++ b/docs/ecctl_platform_instance-configuration.md
@@ -39,11 +39,11 @@ ecctl platform instance-configuration [flags]
 
 ### SEE ALSO
 
-* [ecctl platform](ecctl_platform.md)	 - Manages the platform
-* [ecctl platform instance-configuration create](ecctl_platform_instance-configuration_create.md)	 - Creates a new instance configuration
-* [ecctl platform instance-configuration delete](ecctl_platform_instance-configuration_delete.md)	 - Deletes an instance configuration
-* [ecctl platform instance-configuration list](ecctl_platform_instance-configuration_list.md)	 - Lists the instance configurations
-* [ecctl platform instance-configuration pull](ecctl_platform_instance-configuration_pull.md)	 - Downloads instance configuration into a local folder
-* [ecctl platform instance-configuration show](ecctl_platform_instance-configuration_show.md)	 - Shows an instance configuration
-* [ecctl platform instance-configuration update](ecctl_platform_instance-configuration_update.md)	 - Overwrites an instance configuration
+* [ecctl platform](ecctl_platform.md)	 - Manages the platform (Available for ECE only)
+* [ecctl platform instance-configuration create](ecctl_platform_instance-configuration_create.md)	 - Creates a new instance configuration (Available for ECE only)
+* [ecctl platform instance-configuration delete](ecctl_platform_instance-configuration_delete.md)	 - Deletes an instance configuration (Available for ECE only)
+* [ecctl platform instance-configuration list](ecctl_platform_instance-configuration_list.md)	 - Lists the instance configurations (Available for ECE only)
+* [ecctl platform instance-configuration pull](ecctl_platform_instance-configuration_pull.md)	 - Downloads instance configuration into a local folder (Available for ECE only)
+* [ecctl platform instance-configuration show](ecctl_platform_instance-configuration_show.md)	 - Shows an instance configuration (Available for ECE only)
+* [ecctl platform instance-configuration update](ecctl_platform_instance-configuration_update.md)	 - Overwrites an instance configuration (Available for ECE only)
 

--- a/docs/ecctl_platform_instance-configuration_create.adoc
+++ b/docs/ecctl_platform_instance-configuration_create.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_instance-configuration_create]
 == ecctl platform instance-configuration create
 
-Creates a new instance configuration
+Creates a new instance configuration (Available for ECE only)
 
 [float]
 === Synopsis
 
-Creates a new instance configuration
+Creates a new instance configuration (Available for ECE only)
 
 ----
 ecctl platform instance-configuration create -f <config.json> [flags]

--- a/docs/ecctl_platform_instance-configuration_create.adoc
+++ b/docs/ecctl_platform_instance-configuration_create.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_instance-configuration_create]
 == ecctl platform instance-configuration create
 
-Creates a new instance configuration (Available for ECE only)
+Creates a new instance configuration {ece-icon}
 
 [float]
 === Synopsis
 
-Creates a new instance configuration (Available for ECE only)
+Creates a new instance configuration {ece-icon}
 
 ----
 ecctl platform instance-configuration create -f <config.json> [flags]
@@ -46,4 +46,4 @@ ecctl platform instance-configuration create -f <config.json> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_instance-configuration[ecctl platform instance-configuration]	 - Manages instance configurations (Available for ECE only)
+* xref:ecctl_platform_instance-configuration[ecctl platform instance-configuration]	 - Manages instance configurations {ece-icon}

--- a/docs/ecctl_platform_instance-configuration_create.md
+++ b/docs/ecctl_platform_instance-configuration_create.md
@@ -1,10 +1,10 @@
 ## ecctl platform instance-configuration create
 
-Creates a new instance configuration
+Creates a new instance configuration (Available for ECE only)
 
 ### Synopsis
 
-Creates a new instance configuration
+Creates a new instance configuration (Available for ECE only)
 
 ```
 ecctl platform instance-configuration create -f <config.json> [flags]

--- a/docs/ecctl_platform_instance-configuration_delete.adoc
+++ b/docs/ecctl_platform_instance-configuration_delete.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_instance-configuration_delete]
 == ecctl platform instance-configuration delete
 
-Deletes an instance configuration
+Deletes an instance configuration (Available for ECE only)
 
 [float]
 === Synopsis
 
-Deletes an instance configuration
+Deletes an instance configuration (Available for ECE only)
 
 ----
 ecctl platform instance-configuration delete <config id> [flags]

--- a/docs/ecctl_platform_instance-configuration_delete.adoc
+++ b/docs/ecctl_platform_instance-configuration_delete.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_instance-configuration_delete]
 == ecctl platform instance-configuration delete
 
-Deletes an instance configuration (Available for ECE only)
+Deletes an instance configuration {ece-icon}
 
 [float]
 === Synopsis
 
-Deletes an instance configuration (Available for ECE only)
+Deletes an instance configuration {ece-icon}
 
 ----
 ecctl platform instance-configuration delete <config id> [flags]
@@ -44,4 +44,4 @@ ecctl platform instance-configuration delete <config id> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_instance-configuration[ecctl platform instance-configuration]	 - Manages instance configurations (Available for ECE only)
+* xref:ecctl_platform_instance-configuration[ecctl platform instance-configuration]	 - Manages instance configurations {ece-icon}

--- a/docs/ecctl_platform_instance-configuration_delete.md
+++ b/docs/ecctl_platform_instance-configuration_delete.md
@@ -1,10 +1,10 @@
 ## ecctl platform instance-configuration delete
 
-Deletes an instance configuration
+Deletes an instance configuration (Available for ECE only)
 
 ### Synopsis
 
-Deletes an instance configuration
+Deletes an instance configuration (Available for ECE only)
 
 ```
 ecctl platform instance-configuration delete <config id> [flags]

--- a/docs/ecctl_platform_instance-configuration_list.adoc
+++ b/docs/ecctl_platform_instance-configuration_list.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_instance-configuration_list]
 == ecctl platform instance-configuration list
 
-Lists the instance configurations (Available for ECE only)
+Lists the instance configurations {ece-icon}
 
 [float]
 === Synopsis
 
-Lists the instance configurations (Available for ECE only)
+Lists the instance configurations {ece-icon}
 
 ----
 ecctl platform instance-configuration list [flags]
@@ -44,4 +44,4 @@ ecctl platform instance-configuration list [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_instance-configuration[ecctl platform instance-configuration]	 - Manages instance configurations (Available for ECE only)
+* xref:ecctl_platform_instance-configuration[ecctl platform instance-configuration]	 - Manages instance configurations {ece-icon}

--- a/docs/ecctl_platform_instance-configuration_list.adoc
+++ b/docs/ecctl_platform_instance-configuration_list.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_instance-configuration_list]
 == ecctl platform instance-configuration list
 
-Lists the instance configurations
+Lists the instance configurations (Available for ECE only)
 
 [float]
 === Synopsis
 
-Lists the instance configurations
+Lists the instance configurations (Available for ECE only)
 
 ----
 ecctl platform instance-configuration list [flags]

--- a/docs/ecctl_platform_instance-configuration_list.md
+++ b/docs/ecctl_platform_instance-configuration_list.md
@@ -1,10 +1,10 @@
 ## ecctl platform instance-configuration list
 
-Lists the instance configurations
+Lists the instance configurations (Available for ECE only)
 
 ### Synopsis
 
-Lists the instance configurations
+Lists the instance configurations (Available for ECE only)
 
 ```
 ecctl platform instance-configuration list [flags]

--- a/docs/ecctl_platform_instance-configuration_pull.adoc
+++ b/docs/ecctl_platform_instance-configuration_pull.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_instance-configuration_pull]
 == ecctl platform instance-configuration pull
 
-Downloads instance configuration into a local folder (Available for ECE only)
+Downloads instance configuration into a local folder {ece-icon}
 
 [float]
 === Synopsis
 
-Downloads instance configuration into a local folder (Available for ECE only)
+Downloads instance configuration into a local folder {ece-icon}
 
 ----
 ecctl platform instance-configuration pull --path <path> [flags]
@@ -45,4 +45,4 @@ ecctl platform instance-configuration pull --path <path> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_instance-configuration[ecctl platform instance-configuration]	 - Manages instance configurations (Available for ECE only)
+* xref:ecctl_platform_instance-configuration[ecctl platform instance-configuration]	 - Manages instance configurations {ece-icon}

--- a/docs/ecctl_platform_instance-configuration_pull.adoc
+++ b/docs/ecctl_platform_instance-configuration_pull.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_instance-configuration_pull]
 == ecctl platform instance-configuration pull
 
-Downloads instance configuration into a local folder
+Downloads instance configuration into a local folder (Available for ECE only)
 
 [float]
 === Synopsis
 
-Downloads instance configuration into a local folder
+Downloads instance configuration into a local folder (Available for ECE only)
 
 ----
 ecctl platform instance-configuration pull --path <path> [flags]

--- a/docs/ecctl_platform_instance-configuration_pull.md
+++ b/docs/ecctl_platform_instance-configuration_pull.md
@@ -1,10 +1,10 @@
 ## ecctl platform instance-configuration pull
 
-Downloads instance configuration into a local folder
+Downloads instance configuration into a local folder (Available for ECE only)
 
 ### Synopsis
 
-Downloads instance configuration into a local folder
+Downloads instance configuration into a local folder (Available for ECE only)
 
 ```
 ecctl platform instance-configuration pull --path <path> [flags]

--- a/docs/ecctl_platform_instance-configuration_show.adoc
+++ b/docs/ecctl_platform_instance-configuration_show.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_instance-configuration_show]
 == ecctl platform instance-configuration show
 
-Shows an instance configuration
+Shows an instance configuration (Available for ECE only)
 
 [float]
 === Synopsis
 
-Shows an instance configuration
+Shows an instance configuration (Available for ECE only)
 
 ----
 ecctl platform instance-configuration show <config id> [flags]

--- a/docs/ecctl_platform_instance-configuration_show.adoc
+++ b/docs/ecctl_platform_instance-configuration_show.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_instance-configuration_show]
 == ecctl platform instance-configuration show
 
-Shows an instance configuration (Available for ECE only)
+Shows an instance configuration {ece-icon}
 
 [float]
 === Synopsis
 
-Shows an instance configuration (Available for ECE only)
+Shows an instance configuration {ece-icon}
 
 ----
 ecctl platform instance-configuration show <config id> [flags]
@@ -44,4 +44,4 @@ ecctl platform instance-configuration show <config id> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_instance-configuration[ecctl platform instance-configuration]	 - Manages instance configurations (Available for ECE only)
+* xref:ecctl_platform_instance-configuration[ecctl platform instance-configuration]	 - Manages instance configurations {ece-icon}

--- a/docs/ecctl_platform_instance-configuration_show.md
+++ b/docs/ecctl_platform_instance-configuration_show.md
@@ -1,10 +1,10 @@
 ## ecctl platform instance-configuration show
 
-Shows an instance configuration
+Shows an instance configuration (Available for ECE only)
 
 ### Synopsis
 
-Shows an instance configuration
+Shows an instance configuration (Available for ECE only)
 
 ```
 ecctl platform instance-configuration show <config id> [flags]

--- a/docs/ecctl_platform_instance-configuration_update.adoc
+++ b/docs/ecctl_platform_instance-configuration_update.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_instance-configuration_update]
 == ecctl platform instance-configuration update
 
-Overwrites an instance configuration
+Overwrites an instance configuration (Available for ECE only)
 
 [float]
 === Synopsis
 
-Overwrites an instance configuration
+Overwrites an instance configuration (Available for ECE only)
 
 ----
 ecctl platform instance-configuration update <config id> -f <config.json> [flags]

--- a/docs/ecctl_platform_instance-configuration_update.adoc
+++ b/docs/ecctl_platform_instance-configuration_update.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_instance-configuration_update]
 == ecctl platform instance-configuration update
 
-Overwrites an instance configuration (Available for ECE only)
+Overwrites an instance configuration {ece-icon}
 
 [float]
 === Synopsis
 
-Overwrites an instance configuration (Available for ECE only)
+Overwrites an instance configuration {ece-icon}
 
 ----
 ecctl platform instance-configuration update <config id> -f <config.json> [flags]
@@ -45,4 +45,4 @@ ecctl platform instance-configuration update <config id> -f <config.json> [flags
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_instance-configuration[ecctl platform instance-configuration]	 - Manages instance configurations (Available for ECE only)
+* xref:ecctl_platform_instance-configuration[ecctl platform instance-configuration]	 - Manages instance configurations {ece-icon}

--- a/docs/ecctl_platform_instance-configuration_update.md
+++ b/docs/ecctl_platform_instance-configuration_update.md
@@ -1,10 +1,10 @@
 ## ecctl platform instance-configuration update
 
-Overwrites an instance configuration
+Overwrites an instance configuration (Available for ECE only)
 
 ### Synopsis
 
-Overwrites an instance configuration
+Overwrites an instance configuration (Available for ECE only)
 
 ```
 ecctl platform instance-configuration update <config id> -f <config.json> [flags]

--- a/docs/ecctl_platform_proxy.adoc
+++ b/docs/ecctl_platform_proxy.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_proxy]
 == ecctl platform proxy
 
-Manages proxies (Available for ECE only)
+Manages proxies {ece-icon}
 
 [float]
 === Synopsis
 
-Manages proxies (Available for ECE only)
+Manages proxies {ece-icon}
 
 ----
 ecctl platform proxy [flags]
@@ -44,7 +44,7 @@ ecctl platform proxy [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform[ecctl platform]	 - Manages the platform (Available for ECE only)
-* xref:ecctl_platform_proxy_filtered-group[ecctl platform proxy filtered-group]	 - Manages proxies filtered group (Available for ECE only)
-* xref:ecctl_platform_proxy_list[ecctl platform proxy list]	 - Returns all of the proxies in the platform (Available for ECE only)
-* xref:ecctl_platform_proxy_show[ecctl platform proxy show]	 - Returns information about the proxy with given id (Available for ECE only)
+* xref:ecctl_platform[ecctl platform]	 - Manages the platform {ece-icon}
+* xref:ecctl_platform_proxy_filtered-group[ecctl platform proxy filtered-group]	 - Manages proxies filtered group {ece-icon}
+* xref:ecctl_platform_proxy_list[ecctl platform proxy list]	 - Returns all of the proxies in the platform {ece-icon}
+* xref:ecctl_platform_proxy_show[ecctl platform proxy show]	 - Returns information about the proxy with given id {ece-icon}

--- a/docs/ecctl_platform_proxy.adoc
+++ b/docs/ecctl_platform_proxy.adoc
@@ -44,7 +44,7 @@ ecctl platform proxy [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform[ecctl platform]	 - Manages the platform
-* xref:ecctl_platform_proxy_filtered-group[ecctl platform proxy filtered-group]	 - Manages proxies filtered group
-* xref:ecctl_platform_proxy_list[ecctl platform proxy list]	 - Returns all of the proxies in the platform
-* xref:ecctl_platform_proxy_show[ecctl platform proxy show]	 - Returns information about the proxy with given id
+* xref:ecctl_platform[ecctl platform]	 - Manages the platform (Available for ECE only)
+* xref:ecctl_platform_proxy_filtered-group[ecctl platform proxy filtered-group]	 - Manages proxies filtered group (Available for ECE only)
+* xref:ecctl_platform_proxy_list[ecctl platform proxy list]	 - Returns all of the proxies in the platform (Available for ECE only)
+* xref:ecctl_platform_proxy_show[ecctl platform proxy show]	 - Returns information about the proxy with given id (Available for ECE only)

--- a/docs/ecctl_platform_proxy.md
+++ b/docs/ecctl_platform_proxy.md
@@ -39,8 +39,8 @@ ecctl platform proxy [flags]
 
 ### SEE ALSO
 
-* [ecctl platform](ecctl_platform.md)	 - Manages the platform
-* [ecctl platform proxy filtered-group](ecctl_platform_proxy_filtered-group.md)	 - Manages proxies filtered group
-* [ecctl platform proxy list](ecctl_platform_proxy_list.md)	 - Returns all of the proxies in the platform
-* [ecctl platform proxy show](ecctl_platform_proxy_show.md)	 - Returns information about the proxy with given id
+* [ecctl platform](ecctl_platform.md)	 - Manages the platform (Available for ECE only)
+* [ecctl platform proxy filtered-group](ecctl_platform_proxy_filtered-group.md)	 - Manages proxies filtered group (Available for ECE only)
+* [ecctl platform proxy list](ecctl_platform_proxy_list.md)	 - Returns all of the proxies in the platform (Available for ECE only)
+* [ecctl platform proxy show](ecctl_platform_proxy_show.md)	 - Returns information about the proxy with given id (Available for ECE only)
 

--- a/docs/ecctl_platform_proxy_filtered-group.adoc
+++ b/docs/ecctl_platform_proxy_filtered-group.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_proxy_filtered-group]
 == ecctl platform proxy filtered-group
 
-Manages proxies filtered group
+Manages proxies filtered group (Available for ECE only)
 
 [float]
 === Synopsis
 
-Manages proxies filtered group
+Manages proxies filtered group (Available for ECE only)
 
 ----
 ecctl platform proxy filtered-group [flags]
@@ -45,8 +45,8 @@ ecctl platform proxy filtered-group [flags]
 === SEE ALSO
 
 * xref:ecctl_platform_proxy[ecctl platform proxy]	 - Manages proxies (Available for ECE only)
-* xref:ecctl_platform_proxy_filtered-group_create[ecctl platform proxy filtered-group create]	 - Creates proxies filtered group
-* xref:ecctl_platform_proxy_filtered-group_delete[ecctl platform proxy filtered-group delete]	 - Deletes proxies filtered group
-* xref:ecctl_platform_proxy_filtered-group_list[ecctl platform proxy filtered-group list]	 - Returns all proxies filtered groups in the platform
-* xref:ecctl_platform_proxy_filtered-group_show[ecctl platform proxy filtered-group show]	 - Shows details for proxies filtered group
-* xref:ecctl_platform_proxy_filtered-group_update[ecctl platform proxy filtered-group update]	 - Updates proxies filtered group
+* xref:ecctl_platform_proxy_filtered-group_create[ecctl platform proxy filtered-group create]	 - Creates proxies filtered group (Available for ECE only)
+* xref:ecctl_platform_proxy_filtered-group_delete[ecctl platform proxy filtered-group delete]	 - Deletes proxies filtered group (Available for ECE only)
+* xref:ecctl_platform_proxy_filtered-group_list[ecctl platform proxy filtered-group list]	 - Returns all proxies filtered groups in the platform (Available for ECE only)
+* xref:ecctl_platform_proxy_filtered-group_show[ecctl platform proxy filtered-group show]	 - Shows details for proxies filtered group (Available for ECE only)
+* xref:ecctl_platform_proxy_filtered-group_update[ecctl platform proxy filtered-group update]	 - Updates proxies filtered group (Available for ECE only)

--- a/docs/ecctl_platform_proxy_filtered-group.adoc
+++ b/docs/ecctl_platform_proxy_filtered-group.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_proxy_filtered-group]
 == ecctl platform proxy filtered-group
 
-Manages proxies filtered group (Available for ECE only)
+Manages proxies filtered group {ece-icon}
 
 [float]
 === Synopsis
 
-Manages proxies filtered group (Available for ECE only)
+Manages proxies filtered group {ece-icon}
 
 ----
 ecctl platform proxy filtered-group [flags]
@@ -44,9 +44,9 @@ ecctl platform proxy filtered-group [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_proxy[ecctl platform proxy]	 - Manages proxies (Available for ECE only)
-* xref:ecctl_platform_proxy_filtered-group_create[ecctl platform proxy filtered-group create]	 - Creates proxies filtered group (Available for ECE only)
-* xref:ecctl_platform_proxy_filtered-group_delete[ecctl platform proxy filtered-group delete]	 - Deletes proxies filtered group (Available for ECE only)
-* xref:ecctl_platform_proxy_filtered-group_list[ecctl platform proxy filtered-group list]	 - Returns all proxies filtered groups in the platform (Available for ECE only)
-* xref:ecctl_platform_proxy_filtered-group_show[ecctl platform proxy filtered-group show]	 - Shows details for proxies filtered group (Available for ECE only)
-* xref:ecctl_platform_proxy_filtered-group_update[ecctl platform proxy filtered-group update]	 - Updates proxies filtered group (Available for ECE only)
+* xref:ecctl_platform_proxy[ecctl platform proxy]	 - Manages proxies {ece-icon}
+* xref:ecctl_platform_proxy_filtered-group_create[ecctl platform proxy filtered-group create]	 - Creates proxies filtered group {ece-icon}
+* xref:ecctl_platform_proxy_filtered-group_delete[ecctl platform proxy filtered-group delete]	 - Deletes proxies filtered group {ece-icon}
+* xref:ecctl_platform_proxy_filtered-group_list[ecctl platform proxy filtered-group list]	 - Returns all proxies filtered groups in the platform {ece-icon}
+* xref:ecctl_platform_proxy_filtered-group_show[ecctl platform proxy filtered-group show]	 - Shows details for proxies filtered group {ece-icon}
+* xref:ecctl_platform_proxy_filtered-group_update[ecctl platform proxy filtered-group update]	 - Updates proxies filtered group {ece-icon}

--- a/docs/ecctl_platform_proxy_filtered-group.md
+++ b/docs/ecctl_platform_proxy_filtered-group.md
@@ -1,10 +1,10 @@
 ## ecctl platform proxy filtered-group
 
-Manages proxies filtered group
+Manages proxies filtered group (Available for ECE only)
 
 ### Synopsis
 
-Manages proxies filtered group
+Manages proxies filtered group (Available for ECE only)
 
 ```
 ecctl platform proxy filtered-group [flags]
@@ -40,9 +40,9 @@ ecctl platform proxy filtered-group [flags]
 ### SEE ALSO
 
 * [ecctl platform proxy](ecctl_platform_proxy.md)	 - Manages proxies (Available for ECE only)
-* [ecctl platform proxy filtered-group create](ecctl_platform_proxy_filtered-group_create.md)	 - Creates proxies filtered group
-* [ecctl platform proxy filtered-group delete](ecctl_platform_proxy_filtered-group_delete.md)	 - Deletes proxies filtered group
-* [ecctl platform proxy filtered-group list](ecctl_platform_proxy_filtered-group_list.md)	 - Returns all proxies filtered groups in the platform
-* [ecctl platform proxy filtered-group show](ecctl_platform_proxy_filtered-group_show.md)	 - Shows details for proxies filtered group
-* [ecctl platform proxy filtered-group update](ecctl_platform_proxy_filtered-group_update.md)	 - Updates proxies filtered group
+* [ecctl platform proxy filtered-group create](ecctl_platform_proxy_filtered-group_create.md)	 - Creates proxies filtered group (Available for ECE only)
+* [ecctl platform proxy filtered-group delete](ecctl_platform_proxy_filtered-group_delete.md)	 - Deletes proxies filtered group (Available for ECE only)
+* [ecctl platform proxy filtered-group list](ecctl_platform_proxy_filtered-group_list.md)	 - Returns all proxies filtered groups in the platform (Available for ECE only)
+* [ecctl platform proxy filtered-group show](ecctl_platform_proxy_filtered-group_show.md)	 - Shows details for proxies filtered group (Available for ECE only)
+* [ecctl platform proxy filtered-group update](ecctl_platform_proxy_filtered-group_update.md)	 - Updates proxies filtered group (Available for ECE only)
 

--- a/docs/ecctl_platform_proxy_filtered-group_create.adoc
+++ b/docs/ecctl_platform_proxy_filtered-group_create.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_proxy_filtered-group_create]
 == ecctl platform proxy filtered-group create
 
-Creates proxies filtered group
+Creates proxies filtered group (Available for ECE only)
 
 [float]
 === Synopsis
 
-Creates proxies filtered group
+Creates proxies filtered group (Available for ECE only)
 
 ----
 ecctl platform proxy filtered-group create <filtered group id> --filters <key1=value1,key2=value2> --expected-proxies-count <int> [flags]
@@ -46,4 +46,4 @@ ecctl platform proxy filtered-group create <filtered group id> --filters <key1=v
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_proxy_filtered-group[ecctl platform proxy filtered-group]	 - Manages proxies filtered group
+* xref:ecctl_platform_proxy_filtered-group[ecctl platform proxy filtered-group]	 - Manages proxies filtered group (Available for ECE only)

--- a/docs/ecctl_platform_proxy_filtered-group_create.adoc
+++ b/docs/ecctl_platform_proxy_filtered-group_create.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_proxy_filtered-group_create]
 == ecctl platform proxy filtered-group create
 
-Creates proxies filtered group (Available for ECE only)
+Creates proxies filtered group {ece-icon}
 
 [float]
 === Synopsis
 
-Creates proxies filtered group (Available for ECE only)
+Creates proxies filtered group {ece-icon}
 
 ----
 ecctl platform proxy filtered-group create <filtered group id> --filters <key1=value1,key2=value2> --expected-proxies-count <int> [flags]
@@ -46,4 +46,4 @@ ecctl platform proxy filtered-group create <filtered group id> --filters <key1=v
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_proxy_filtered-group[ecctl platform proxy filtered-group]	 - Manages proxies filtered group (Available for ECE only)
+* xref:ecctl_platform_proxy_filtered-group[ecctl platform proxy filtered-group]	 - Manages proxies filtered group {ece-icon}

--- a/docs/ecctl_platform_proxy_filtered-group_create.md
+++ b/docs/ecctl_platform_proxy_filtered-group_create.md
@@ -1,10 +1,10 @@
 ## ecctl platform proxy filtered-group create
 
-Creates proxies filtered group
+Creates proxies filtered group (Available for ECE only)
 
 ### Synopsis
 
-Creates proxies filtered group
+Creates proxies filtered group (Available for ECE only)
 
 ```
 ecctl platform proxy filtered-group create <filtered group id> --filters <key1=value1,key2=value2> --expected-proxies-count <int> [flags]
@@ -41,5 +41,5 @@ ecctl platform proxy filtered-group create <filtered group id> --filters <key1=v
 
 ### SEE ALSO
 
-* [ecctl platform proxy filtered-group](ecctl_platform_proxy_filtered-group.md)	 - Manages proxies filtered group
+* [ecctl platform proxy filtered-group](ecctl_platform_proxy_filtered-group.md)	 - Manages proxies filtered group (Available for ECE only)
 

--- a/docs/ecctl_platform_proxy_filtered-group_delete.adoc
+++ b/docs/ecctl_platform_proxy_filtered-group_delete.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_proxy_filtered-group_delete]
 == ecctl platform proxy filtered-group delete
 
-Deletes proxies filtered group
+Deletes proxies filtered group (Available for ECE only)
 
 [float]
 === Synopsis
 
-Deletes proxies filtered group
+Deletes proxies filtered group (Available for ECE only)
 
 ----
 ecctl platform proxy filtered-group delete <filtered group id> [flags]
@@ -44,4 +44,4 @@ ecctl platform proxy filtered-group delete <filtered group id> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_proxy_filtered-group[ecctl platform proxy filtered-group]	 - Manages proxies filtered group
+* xref:ecctl_platform_proxy_filtered-group[ecctl platform proxy filtered-group]	 - Manages proxies filtered group (Available for ECE only)

--- a/docs/ecctl_platform_proxy_filtered-group_delete.adoc
+++ b/docs/ecctl_platform_proxy_filtered-group_delete.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_proxy_filtered-group_delete]
 == ecctl platform proxy filtered-group delete
 
-Deletes proxies filtered group (Available for ECE only)
+Deletes proxies filtered group {ece-icon}
 
 [float]
 === Synopsis
 
-Deletes proxies filtered group (Available for ECE only)
+Deletes proxies filtered group {ece-icon}
 
 ----
 ecctl platform proxy filtered-group delete <filtered group id> [flags]
@@ -44,4 +44,4 @@ ecctl platform proxy filtered-group delete <filtered group id> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_proxy_filtered-group[ecctl platform proxy filtered-group]	 - Manages proxies filtered group (Available for ECE only)
+* xref:ecctl_platform_proxy_filtered-group[ecctl platform proxy filtered-group]	 - Manages proxies filtered group {ece-icon}

--- a/docs/ecctl_platform_proxy_filtered-group_delete.md
+++ b/docs/ecctl_platform_proxy_filtered-group_delete.md
@@ -1,10 +1,10 @@
 ## ecctl platform proxy filtered-group delete
 
-Deletes proxies filtered group
+Deletes proxies filtered group (Available for ECE only)
 
 ### Synopsis
 
-Deletes proxies filtered group
+Deletes proxies filtered group (Available for ECE only)
 
 ```
 ecctl platform proxy filtered-group delete <filtered group id> [flags]
@@ -39,5 +39,5 @@ ecctl platform proxy filtered-group delete <filtered group id> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform proxy filtered-group](ecctl_platform_proxy_filtered-group.md)	 - Manages proxies filtered group
+* [ecctl platform proxy filtered-group](ecctl_platform_proxy_filtered-group.md)	 - Manages proxies filtered group (Available for ECE only)
 

--- a/docs/ecctl_platform_proxy_filtered-group_list.adoc
+++ b/docs/ecctl_platform_proxy_filtered-group_list.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_proxy_filtered-group_list]
 == ecctl platform proxy filtered-group list
 
-Returns all proxies filtered groups in the platform (Available for ECE only)
+Returns all proxies filtered groups in the platform {ece-icon}
 
 [float]
 === Synopsis
 
-Returns all proxies filtered groups in the platform (Available for ECE only)
+Returns all proxies filtered groups in the platform {ece-icon}
 
 ----
 ecctl platform proxy filtered-group list [flags]
@@ -44,4 +44,4 @@ ecctl platform proxy filtered-group list [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_proxy_filtered-group[ecctl platform proxy filtered-group]	 - Manages proxies filtered group (Available for ECE only)
+* xref:ecctl_platform_proxy_filtered-group[ecctl platform proxy filtered-group]	 - Manages proxies filtered group {ece-icon}

--- a/docs/ecctl_platform_proxy_filtered-group_list.adoc
+++ b/docs/ecctl_platform_proxy_filtered-group_list.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_proxy_filtered-group_list]
 == ecctl platform proxy filtered-group list
 
-Returns all proxies filtered groups in the platform
+Returns all proxies filtered groups in the platform (Available for ECE only)
 
 [float]
 === Synopsis
 
-Returns all proxies filtered groups in the platform
+Returns all proxies filtered groups in the platform (Available for ECE only)
 
 ----
 ecctl platform proxy filtered-group list [flags]
@@ -44,4 +44,4 @@ ecctl platform proxy filtered-group list [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_proxy_filtered-group[ecctl platform proxy filtered-group]	 - Manages proxies filtered group
+* xref:ecctl_platform_proxy_filtered-group[ecctl platform proxy filtered-group]	 - Manages proxies filtered group (Available for ECE only)

--- a/docs/ecctl_platform_proxy_filtered-group_list.md
+++ b/docs/ecctl_platform_proxy_filtered-group_list.md
@@ -1,10 +1,10 @@
 ## ecctl platform proxy filtered-group list
 
-Returns all proxies filtered groups in the platform
+Returns all proxies filtered groups in the platform (Available for ECE only)
 
 ### Synopsis
 
-Returns all proxies filtered groups in the platform
+Returns all proxies filtered groups in the platform (Available for ECE only)
 
 ```
 ecctl platform proxy filtered-group list [flags]
@@ -39,5 +39,5 @@ ecctl platform proxy filtered-group list [flags]
 
 ### SEE ALSO
 
-* [ecctl platform proxy filtered-group](ecctl_platform_proxy_filtered-group.md)	 - Manages proxies filtered group
+* [ecctl platform proxy filtered-group](ecctl_platform_proxy_filtered-group.md)	 - Manages proxies filtered group (Available for ECE only)
 

--- a/docs/ecctl_platform_proxy_filtered-group_show.adoc
+++ b/docs/ecctl_platform_proxy_filtered-group_show.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_proxy_filtered-group_show]
 == ecctl platform proxy filtered-group show
 
-Shows details for proxies filtered group
+Shows details for proxies filtered group (Available for ECE only)
 
 [float]
 === Synopsis
 
-Shows details for proxies filtered group
+Shows details for proxies filtered group (Available for ECE only)
 
 ----
 ecctl platform proxy filtered-group show <filtered group id> [flags]
@@ -44,4 +44,4 @@ ecctl platform proxy filtered-group show <filtered group id> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_proxy_filtered-group[ecctl platform proxy filtered-group]	 - Manages proxies filtered group
+* xref:ecctl_platform_proxy_filtered-group[ecctl platform proxy filtered-group]	 - Manages proxies filtered group (Available for ECE only)

--- a/docs/ecctl_platform_proxy_filtered-group_show.adoc
+++ b/docs/ecctl_platform_proxy_filtered-group_show.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_proxy_filtered-group_show]
 == ecctl platform proxy filtered-group show
 
-Shows details for proxies filtered group (Available for ECE only)
+Shows details for proxies filtered group {ece-icon}
 
 [float]
 === Synopsis
 
-Shows details for proxies filtered group (Available for ECE only)
+Shows details for proxies filtered group {ece-icon}
 
 ----
 ecctl platform proxy filtered-group show <filtered group id> [flags]
@@ -44,4 +44,4 @@ ecctl platform proxy filtered-group show <filtered group id> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_proxy_filtered-group[ecctl platform proxy filtered-group]	 - Manages proxies filtered group (Available for ECE only)
+* xref:ecctl_platform_proxy_filtered-group[ecctl platform proxy filtered-group]	 - Manages proxies filtered group {ece-icon}

--- a/docs/ecctl_platform_proxy_filtered-group_show.md
+++ b/docs/ecctl_platform_proxy_filtered-group_show.md
@@ -1,10 +1,10 @@
 ## ecctl platform proxy filtered-group show
 
-Shows details for proxies filtered group
+Shows details for proxies filtered group (Available for ECE only)
 
 ### Synopsis
 
-Shows details for proxies filtered group
+Shows details for proxies filtered group (Available for ECE only)
 
 ```
 ecctl platform proxy filtered-group show <filtered group id> [flags]
@@ -39,5 +39,5 @@ ecctl platform proxy filtered-group show <filtered group id> [flags]
 
 ### SEE ALSO
 
-* [ecctl platform proxy filtered-group](ecctl_platform_proxy_filtered-group.md)	 - Manages proxies filtered group
+* [ecctl platform proxy filtered-group](ecctl_platform_proxy_filtered-group.md)	 - Manages proxies filtered group (Available for ECE only)
 

--- a/docs/ecctl_platform_proxy_filtered-group_update.adoc
+++ b/docs/ecctl_platform_proxy_filtered-group_update.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_proxy_filtered-group_update]
 == ecctl platform proxy filtered-group update
 
-Updates proxies filtered group
+Updates proxies filtered group (Available for ECE only)
 
 [float]
 === Synopsis
 
-Updates proxies filtered group
+Updates proxies filtered group (Available for ECE only)
 
 ----
 ecctl platform proxy filtered-group update <filtered group id> --filters <key1=value1,key2=value2> --expected-proxies-count <int> --version <int> [flags]
@@ -47,4 +47,4 @@ ecctl platform proxy filtered-group update <filtered group id> --filters <key1=v
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_proxy_filtered-group[ecctl platform proxy filtered-group]	 - Manages proxies filtered group
+* xref:ecctl_platform_proxy_filtered-group[ecctl platform proxy filtered-group]	 - Manages proxies filtered group (Available for ECE only)

--- a/docs/ecctl_platform_proxy_filtered-group_update.adoc
+++ b/docs/ecctl_platform_proxy_filtered-group_update.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_proxy_filtered-group_update]
 == ecctl platform proxy filtered-group update
 
-Updates proxies filtered group (Available for ECE only)
+Updates proxies filtered group {ece-icon}
 
 [float]
 === Synopsis
 
-Updates proxies filtered group (Available for ECE only)
+Updates proxies filtered group {ece-icon}
 
 ----
 ecctl platform proxy filtered-group update <filtered group id> --filters <key1=value1,key2=value2> --expected-proxies-count <int> --version <int> [flags]
@@ -47,4 +47,4 @@ ecctl platform proxy filtered-group update <filtered group id> --filters <key1=v
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_proxy_filtered-group[ecctl platform proxy filtered-group]	 - Manages proxies filtered group (Available for ECE only)
+* xref:ecctl_platform_proxy_filtered-group[ecctl platform proxy filtered-group]	 - Manages proxies filtered group {ece-icon}

--- a/docs/ecctl_platform_proxy_filtered-group_update.md
+++ b/docs/ecctl_platform_proxy_filtered-group_update.md
@@ -1,10 +1,10 @@
 ## ecctl platform proxy filtered-group update
 
-Updates proxies filtered group
+Updates proxies filtered group (Available for ECE only)
 
 ### Synopsis
 
-Updates proxies filtered group
+Updates proxies filtered group (Available for ECE only)
 
 ```
 ecctl platform proxy filtered-group update <filtered group id> --filters <key1=value1,key2=value2> --expected-proxies-count <int> --version <int> [flags]
@@ -42,5 +42,5 @@ ecctl platform proxy filtered-group update <filtered group id> --filters <key1=v
 
 ### SEE ALSO
 
-* [ecctl platform proxy filtered-group](ecctl_platform_proxy_filtered-group.md)	 - Manages proxies filtered group
+* [ecctl platform proxy filtered-group](ecctl_platform_proxy_filtered-group.md)	 - Manages proxies filtered group (Available for ECE only)
 

--- a/docs/ecctl_platform_proxy_list.adoc
+++ b/docs/ecctl_platform_proxy_list.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_proxy_list]
 == ecctl platform proxy list
 
-Returns all of the proxies in the platform (Available for ECE only)
+Returns all of the proxies in the platform {ece-icon}
 
 [float]
 === Synopsis
 
-Returns all of the proxies in the platform (Available for ECE only)
+Returns all of the proxies in the platform {ece-icon}
 
 ----
 ecctl platform proxy list [flags]
@@ -44,4 +44,4 @@ ecctl platform proxy list [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_proxy[ecctl platform proxy]	 - Manages proxies (Available for ECE only)
+* xref:ecctl_platform_proxy[ecctl platform proxy]	 - Manages proxies {ece-icon}

--- a/docs/ecctl_platform_proxy_list.adoc
+++ b/docs/ecctl_platform_proxy_list.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_proxy_list]
 == ecctl platform proxy list
 
-Returns all of the proxies in the platform
+Returns all of the proxies in the platform (Available for ECE only)
 
 [float]
 === Synopsis
 
-Returns all of the proxies in the platform
+Returns all of the proxies in the platform (Available for ECE only)
 
 ----
 ecctl platform proxy list [flags]

--- a/docs/ecctl_platform_proxy_list.md
+++ b/docs/ecctl_platform_proxy_list.md
@@ -1,10 +1,10 @@
 ## ecctl platform proxy list
 
-Returns all of the proxies in the platform
+Returns all of the proxies in the platform (Available for ECE only)
 
 ### Synopsis
 
-Returns all of the proxies in the platform
+Returns all of the proxies in the platform (Available for ECE only)
 
 ```
 ecctl platform proxy list [flags]

--- a/docs/ecctl_platform_proxy_show.adoc
+++ b/docs/ecctl_platform_proxy_show.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_proxy_show]
 == ecctl platform proxy show
 
-Returns information about the proxy with given id
+Returns information about the proxy with given id (Available for ECE only)
 
 [float]
 === Synopsis
 
-Returns information about the proxy with given id
+Returns information about the proxy with given id (Available for ECE only)
 
 ----
 ecctl platform proxy show <proxy id> [flags]

--- a/docs/ecctl_platform_proxy_show.adoc
+++ b/docs/ecctl_platform_proxy_show.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_proxy_show]
 == ecctl platform proxy show
 
-Returns information about the proxy with given id (Available for ECE only)
+Returns information about the proxy with given id {ece-icon}
 
 [float]
 === Synopsis
 
-Returns information about the proxy with given id (Available for ECE only)
+Returns information about the proxy with given id {ece-icon}
 
 ----
 ecctl platform proxy show <proxy id> [flags]
@@ -44,4 +44,4 @@ ecctl platform proxy show <proxy id> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_proxy[ecctl platform proxy]	 - Manages proxies (Available for ECE only)
+* xref:ecctl_platform_proxy[ecctl platform proxy]	 - Manages proxies {ece-icon}

--- a/docs/ecctl_platform_proxy_show.md
+++ b/docs/ecctl_platform_proxy_show.md
@@ -1,10 +1,10 @@
 ## ecctl platform proxy show
 
-Returns information about the proxy with given id
+Returns information about the proxy with given id (Available for ECE only)
 
 ### Synopsis
 
-Returns information about the proxy with given id
+Returns information about the proxy with given id (Available for ECE only)
 
 ```
 ecctl platform proxy show <proxy id> [flags]

--- a/docs/ecctl_platform_repository.adoc
+++ b/docs/ecctl_platform_repository.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_repository]
 == ecctl platform repository
 
-Manages snapshot repositories (Available for ECE only)
+Manages snapshot repositories {ece-icon}
 
 [float]
 === Synopsis
@@ -45,8 +45,8 @@ ecctl platform repository [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform[ecctl platform]	 - Manages the platform (Available for ECE only)
-* xref:ecctl_platform_repository_create[ecctl platform repository create]	 - Creates / updates a snapshot repository (Available for ECE only)
-* xref:ecctl_platform_repository_delete[ecctl platform repository delete]	 - Deletes a snapshot repositories (Available for ECE only)
-* xref:ecctl_platform_repository_list[ecctl platform repository list]	 - Lists all the snapshot repositories (Available for ECE only)
-* xref:ecctl_platform_repository_show[ecctl platform repository show]	 - Obtains a snapshot repository config (Available for ECE only)
+* xref:ecctl_platform[ecctl platform]	 - Manages the platform {ece-icon}
+* xref:ecctl_platform_repository_create[ecctl platform repository create]	 - Creates / updates a snapshot repository {ece-icon}
+* xref:ecctl_platform_repository_delete[ecctl platform repository delete]	 - Deletes a snapshot repositories {ece-icon}
+* xref:ecctl_platform_repository_list[ecctl platform repository list]	 - Lists all the snapshot repositories {ece-icon}
+* xref:ecctl_platform_repository_show[ecctl platform repository show]	 - Obtains a snapshot repository config {ece-icon}

--- a/docs/ecctl_platform_repository.adoc
+++ b/docs/ecctl_platform_repository.adoc
@@ -45,8 +45,8 @@ ecctl platform repository [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform[ecctl platform]	 - Manages the platform
-* xref:ecctl_platform_repository_create[ecctl platform repository create]	 - Creates / updates a snapshot repository
-* xref:ecctl_platform_repository_delete[ecctl platform repository delete]	 - Deletes a snapshot repositories
-* xref:ecctl_platform_repository_list[ecctl platform repository list]	 - Lists all the snapshot repositories
-* xref:ecctl_platform_repository_show[ecctl platform repository show]	 - Obtains a snapshot repository config
+* xref:ecctl_platform[ecctl platform]	 - Manages the platform (Available for ECE only)
+* xref:ecctl_platform_repository_create[ecctl platform repository create]	 - Creates / updates a snapshot repository (Available for ECE only)
+* xref:ecctl_platform_repository_delete[ecctl platform repository delete]	 - Deletes a snapshot repositories (Available for ECE only)
+* xref:ecctl_platform_repository_list[ecctl platform repository list]	 - Lists all the snapshot repositories (Available for ECE only)
+* xref:ecctl_platform_repository_show[ecctl platform repository show]	 - Obtains a snapshot repository config (Available for ECE only)

--- a/docs/ecctl_platform_repository.md
+++ b/docs/ecctl_platform_repository.md
@@ -41,9 +41,9 @@ ecctl platform repository [flags]
 
 ### SEE ALSO
 
-* [ecctl platform](ecctl_platform.md)	 - Manages the platform
-* [ecctl platform repository create](ecctl_platform_repository_create.md)	 - Creates / updates a snapshot repository
-* [ecctl platform repository delete](ecctl_platform_repository_delete.md)	 - Deletes a snapshot repositories
-* [ecctl platform repository list](ecctl_platform_repository_list.md)	 - Lists all the snapshot repositories
-* [ecctl platform repository show](ecctl_platform_repository_show.md)	 - Obtains a snapshot repository config
+* [ecctl platform](ecctl_platform.md)	 - Manages the platform (Available for ECE only)
+* [ecctl platform repository create](ecctl_platform_repository_create.md)	 - Creates / updates a snapshot repository (Available for ECE only)
+* [ecctl platform repository delete](ecctl_platform_repository_delete.md)	 - Deletes a snapshot repositories (Available for ECE only)
+* [ecctl platform repository list](ecctl_platform_repository_list.md)	 - Lists all the snapshot repositories (Available for ECE only)
+* [ecctl platform repository show](ecctl_platform_repository_show.md)	 - Obtains a snapshot repository config (Available for ECE only)
 

--- a/docs/ecctl_platform_repository_create.adoc
+++ b/docs/ecctl_platform_repository_create.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_repository_create]
 == ecctl platform repository create
 
-Creates / updates a snapshot repository (Available for ECE only)
+Creates / updates a snapshot repository {ece-icon}
 
 [float]
 === Synopsis
@@ -65,4 +65,4 @@ ecctl platform repository create custom --type fs --settings settings.yml
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_repository[ecctl platform repository]	 - Manages snapshot repositories (Available for ECE only)
+* xref:ecctl_platform_repository[ecctl platform repository]	 - Manages snapshot repositories {ece-icon}

--- a/docs/ecctl_platform_repository_create.adoc
+++ b/docs/ecctl_platform_repository_create.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_repository_create]
 == ecctl platform repository create
 
-Creates / updates a snapshot repository
+Creates / updates a snapshot repository (Available for ECE only)
 
 [float]
 === Synopsis

--- a/docs/ecctl_platform_repository_create.md
+++ b/docs/ecctl_platform_repository_create.md
@@ -1,6 +1,6 @@
 ## ecctl platform repository create
 
-Creates / updates a snapshot repository
+Creates / updates a snapshot repository (Available for ECE only)
 
 ### Synopsis
 

--- a/docs/ecctl_platform_repository_delete.adoc
+++ b/docs/ecctl_platform_repository_delete.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_repository_delete]
 == ecctl platform repository delete
 
-Deletes a snapshot repositories
+Deletes a snapshot repositories (Available for ECE only)
 
 [float]
 === Synopsis
 
-Deletes a snapshot repositories
+Deletes a snapshot repositories (Available for ECE only)
 
 ----
 ecctl platform repository delete <repository name> [flags]

--- a/docs/ecctl_platform_repository_delete.adoc
+++ b/docs/ecctl_platform_repository_delete.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_repository_delete]
 == ecctl platform repository delete
 
-Deletes a snapshot repositories (Available for ECE only)
+Deletes a snapshot repositories {ece-icon}
 
 [float]
 === Synopsis
 
-Deletes a snapshot repositories (Available for ECE only)
+Deletes a snapshot repositories {ece-icon}
 
 ----
 ecctl platform repository delete <repository name> [flags]
@@ -44,4 +44,4 @@ ecctl platform repository delete <repository name> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_repository[ecctl platform repository]	 - Manages snapshot repositories (Available for ECE only)
+* xref:ecctl_platform_repository[ecctl platform repository]	 - Manages snapshot repositories {ece-icon}

--- a/docs/ecctl_platform_repository_delete.md
+++ b/docs/ecctl_platform_repository_delete.md
@@ -1,10 +1,10 @@
 ## ecctl platform repository delete
 
-Deletes a snapshot repositories
+Deletes a snapshot repositories (Available for ECE only)
 
 ### Synopsis
 
-Deletes a snapshot repositories
+Deletes a snapshot repositories (Available for ECE only)
 
 ```
 ecctl platform repository delete <repository name> [flags]

--- a/docs/ecctl_platform_repository_list.adoc
+++ b/docs/ecctl_platform_repository_list.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_repository_list]
 == ecctl platform repository list
 
-Lists all the snapshot repositories
+Lists all the snapshot repositories (Available for ECE only)
 
 [float]
 === Synopsis
 
-Lists all the snapshot repositories
+Lists all the snapshot repositories (Available for ECE only)
 
 ----
 ecctl platform repository list [flags]

--- a/docs/ecctl_platform_repository_list.adoc
+++ b/docs/ecctl_platform_repository_list.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_repository_list]
 == ecctl platform repository list
 
-Lists all the snapshot repositories (Available for ECE only)
+Lists all the snapshot repositories {ece-icon}
 
 [float]
 === Synopsis
 
-Lists all the snapshot repositories (Available for ECE only)
+Lists all the snapshot repositories {ece-icon}
 
 ----
 ecctl platform repository list [flags]
@@ -44,4 +44,4 @@ ecctl platform repository list [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_repository[ecctl platform repository]	 - Manages snapshot repositories (Available for ECE only)
+* xref:ecctl_platform_repository[ecctl platform repository]	 - Manages snapshot repositories {ece-icon}

--- a/docs/ecctl_platform_repository_list.md
+++ b/docs/ecctl_platform_repository_list.md
@@ -1,10 +1,10 @@
 ## ecctl platform repository list
 
-Lists all the snapshot repositories
+Lists all the snapshot repositories (Available for ECE only)
 
 ### Synopsis
 
-Lists all the snapshot repositories
+Lists all the snapshot repositories (Available for ECE only)
 
 ```
 ecctl platform repository list [flags]

--- a/docs/ecctl_platform_repository_show.adoc
+++ b/docs/ecctl_platform_repository_show.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_repository_show]
 == ecctl platform repository show
 
-Obtains a snapshot repository config (Available for ECE only)
+Obtains a snapshot repository config {ece-icon}
 
 [float]
 === Synopsis
 
-Obtains a snapshot repository config (Available for ECE only)
+Obtains a snapshot repository config {ece-icon}
 
 ----
 ecctl platform repository show <repository name> [flags]
@@ -44,4 +44,4 @@ ecctl platform repository show <repository name> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_repository[ecctl platform repository]	 - Manages snapshot repositories (Available for ECE only)
+* xref:ecctl_platform_repository[ecctl platform repository]	 - Manages snapshot repositories {ece-icon}

--- a/docs/ecctl_platform_repository_show.adoc
+++ b/docs/ecctl_platform_repository_show.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_repository_show]
 == ecctl platform repository show
 
-Obtains a snapshot repository config
+Obtains a snapshot repository config (Available for ECE only)
 
 [float]
 === Synopsis
 
-Obtains a snapshot repository config
+Obtains a snapshot repository config (Available for ECE only)
 
 ----
 ecctl platform repository show <repository name> [flags]

--- a/docs/ecctl_platform_repository_show.md
+++ b/docs/ecctl_platform_repository_show.md
@@ -1,10 +1,10 @@
 ## ecctl platform repository show
 
-Obtains a snapshot repository config
+Obtains a snapshot repository config (Available for ECE only)
 
 ### Synopsis
 
-Obtains a snapshot repository config
+Obtains a snapshot repository config (Available for ECE only)
 
 ```
 ecctl platform repository show <repository name> [flags]

--- a/docs/ecctl_platform_role.adoc
+++ b/docs/ecctl_platform_role.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_role]
 == ecctl platform role
 
-Manages platform roles (Available for ECE only)
+Manages platform roles {ece-icon}
 
 [float]
 === Synopsis
 
-Manages platform roles (Available for ECE only)
+Manages platform roles {ece-icon}
 
 ----
 ecctl platform role [flags]
@@ -44,8 +44,8 @@ ecctl platform role [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform[ecctl platform]	 - Manages the platform (Available for ECE only)
-* xref:ecctl_platform_role_create[ecctl platform role create]	 - Creates a new platform role from a definition (Available for ECE only)
-* xref:ecctl_platform_role_delete[ecctl platform role delete]	 - Deletes an existing platform role (Available for ECE only)
-* xref:ecctl_platform_role_list[ecctl platform role list]	 - Lists the existing platform roles (Available for ECE only)
-* xref:ecctl_platform_role_show[ecctl platform role show]	 - Shows the existing platform roles (Available for ECE only)
+* xref:ecctl_platform[ecctl platform]	 - Manages the platform {ece-icon}
+* xref:ecctl_platform_role_create[ecctl platform role create]	 - Creates a new platform role from a definition {ece-icon}
+* xref:ecctl_platform_role_delete[ecctl platform role delete]	 - Deletes an existing platform role {ece-icon}
+* xref:ecctl_platform_role_list[ecctl platform role list]	 - Lists the existing platform roles {ece-icon}
+* xref:ecctl_platform_role_show[ecctl platform role show]	 - Shows the existing platform roles {ece-icon}

--- a/docs/ecctl_platform_role.adoc
+++ b/docs/ecctl_platform_role.adoc
@@ -44,8 +44,8 @@ ecctl platform role [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform[ecctl platform]	 - Manages the platform
-* xref:ecctl_platform_role_create[ecctl platform role create]	 - Creates a new platform role from a definition
-* xref:ecctl_platform_role_delete[ecctl platform role delete]	 - Deletes an existing platform role
-* xref:ecctl_platform_role_list[ecctl platform role list]	 - Lists the existing platform roles
-* xref:ecctl_platform_role_show[ecctl platform role show]	 - Shows the existing platform roles
+* xref:ecctl_platform[ecctl platform]	 - Manages the platform (Available for ECE only)
+* xref:ecctl_platform_role_create[ecctl platform role create]	 - Creates a new platform role from a definition (Available for ECE only)
+* xref:ecctl_platform_role_delete[ecctl platform role delete]	 - Deletes an existing platform role (Available for ECE only)
+* xref:ecctl_platform_role_list[ecctl platform role list]	 - Lists the existing platform roles (Available for ECE only)
+* xref:ecctl_platform_role_show[ecctl platform role show]	 - Shows the existing platform roles (Available for ECE only)

--- a/docs/ecctl_platform_role.md
+++ b/docs/ecctl_platform_role.md
@@ -39,9 +39,9 @@ ecctl platform role [flags]
 
 ### SEE ALSO
 
-* [ecctl platform](ecctl_platform.md)	 - Manages the platform
-* [ecctl platform role create](ecctl_platform_role_create.md)	 - Creates a new platform role from a definition
-* [ecctl platform role delete](ecctl_platform_role_delete.md)	 - Deletes an existing platform role
-* [ecctl platform role list](ecctl_platform_role_list.md)	 - Lists the existing platform roles
-* [ecctl platform role show](ecctl_platform_role_show.md)	 - Shows the existing platform roles
+* [ecctl platform](ecctl_platform.md)	 - Manages the platform (Available for ECE only)
+* [ecctl platform role create](ecctl_platform_role_create.md)	 - Creates a new platform role from a definition (Available for ECE only)
+* [ecctl platform role delete](ecctl_platform_role_delete.md)	 - Deletes an existing platform role (Available for ECE only)
+* [ecctl platform role list](ecctl_platform_role_list.md)	 - Lists the existing platform roles (Available for ECE only)
+* [ecctl platform role show](ecctl_platform_role_show.md)	 - Shows the existing platform roles (Available for ECE only)
 

--- a/docs/ecctl_platform_role_create.adoc
+++ b/docs/ecctl_platform_role_create.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_role_create]
 == ecctl platform role create
 
-Creates a new platform role from a definition (Available for ECE only)
+Creates a new platform role from a definition {ece-icon}
 
 [float]
 === Synopsis
 
-Creates a new platform role from a definition (Available for ECE only)
+Creates a new platform role from a definition {ece-icon}
 
 ----
 ecctl platform role create --file <filename.json> [flags]
@@ -45,4 +45,4 @@ ecctl platform role create --file <filename.json> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_role[ecctl platform role]	 - Manages platform roles (Available for ECE only)
+* xref:ecctl_platform_role[ecctl platform role]	 - Manages platform roles {ece-icon}

--- a/docs/ecctl_platform_role_create.adoc
+++ b/docs/ecctl_platform_role_create.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_role_create]
 == ecctl platform role create
 
-Creates a new platform role from a definition
+Creates a new platform role from a definition (Available for ECE only)
 
 [float]
 === Synopsis
 
-Creates a new platform role from a definition
+Creates a new platform role from a definition (Available for ECE only)
 
 ----
 ecctl platform role create --file <filename.json> [flags]

--- a/docs/ecctl_platform_role_create.md
+++ b/docs/ecctl_platform_role_create.md
@@ -1,10 +1,10 @@
 ## ecctl platform role create
 
-Creates a new platform role from a definition
+Creates a new platform role from a definition (Available for ECE only)
 
 ### Synopsis
 
-Creates a new platform role from a definition
+Creates a new platform role from a definition (Available for ECE only)
 
 ```
 ecctl platform role create --file <filename.json> [flags]

--- a/docs/ecctl_platform_role_delete.adoc
+++ b/docs/ecctl_platform_role_delete.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_role_delete]
 == ecctl platform role delete
 
-Deletes an existing platform role
+Deletes an existing platform role (Available for ECE only)
 
 [float]
 === Synopsis
 
-Deletes an existing platform role
+Deletes an existing platform role (Available for ECE only)
 
 ----
 ecctl platform role delete <role> [flags]

--- a/docs/ecctl_platform_role_delete.adoc
+++ b/docs/ecctl_platform_role_delete.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_role_delete]
 == ecctl platform role delete
 
-Deletes an existing platform role (Available for ECE only)
+Deletes an existing platform role {ece-icon}
 
 [float]
 === Synopsis
 
-Deletes an existing platform role (Available for ECE only)
+Deletes an existing platform role {ece-icon}
 
 ----
 ecctl platform role delete <role> [flags]
@@ -44,4 +44,4 @@ ecctl platform role delete <role> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_role[ecctl platform role]	 - Manages platform roles (Available for ECE only)
+* xref:ecctl_platform_role[ecctl platform role]	 - Manages platform roles {ece-icon}

--- a/docs/ecctl_platform_role_delete.md
+++ b/docs/ecctl_platform_role_delete.md
@@ -1,10 +1,10 @@
 ## ecctl platform role delete
 
-Deletes an existing platform role
+Deletes an existing platform role (Available for ECE only)
 
 ### Synopsis
 
-Deletes an existing platform role
+Deletes an existing platform role (Available for ECE only)
 
 ```
 ecctl platform role delete <role> [flags]

--- a/docs/ecctl_platform_role_list.adoc
+++ b/docs/ecctl_platform_role_list.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_role_list]
 == ecctl platform role list
 
-Lists the existing platform roles
+Lists the existing platform roles (Available for ECE only)
 
 [float]
 === Synopsis
 
-Lists the existing platform roles
+Lists the existing platform roles (Available for ECE only)
 
 ----
 ecctl platform role list [flags]

--- a/docs/ecctl_platform_role_list.adoc
+++ b/docs/ecctl_platform_role_list.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_role_list]
 == ecctl platform role list
 
-Lists the existing platform roles (Available for ECE only)
+Lists the existing platform roles {ece-icon}
 
 [float]
 === Synopsis
 
-Lists the existing platform roles (Available for ECE only)
+Lists the existing platform roles {ece-icon}
 
 ----
 ecctl platform role list [flags]
@@ -44,4 +44,4 @@ ecctl platform role list [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_role[ecctl platform role]	 - Manages platform roles (Available for ECE only)
+* xref:ecctl_platform_role[ecctl platform role]	 - Manages platform roles {ece-icon}

--- a/docs/ecctl_platform_role_list.md
+++ b/docs/ecctl_platform_role_list.md
@@ -1,10 +1,10 @@
 ## ecctl platform role list
 
-Lists the existing platform roles
+Lists the existing platform roles (Available for ECE only)
 
 ### Synopsis
 
-Lists the existing platform roles
+Lists the existing platform roles (Available for ECE only)
 
 ```
 ecctl platform role list [flags]

--- a/docs/ecctl_platform_role_show.adoc
+++ b/docs/ecctl_platform_role_show.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_role_show]
 == ecctl platform role show
 
-Shows the existing platform roles (Available for ECE only)
+Shows the existing platform roles {ece-icon}
 
 [float]
 === Synopsis
 
-Shows the existing platform roles (Available for ECE only)
+Shows the existing platform roles {ece-icon}
 
 ----
 ecctl platform role show <role> [flags]
@@ -44,4 +44,4 @@ ecctl platform role show <role> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_role[ecctl platform role]	 - Manages platform roles (Available for ECE only)
+* xref:ecctl_platform_role[ecctl platform role]	 - Manages platform roles {ece-icon}

--- a/docs/ecctl_platform_role_show.adoc
+++ b/docs/ecctl_platform_role_show.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_role_show]
 == ecctl platform role show
 
-Shows the existing platform roles
+Shows the existing platform roles (Available for ECE only)
 
 [float]
 === Synopsis
 
-Shows the existing platform roles
+Shows the existing platform roles (Available for ECE only)
 
 ----
 ecctl platform role show <role> [flags]

--- a/docs/ecctl_platform_role_show.md
+++ b/docs/ecctl_platform_role_show.md
@@ -1,10 +1,10 @@
 ## ecctl platform role show
 
-Shows the existing platform roles
+Shows the existing platform roles (Available for ECE only)
 
 ### Synopsis
 
-Shows the existing platform roles
+Shows the existing platform roles (Available for ECE only)
 
 ```
 ecctl platform role show <role> [flags]

--- a/docs/ecctl_platform_runner.adoc
+++ b/docs/ecctl_platform_runner.adoc
@@ -44,8 +44,8 @@ ecctl platform runner [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform[ecctl platform]	 - Manages the platform
-* xref:ecctl_platform_runner_list[ecctl platform runner list]	 - Lists the existing platform runners
-* xref:ecctl_platform_runner_resync[ecctl platform runner resync]	 - Resynchronizes the search index and cache for the selected runner or all
-* xref:ecctl_platform_runner_search[ecctl platform runner search]	 - Performs advanced runner searching
-* xref:ecctl_platform_runner_show[ecctl platform runner show]	 - Shows information about the specified runner
+* xref:ecctl_platform[ecctl platform]	 - Manages the platform (Available for ECE only)
+* xref:ecctl_platform_runner_list[ecctl platform runner list]	 - Lists the existing platform runners (Available for ECE only)
+* xref:ecctl_platform_runner_resync[ecctl platform runner resync]	 - Resynchronizes the search index and cache for the selected runner or all (Available for ECE only)
+* xref:ecctl_platform_runner_search[ecctl platform runner search]	 - Performs advanced runner searching (Available for ECE only)
+* xref:ecctl_platform_runner_show[ecctl platform runner show]	 - Shows information about the specified runner (Available for ECE only)

--- a/docs/ecctl_platform_runner.adoc
+++ b/docs/ecctl_platform_runner.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_runner]
 == ecctl platform runner
 
-Manages platform runners (Available for ECE only)
+Manages platform runners {ece-icon}
 
 [float]
 === Synopsis
 
-Manages platform runners (Available for ECE only)
+Manages platform runners {ece-icon}
 
 ----
 ecctl platform runner [flags]
@@ -44,8 +44,8 @@ ecctl platform runner [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform[ecctl platform]	 - Manages the platform (Available for ECE only)
-* xref:ecctl_platform_runner_list[ecctl platform runner list]	 - Lists the existing platform runners (Available for ECE only)
-* xref:ecctl_platform_runner_resync[ecctl platform runner resync]	 - Resynchronizes the search index and cache for the selected runner or all (Available for ECE only)
-* xref:ecctl_platform_runner_search[ecctl platform runner search]	 - Performs advanced runner searching (Available for ECE only)
-* xref:ecctl_platform_runner_show[ecctl platform runner show]	 - Shows information about the specified runner (Available for ECE only)
+* xref:ecctl_platform[ecctl platform]	 - Manages the platform {ece-icon}
+* xref:ecctl_platform_runner_list[ecctl platform runner list]	 - Lists the existing platform runners {ece-icon}
+* xref:ecctl_platform_runner_resync[ecctl platform runner resync]	 - Resynchronizes the search index and cache for the selected runner or all {ece-icon}
+* xref:ecctl_platform_runner_search[ecctl platform runner search]	 - Performs advanced runner searching {ece-icon}
+* xref:ecctl_platform_runner_show[ecctl platform runner show]	 - Shows information about the specified runner {ece-icon}

--- a/docs/ecctl_platform_runner.md
+++ b/docs/ecctl_platform_runner.md
@@ -39,9 +39,9 @@ ecctl platform runner [flags]
 
 ### SEE ALSO
 
-* [ecctl platform](ecctl_platform.md)	 - Manages the platform
-* [ecctl platform runner list](ecctl_platform_runner_list.md)	 - Lists the existing platform runners
-* [ecctl platform runner resync](ecctl_platform_runner_resync.md)	 - Resynchronizes the search index and cache for the selected runner or all
-* [ecctl platform runner search](ecctl_platform_runner_search.md)	 - Performs advanced runner searching
-* [ecctl platform runner show](ecctl_platform_runner_show.md)	 - Shows information about the specified runner
+* [ecctl platform](ecctl_platform.md)	 - Manages the platform (Available for ECE only)
+* [ecctl platform runner list](ecctl_platform_runner_list.md)	 - Lists the existing platform runners (Available for ECE only)
+* [ecctl platform runner resync](ecctl_platform_runner_resync.md)	 - Resynchronizes the search index and cache for the selected runner or all (Available for ECE only)
+* [ecctl platform runner search](ecctl_platform_runner_search.md)	 - Performs advanced runner searching (Available for ECE only)
+* [ecctl platform runner show](ecctl_platform_runner_show.md)	 - Shows information about the specified runner (Available for ECE only)
 

--- a/docs/ecctl_platform_runner_list.adoc
+++ b/docs/ecctl_platform_runner_list.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_runner_list]
 == ecctl platform runner list
 
-Lists the existing platform runners
+Lists the existing platform runners (Available for ECE only)
 
 [float]
 === Synopsis
 
-Lists the existing platform runners
+Lists the existing platform runners (Available for ECE only)
 
 ----
 ecctl platform runner list [flags]

--- a/docs/ecctl_platform_runner_list.adoc
+++ b/docs/ecctl_platform_runner_list.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_runner_list]
 == ecctl platform runner list
 
-Lists the existing platform runners (Available for ECE only)
+Lists the existing platform runners {ece-icon}
 
 [float]
 === Synopsis
 
-Lists the existing platform runners (Available for ECE only)
+Lists the existing platform runners {ece-icon}
 
 ----
 ecctl platform runner list [flags]
@@ -44,4 +44,4 @@ ecctl platform runner list [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_runner[ecctl platform runner]	 - Manages platform runners (Available for ECE only)
+* xref:ecctl_platform_runner[ecctl platform runner]	 - Manages platform runners {ece-icon}

--- a/docs/ecctl_platform_runner_list.md
+++ b/docs/ecctl_platform_runner_list.md
@@ -1,10 +1,10 @@
 ## ecctl platform runner list
 
-Lists the existing platform runners
+Lists the existing platform runners (Available for ECE only)
 
 ### Synopsis
 
-Lists the existing platform runners
+Lists the existing platform runners (Available for ECE only)
 
 ```
 ecctl platform runner list [flags]

--- a/docs/ecctl_platform_runner_resync.adoc
+++ b/docs/ecctl_platform_runner_resync.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_runner_resync]
 == ecctl platform runner resync
 
-Resynchronizes the search index and cache for the selected runner or all (Available for ECE only)
+Resynchronizes the search index and cache for the selected runner or all {ece-icon}
 
 [float]
 === Synopsis
 
-Resynchronizes the search index and cache for the selected runner or all (Available for ECE only)
+Resynchronizes the search index and cache for the selected runner or all {ece-icon}
 
 ----
 ecctl platform runner resync {<runner id> | --all} [flags]
@@ -45,4 +45,4 @@ ecctl platform runner resync {<runner id> | --all} [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_runner[ecctl platform runner]	 - Manages platform runners (Available for ECE only)
+* xref:ecctl_platform_runner[ecctl platform runner]	 - Manages platform runners {ece-icon}

--- a/docs/ecctl_platform_runner_resync.adoc
+++ b/docs/ecctl_platform_runner_resync.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_runner_resync]
 == ecctl platform runner resync
 
-Resynchronizes the search index and cache for the selected runner or all
+Resynchronizes the search index and cache for the selected runner or all (Available for ECE only)
 
 [float]
 === Synopsis
 
-Resynchronizes the search index and cache for the selected runner or all
+Resynchronizes the search index and cache for the selected runner or all (Available for ECE only)
 
 ----
 ecctl platform runner resync {<runner id> | --all} [flags]

--- a/docs/ecctl_platform_runner_resync.md
+++ b/docs/ecctl_platform_runner_resync.md
@@ -1,10 +1,10 @@
 ## ecctl platform runner resync
 
-Resynchronizes the search index and cache for the selected runner or all
+Resynchronizes the search index and cache for the selected runner or all (Available for ECE only)
 
 ### Synopsis
 
-Resynchronizes the search index and cache for the selected runner or all
+Resynchronizes the search index and cache for the selected runner or all (Available for ECE only)
 
 ```
 ecctl platform runner resync {<runner id> | --all} [flags]

--- a/docs/ecctl_platform_runner_search.adoc
+++ b/docs/ecctl_platform_runner_search.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_runner_search]
 == ecctl platform runner search
 
-Performs advanced runner searching
+Performs advanced runner searching (Available for ECE only)
 
 [float]
 === Synopsis

--- a/docs/ecctl_platform_runner_search.adoc
+++ b/docs/ecctl_platform_runner_search.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_runner_search]
 == ecctl platform runner search
 
-Performs advanced runner searching (Available for ECE only)
+Performs advanced runner searching {ece-icon}
 
 [float]
 === Synopsis
@@ -46,4 +46,4 @@ ecctl platform runner search [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_runner[ecctl platform runner]	 - Manages platform runners (Available for ECE only)
+* xref:ecctl_platform_runner[ecctl platform runner]	 - Manages platform runners {ece-icon}

--- a/docs/ecctl_platform_runner_search.md
+++ b/docs/ecctl_platform_runner_search.md
@@ -1,6 +1,6 @@
 ## ecctl platform runner search
 
-Performs advanced runner searching
+Performs advanced runner searching (Available for ECE only)
 
 ### Synopsis
 

--- a/docs/ecctl_platform_runner_show.adoc
+++ b/docs/ecctl_platform_runner_show.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_runner_show]
 == ecctl platform runner show
 
-Shows information about the specified runner (Available for ECE only)
+Shows information about the specified runner {ece-icon}
 
 [float]
 === Synopsis
 
-Shows information about the specified runner (Available for ECE only)
+Shows information about the specified runner {ece-icon}
 
 ----
 ecctl platform runner show <runner id> [flags]
@@ -44,4 +44,4 @@ ecctl platform runner show <runner id> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_runner[ecctl platform runner]	 - Manages platform runners (Available for ECE only)
+* xref:ecctl_platform_runner[ecctl platform runner]	 - Manages platform runners {ece-icon}

--- a/docs/ecctl_platform_runner_show.adoc
+++ b/docs/ecctl_platform_runner_show.adoc
@@ -1,12 +1,12 @@
 [#ecctl_platform_runner_show]
 == ecctl platform runner show
 
-Shows information about the specified runner
+Shows information about the specified runner (Available for ECE only)
 
 [float]
 === Synopsis
 
-Shows information about the specified runner
+Shows information about the specified runner (Available for ECE only)
 
 ----
 ecctl platform runner show <runner id> [flags]

--- a/docs/ecctl_platform_runner_show.md
+++ b/docs/ecctl_platform_runner_show.md
@@ -1,10 +1,10 @@
 ## ecctl platform runner show
 
-Shows information about the specified runner
+Shows information about the specified runner (Available for ECE only)
 
 ### Synopsis
 
-Shows information about the specified runner
+Shows information about the specified runner (Available for ECE only)
 
 ```
 ecctl platform runner show <runner id> [flags]

--- a/docs/ecctl_stack.adoc
+++ b/docs/ecctl_stack.adoc
@@ -45,7 +45,7 @@ ecctl stack [flags]
 === SEE ALSO
 
 * xref:ecctl[ecctl]	 - Elastic Cloud Control
-* xref:ecctl_stack_delete[ecctl stack delete]	 - Deletes an Elastic StackPack (Available for ECE only)
+* xref:ecctl_stack_delete[ecctl stack delete]	 - Deletes an Elastic StackPack {ece-icon}
 * xref:ecctl_stack_list[ecctl stack list]	 - Lists Elastic StackPacks
 * xref:ecctl_stack_show[ecctl stack show]	 - Shows information about an Elastic StackPack
-* xref:ecctl_stack_upload[ecctl stack upload]	 - Uploads an Elastic StackPack (Available for ECE only)
+* xref:ecctl_stack_upload[ecctl stack upload]	 - Uploads an Elastic StackPack {ece-icon}

--- a/docs/ecctl_stack_delete.adoc
+++ b/docs/ecctl_stack_delete.adoc
@@ -1,12 +1,12 @@
 [#ecctl_stack_delete]
 == ecctl stack delete
 
-Deletes an Elastic StackPack (Available for ECE only)
+Deletes an Elastic StackPack {ece-icon}
 
 [float]
 === Synopsis
 
-Deletes an Elastic StackPack (Available for ECE only)
+Deletes an Elastic StackPack {ece-icon}
 
 ----
 ecctl stack delete [flags]

--- a/docs/ecctl_stack_upload.adoc
+++ b/docs/ecctl_stack_upload.adoc
@@ -1,12 +1,12 @@
 [#ecctl_stack_upload]
 == ecctl stack upload
 
-Uploads an Elastic StackPack (Available for ECE only)
+Uploads an Elastic StackPack {ece-icon}
 
 [float]
 === Synopsis
 
-Uploads an Elastic StackPack (Available for ECE only)
+Uploads an Elastic StackPack {ece-icon}
 
 ----
 ecctl stack upload [flags]

--- a/docs/ecctl_user.adoc
+++ b/docs/ecctl_user.adoc
@@ -45,11 +45,11 @@ ecctl user [flags]
 === SEE ALSO
 
 * xref:ecctl[ecctl]	 - Elastic Cloud Control
-* xref:ecctl_user_create[ecctl user create]	 - Creates a new platform user
-* xref:ecctl_user_delete[ecctl user delete]	 - Deletes one or more platform users
-* xref:ecctl_user_disable[ecctl user disable]	 - Disables a platform user
-* xref:ecctl_user_enable[ecctl user enable]	 - Enables a previously disabled platform user
+* xref:ecctl_user_create[ecctl user create]	 - Creates a new platform user (Available for ECE only)
+* xref:ecctl_user_delete[ecctl user delete]	 - Deletes one or more platform users (Available for ECE only)
+* xref:ecctl_user_disable[ecctl user disable]	 - Disables a platform user (Available for ECE only)
+* xref:ecctl_user_enable[ecctl user enable]	 - Enables a previously disabled platform user (Available for ECE only)
 * xref:ecctl_user_key[ecctl user key]	 - Manages the API keys of a platform user
-* xref:ecctl_user_list[ecctl user list]	 - Lists all platform users
-* xref:ecctl_user_show[ecctl user show]	 - Shows details of a specified user
-* xref:ecctl_user_update[ecctl user update]	 - Updates a platform user
+* xref:ecctl_user_list[ecctl user list]	 - Lists all platform users (Available for ECE only)
+* xref:ecctl_user_show[ecctl user show]	 - Shows details of a specified user (Available for ECE only)
+* xref:ecctl_user_update[ecctl user update]	 - Updates a platform user (Available for ECE only)

--- a/docs/ecctl_user.adoc
+++ b/docs/ecctl_user.adoc
@@ -1,12 +1,12 @@
 [#ecctl_user]
 == ecctl user
 
-Manages the platform users (Available for ECE only)
+Manages the platform users {ece-icon}
 
 [float]
 === Synopsis
 
-Manages the platform users (Available for ECE only)
+Manages the platform users {ece-icon}
 
 ----
 ecctl user [flags]
@@ -45,11 +45,11 @@ ecctl user [flags]
 === SEE ALSO
 
 * xref:ecctl[ecctl]	 - Elastic Cloud Control
-* xref:ecctl_user_create[ecctl user create]	 - Creates a new platform user (Available for ECE only)
-* xref:ecctl_user_delete[ecctl user delete]	 - Deletes one or more platform users (Available for ECE only)
-* xref:ecctl_user_disable[ecctl user disable]	 - Disables a platform user (Available for ECE only)
-* xref:ecctl_user_enable[ecctl user enable]	 - Enables a previously disabled platform user (Available for ECE only)
+* xref:ecctl_user_create[ecctl user create]	 - Creates a new platform user {ece-icon}
+* xref:ecctl_user_delete[ecctl user delete]	 - Deletes one or more platform users {ece-icon}
+* xref:ecctl_user_disable[ecctl user disable]	 - Disables a platform user {ece-icon}
+* xref:ecctl_user_enable[ecctl user enable]	 - Enables a previously disabled platform user {ece-icon}
 * xref:ecctl_user_key[ecctl user key]	 - Manages the API keys of a platform user
-* xref:ecctl_user_list[ecctl user list]	 - Lists all platform users (Available for ECE only)
-* xref:ecctl_user_show[ecctl user show]	 - Shows details of a specified user (Available for ECE only)
-* xref:ecctl_user_update[ecctl user update]	 - Updates a platform user (Available for ECE only)
+* xref:ecctl_user_list[ecctl user list]	 - Lists all platform users {ece-icon}
+* xref:ecctl_user_show[ecctl user show]	 - Shows details of a specified user {ece-icon}
+* xref:ecctl_user_update[ecctl user update]	 - Updates a platform user {ece-icon}

--- a/docs/ecctl_user.md
+++ b/docs/ecctl_user.md
@@ -40,12 +40,12 @@ ecctl user [flags]
 ### SEE ALSO
 
 * [ecctl](ecctl.md)	 - Elastic Cloud Control
-* [ecctl user create](ecctl_user_create.md)	 - Creates a new platform user
-* [ecctl user delete](ecctl_user_delete.md)	 - Deletes one or more platform users
-* [ecctl user disable](ecctl_user_disable.md)	 - Disables a platform user
-* [ecctl user enable](ecctl_user_enable.md)	 - Enables a previously disabled platform user
+* [ecctl user create](ecctl_user_create.md)	 - Creates a new platform user (Available for ECE only)
+* [ecctl user delete](ecctl_user_delete.md)	 - Deletes one or more platform users (Available for ECE only)
+* [ecctl user disable](ecctl_user_disable.md)	 - Disables a platform user (Available for ECE only)
+* [ecctl user enable](ecctl_user_enable.md)	 - Enables a previously disabled platform user (Available for ECE only)
 * [ecctl user key](ecctl_user_key.md)	 - Manages the API keys of a platform user
-* [ecctl user list](ecctl_user_list.md)	 - Lists all platform users
-* [ecctl user show](ecctl_user_show.md)	 - Shows details of a specified user
-* [ecctl user update](ecctl_user_update.md)	 - Updates a platform user
+* [ecctl user list](ecctl_user_list.md)	 - Lists all platform users (Available for ECE only)
+* [ecctl user show](ecctl_user_show.md)	 - Shows details of a specified user (Available for ECE only)
+* [ecctl user update](ecctl_user_update.md)	 - Updates a platform user (Available for ECE only)
 

--- a/docs/ecctl_user_create.adoc
+++ b/docs/ecctl_user_create.adoc
@@ -1,12 +1,12 @@
 [#ecctl_user_create]
 == ecctl user create
 
-Creates a new platform user
+Creates a new platform user (Available for ECE only)
 
 [float]
 === Synopsis
 
-Creates a new platform user
+Creates a new platform user (Available for ECE only)
 
 ----
 ecctl user create --username <username> --role <role> [flags]

--- a/docs/ecctl_user_create.adoc
+++ b/docs/ecctl_user_create.adoc
@@ -1,12 +1,12 @@
 [#ecctl_user_create]
 == ecctl user create
 
-Creates a new platform user (Available for ECE only)
+Creates a new platform user {ece-icon}
 
 [float]
 === Synopsis
 
-Creates a new platform user (Available for ECE only)
+Creates a new platform user {ece-icon}
 
 ----
 ecctl user create --username <username> --role <role> [flags]
@@ -59,4 +59,4 @@ ecctl user create --username <username> --role <role> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_user[ecctl user]	 - Manages the platform users (Available for ECE only)
+* xref:ecctl_user[ecctl user]	 - Manages the platform users {ece-icon}

--- a/docs/ecctl_user_create.md
+++ b/docs/ecctl_user_create.md
@@ -1,10 +1,10 @@
 ## ecctl user create
 
-Creates a new platform user
+Creates a new platform user (Available for ECE only)
 
 ### Synopsis
 
-Creates a new platform user
+Creates a new platform user (Available for ECE only)
 
 ```
 ecctl user create --username <username> --role <role> [flags]

--- a/docs/ecctl_user_delete.adoc
+++ b/docs/ecctl_user_delete.adoc
@@ -1,12 +1,12 @@
 [#ecctl_user_delete]
 == ecctl user delete
 
-Deletes one or more platform users
+Deletes one or more platform users (Available for ECE only)
 
 [float]
 === Synopsis
 
-Deletes one or more platform users
+Deletes one or more platform users (Available for ECE only)
 
 ----
 ecctl user delete <user name> <user name>... [flags]

--- a/docs/ecctl_user_delete.adoc
+++ b/docs/ecctl_user_delete.adoc
@@ -1,12 +1,12 @@
 [#ecctl_user_delete]
 == ecctl user delete
 
-Deletes one or more platform users (Available for ECE only)
+Deletes one or more platform users {ece-icon}
 
 [float]
 === Synopsis
 
-Deletes one or more platform users (Available for ECE only)
+Deletes one or more platform users {ece-icon}
 
 ----
 ecctl user delete <user name> <user name>... [flags]
@@ -44,4 +44,4 @@ ecctl user delete <user name> <user name>... [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_user[ecctl user]	 - Manages the platform users (Available for ECE only)
+* xref:ecctl_user[ecctl user]	 - Manages the platform users {ece-icon}

--- a/docs/ecctl_user_delete.md
+++ b/docs/ecctl_user_delete.md
@@ -1,10 +1,10 @@
 ## ecctl user delete
 
-Deletes one or more platform users
+Deletes one or more platform users (Available for ECE only)
 
 ### Synopsis
 
-Deletes one or more platform users
+Deletes one or more platform users (Available for ECE only)
 
 ```
 ecctl user delete <user name> <user name>... [flags]

--- a/docs/ecctl_user_disable.adoc
+++ b/docs/ecctl_user_disable.adoc
@@ -1,12 +1,12 @@
 [#ecctl_user_disable]
 == ecctl user disable
 
-Disables a platform user
+Disables a platform user (Available for ECE only)
 
 [float]
 === Synopsis
 
-Disables a platform user
+Disables a platform user (Available for ECE only)
 
 ----
 ecctl user disable <username> [flags]

--- a/docs/ecctl_user_disable.adoc
+++ b/docs/ecctl_user_disable.adoc
@@ -1,12 +1,12 @@
 [#ecctl_user_disable]
 == ecctl user disable
 
-Disables a platform user (Available for ECE only)
+Disables a platform user {ece-icon}
 
 [float]
 === Synopsis
 
-Disables a platform user (Available for ECE only)
+Disables a platform user {ece-icon}
 
 ----
 ecctl user disable <username> [flags]
@@ -44,4 +44,4 @@ ecctl user disable <username> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_user[ecctl user]	 - Manages the platform users (Available for ECE only)
+* xref:ecctl_user[ecctl user]	 - Manages the platform users {ece-icon}

--- a/docs/ecctl_user_disable.md
+++ b/docs/ecctl_user_disable.md
@@ -1,10 +1,10 @@
 ## ecctl user disable
 
-Disables a platform user
+Disables a platform user (Available for ECE only)
 
 ### Synopsis
 
-Disables a platform user
+Disables a platform user (Available for ECE only)
 
 ```
 ecctl user disable <username> [flags]

--- a/docs/ecctl_user_enable.adoc
+++ b/docs/ecctl_user_enable.adoc
@@ -1,12 +1,12 @@
 [#ecctl_user_enable]
 == ecctl user enable
 
-Enables a previously disabled platform user
+Enables a previously disabled platform user (Available for ECE only)
 
 [float]
 === Synopsis
 
-Enables a previously disabled platform user
+Enables a previously disabled platform user (Available for ECE only)
 
 ----
 ecctl user enable <username> [flags]

--- a/docs/ecctl_user_enable.adoc
+++ b/docs/ecctl_user_enable.adoc
@@ -1,12 +1,12 @@
 [#ecctl_user_enable]
 == ecctl user enable
 
-Enables a previously disabled platform user (Available for ECE only)
+Enables a previously disabled platform user {ece-icon}
 
 [float]
 === Synopsis
 
-Enables a previously disabled platform user (Available for ECE only)
+Enables a previously disabled platform user {ece-icon}
 
 ----
 ecctl user enable <username> [flags]
@@ -44,4 +44,4 @@ ecctl user enable <username> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_user[ecctl user]	 - Manages the platform users (Available for ECE only)
+* xref:ecctl_user[ecctl user]	 - Manages the platform users {ece-icon}

--- a/docs/ecctl_user_enable.md
+++ b/docs/ecctl_user_enable.md
@@ -1,10 +1,10 @@
 ## ecctl user enable
 
-Enables a previously disabled platform user
+Enables a previously disabled platform user (Available for ECE only)
 
 ### Synopsis
 
-Enables a previously disabled platform user
+Enables a previously disabled platform user (Available for ECE only)
 
 ```
 ecctl user enable <username> [flags]

--- a/docs/ecctl_user_key.adoc
+++ b/docs/ecctl_user_key.adoc
@@ -44,7 +44,7 @@ ecctl user key [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_user[ecctl user]	 - Manages the platform users (Available for ECE only)
+* xref:ecctl_user[ecctl user]	 - Manages the platform users {ece-icon}
 * xref:ecctl_user_key_delete[ecctl user key delete]	 - Deletes an existing API key for the specified user
 * xref:ecctl_user_key_list[ecctl user key list]	 - Lists the API keys for the specified user, or all platform users
 * xref:ecctl_user_key_show[ecctl user key show]	 - Shows the API key details for the specified user

--- a/docs/ecctl_user_list.adoc
+++ b/docs/ecctl_user_list.adoc
@@ -1,12 +1,12 @@
 [#ecctl_user_list]
 == ecctl user list
 
-Lists all platform users
+Lists all platform users (Available for ECE only)
 
 [float]
 === Synopsis
 
-Lists all platform users
+Lists all platform users (Available for ECE only)
 
 ----
 ecctl user list [flags]

--- a/docs/ecctl_user_list.adoc
+++ b/docs/ecctl_user_list.adoc
@@ -1,12 +1,12 @@
 [#ecctl_user_list]
 == ecctl user list
 
-Lists all platform users (Available for ECE only)
+Lists all platform users {ece-icon}
 
 [float]
 === Synopsis
 
-Lists all platform users (Available for ECE only)
+Lists all platform users {ece-icon}
 
 ----
 ecctl user list [flags]
@@ -44,4 +44,4 @@ ecctl user list [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_user[ecctl user]	 - Manages the platform users (Available for ECE only)
+* xref:ecctl_user[ecctl user]	 - Manages the platform users {ece-icon}

--- a/docs/ecctl_user_list.md
+++ b/docs/ecctl_user_list.md
@@ -1,10 +1,10 @@
 ## ecctl user list
 
-Lists all platform users
+Lists all platform users (Available for ECE only)
 
 ### Synopsis
 
-Lists all platform users
+Lists all platform users (Available for ECE only)
 
 ```
 ecctl user list [flags]

--- a/docs/ecctl_user_show.adoc
+++ b/docs/ecctl_user_show.adoc
@@ -1,12 +1,12 @@
 [#ecctl_user_show]
 == ecctl user show
 
-Shows details of a specified user (Available for ECE only)
+Shows details of a specified user {ece-icon}
 
 [float]
 === Synopsis
 
-Shows details of a specified user (Available for ECE only)
+Shows details of a specified user {ece-icon}
 
 ----
 ecctl user show <user name> [flags]
@@ -45,4 +45,4 @@ ecctl user show <user name> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_user[ecctl user]	 - Manages the platform users (Available for ECE only)
+* xref:ecctl_user[ecctl user]	 - Manages the platform users {ece-icon}

--- a/docs/ecctl_user_show.adoc
+++ b/docs/ecctl_user_show.adoc
@@ -1,12 +1,12 @@
 [#ecctl_user_show]
 == ecctl user show
 
-Shows details of a specified user
+Shows details of a specified user (Available for ECE only)
 
 [float]
 === Synopsis
 
-Shows details of a specified user
+Shows details of a specified user (Available for ECE only)
 
 ----
 ecctl user show <user name> [flags]

--- a/docs/ecctl_user_show.md
+++ b/docs/ecctl_user_show.md
@@ -1,10 +1,10 @@
 ## ecctl user show
 
-Shows details of a specified user
+Shows details of a specified user (Available for ECE only)
 
 ### Synopsis
 
-Shows details of a specified user
+Shows details of a specified user (Available for ECE only)
 
 ```
 ecctl user show <user name> [flags]

--- a/docs/ecctl_user_update.adoc
+++ b/docs/ecctl_user_update.adoc
@@ -1,12 +1,12 @@
 [#ecctl_user_update]
 == ecctl user update
 
-Updates a platform user
+Updates a platform user (Available for ECE only)
 
 [float]
 === Synopsis
 
-Updates a platform user
+Updates a platform user (Available for ECE only)
 
 ----
 ecctl user update <username> --role <role> [flags]

--- a/docs/ecctl_user_update.adoc
+++ b/docs/ecctl_user_update.adoc
@@ -1,12 +1,12 @@
 [#ecctl_user_update]
 == ecctl user update
 
-Updates a platform user (Available for ECE only)
+Updates a platform user {ece-icon}
 
 [float]
 === Synopsis
 
-Updates a platform user (Available for ECE only)
+Updates a platform user {ece-icon}
 
 ----
 ecctl user update <username> --role <role> [flags]
@@ -64,4 +64,4 @@ ecctl user update <username> --role <role> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_user[ecctl user]	 - Manages the platform users (Available for ECE only)
+* xref:ecctl_user[ecctl user]	 - Manages the platform users {ece-icon}

--- a/docs/ecctl_user_update.md
+++ b/docs/ecctl_user_update.md
@@ -1,10 +1,10 @@
 ## ecctl user update
 
-Updates a platform user
+Updates a platform user (Available for ECE only)
 
 ### Synopsis
 
-Updates a platform user
+Updates a platform user (Available for ECE only)
 
 ```
 ecctl user update <username> --role <role> [flags]

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -39,6 +39,9 @@ done
 # Strip extraneous .adoc out of section IDs and xrefs
 sed -i'.bak' -e 's/\.adoc//g' ecctl*.adoc
 
+# Replace ECE availability text for ece icon
+sed -i'.bak' -e 's/(Available for ECE only)/{ece-icon}/g' ecctl*.adoc
+
 # Add [float] tags to H3 sections to keep content together
 sed -i'.bak' -e 's/===/\[float]\
 &/g' ecctl*.adoc


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
This PR is separated in to two.

The first commit adds ECE specific text to all subcommands not just commands as it was before.

The second commit substitutes this text for `{ece-icon}` so our online documentation looks better with an icon instead of text.

@nrichers I'm assuming this will work fine? I looked at the kibana repo and didn't find any actual icon added to their repo

## Related Issues
Related: https://github.com/elastic/ecctl/issues/335

## Motivation and Context
Make the docs pretty 😊 

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Documentation

