### PR TITLE
create: Use standard enterprise_search instead of enterprise-search

### DIFF
--- a/cmd/deployment/create.go
+++ b/cmd/deployment/create.go
@@ -68,10 +68,10 @@ var createCmd = &cobra.Command{
 		var appsearchSize, _ = cmd.Flags().GetInt32("appsearch-size")
 		var appsearchRefID, _ = cmd.Flags().GetString("appsearch-ref-id")
 
-		var enterpriseSearchEnable, _ = cmd.Flags().GetBool("enterprise-search")
-		var enterpriseSearchZoneCount, _ = cmd.Flags().GetInt32("enterprise-search-zones")
-		var enterpriseSearchSize, _ = cmd.Flags().GetInt32("enterprise-search-size")
-		var enterpriseSearchRefID, _ = cmd.Flags().GetString("enterprise-search-ref-id")
+		var enterpriseSearchEnable, _ = cmd.Flags().GetBool("enterprise_search")
+		var enterpriseSearchZoneCount, _ = cmd.Flags().GetInt32("enterprise_search-zones")
+		var enterpriseSearchSize, _ = cmd.Flags().GetInt32("enterprise_search-size")
+		var enterpriseSearchRefID, _ = cmd.Flags().GetString("enterprise_search-ref-id")
 
 		var payload *models.DeploymentCreateRequest
 
@@ -202,10 +202,10 @@ func initFlags() {
 	createCmd.Flags().Int32("appsearch-zones", 1, "Number of zones the App Search instances will span")
 	createCmd.Flags().Int32("appsearch-size", 2048, "Memory (RAM) in MB that each of the App Search instances will have")
 
-	createCmd.Flags().Bool("enterprise-search", false, "Enables Enterprise Search for the deployment")
-	createCmd.Flags().String("enterprise-search-ref-id", "main-enterprise_search", "Optional RefId for the Enterprise Search deployment")
-	createCmd.Flags().Int32("enterprise-search-zones", 1, "Number of zones the Enterprise Search instances will span")
-	createCmd.Flags().Int32("enterprise-search-size", 4096, "Memory (RAM) in MB that each of the Enterprise Search instances will have")
+	createCmd.Flags().Bool("enterprise_search", false, "Enables Enterprise Search for the deployment")
+	createCmd.Flags().String("enterprise_search-ref-id", "main-enterprise_search", "Optional RefId for the Enterprise Search deployment")
+	createCmd.Flags().Int32("enterprise_search-zones", 1, "Number of zones the Enterprise Search instances will span")
+	createCmd.Flags().Int32("enterprise_search-size", 4096, "Memory (RAM) in MB that each of the Enterprise Search instances will have")
 
 	// Remove in the next version.
 	createCmd.Flags().Bool("dt-as-list", true, "")

--- a/cmd/deployment/create_help.go
+++ b/cmd/deployment/create_help.go
@@ -42,7 +42,7 @@ Save it, update or extend the topology and create a deployment using the saved p
 	// nolint
 	createExample = `## Create a deployment with the default values for Elasticsearch, a Kibana instance with a modified size, 
 and a default APM instance. While Elasticsearch and Kibana come enabled by default, APM, Enterprise Search and App Search need to be 
-enabled by using the "--apm", "--enterprise-search" and "--appsearch" flags. The command will exit after the API response has been returned, without 
+enabled by using the "--apm", "--enterprise_search" and "--appsearch" flags. The command will exit after the API response has been returned, without 
 waiting until the deployment resources have been created. 
 $ ecctl deployment create --name my-deployment --zones 2 --kibana-size 2048 --apm --apm-size 1024
 

--- a/cmd/deployment/create_test.go
+++ b/cmd/deployment/create_test.go
@@ -547,7 +547,7 @@ Deployment [%s] - [Apm][%s]: running step "waiting-for-some-step" (Plan duration
 			args: testutils.Args{
 				Cmd: createCmd,
 				Args: []string{
-					"create", "--apm", "--appsearch", "--enterprise-search", "--request-id=some_request_id", "--version=7.8.0",
+					"create", "--apm", "--appsearch", "--enterprise_search", "--request-id=some_request_id", "--version=7.8.0",
 				},
 				Cfg: testutils.MockCfg{Responses: []mock.Response{
 					{

--- a/cmd/deployment/show.go
+++ b/cmd/deployment/show.go
@@ -77,6 +77,10 @@ var showCmd = &cobra.Command{
 }
 
 func init() {
+	initShowFlags()
+}
+
+func initShowFlags() {
 	Command.AddCommand(showCmd)
 	cmdutil.AddKindFlag(showCmd, "Optional", true)
 	showCmd.Flags().String("ref-id", "", "Optional deployment kind RefId, if not set, the RefId will be auto-discovered")

--- a/cmd/deployment/show.go
+++ b/cmd/deployment/show.go
@@ -21,8 +21,6 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi"
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/deputil"
 	sdkcmdutil "github.com/elastic/cloud-sdk-go/pkg/util/cmdutil"
-	"github.com/elastic/cloud-sdk-go/pkg/util/slice"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	cmdutil "github.com/elastic/ecctl/cmd/util"
@@ -36,8 +34,6 @@ const showExample = `
 * Shows apm resource information from a given deployment with a specified ref-id.
   ecctl deployment show <deployment-id> --kind apm --ref-id apm-server`
 
-var acceptedKinds = []string{"apm", "appsearch", "elasticsearch", "kibana"}
-
 var showCmd = &cobra.Command{
 	Use:     "show <deployment-id>",
 	Short:   "Shows the specified deployment resources",
@@ -45,10 +41,6 @@ var showCmd = &cobra.Command{
 	PreRunE: sdkcmdutil.MinimumNArgsAndUUID(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		resourceKind, _ := cmd.Flags().GetString("kind")
-		if resourceKind != "" && !slice.HasString(acceptedKinds, resourceKind) {
-			return errors.Errorf(`"%v" is not a valid resource kind. Accepted resource kinds are: %v`, resourceKind, acceptedKinds)
-		}
-
 		planLogs, _ := cmd.Flags().GetBool("plan-logs")
 		planDefaults, _ := cmd.Flags().GetBool("plan-defaults")
 		planHistory, _ := cmd.Flags().GetBool("plan-history")

--- a/cmd/deployment/show_test.go
+++ b/cmd/deployment/show_test.go
@@ -1,0 +1,406 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmddeployment
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/url"
+	"testing"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+
+	"github.com/elastic/ecctl/cmd/util/testutils"
+)
+
+func Test_showCmd(t *testing.T) {
+	showRawResp, err := ioutil.ReadFile("./testdata/show.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var succeedResp = new(models.DeploymentGetResponse)
+	if err := succeedResp.UnmarshalBinary(showRawResp); err != nil {
+		t.Fatal(err)
+	}
+
+	showJSONOutput, err := json.MarshalIndent(succeedResp, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	showResourceRawResp, err := ioutil.ReadFile("./testdata/show-resource.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var succeedESResp = new(models.ElasticsearchResourceInfo)
+	if err := succeedESResp.UnmarshalBinary(showResourceRawResp); err != nil {
+		t.Fatal(err)
+	}
+
+	showESJSONOutput, err := json.MarshalIndent(succeedESResp, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var succeedKibanaResp = new(models.KibanaResourceInfo)
+	if err := succeedKibanaResp.UnmarshalBinary(showResourceRawResp); err != nil {
+		t.Fatal(err)
+	}
+
+	showKibanaJSONOutput, err := json.MarshalIndent(succeedKibanaResp, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var succeedApmResp = new(models.ApmResourceInfo)
+	if err := succeedApmResp.UnmarshalBinary(showResourceRawResp); err != nil {
+		t.Fatal(err)
+	}
+
+	showApmJSONOutput, err := json.MarshalIndent(succeedApmResp, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var succeedAppSearchResp = new(models.AppSearchResourceInfo)
+	if err := succeedAppSearchResp.UnmarshalBinary(showResourceRawResp); err != nil {
+		t.Fatal(err)
+	}
+
+	showAppSearchJSONOutput, err := json.MarshalIndent(succeedAppSearchResp, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var succeedEnterpriseSearchResp = new(models.EnterpriseSearchResourceInfo)
+	if err := succeedEnterpriseSearchResp.UnmarshalBinary(showResourceRawResp); err != nil {
+		t.Fatal(err)
+	}
+
+	showEnterpriseSearchJSONOutput, err := json.MarshalIndent(succeedEnterpriseSearchResp, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		args testutils.Args
+		want testutils.Assertion
+	}{
+		{
+			name: "fails due empty argument",
+			args: testutils.Args{
+				Cmd: showCmd,
+				Args: []string{
+					"show",
+				},
+				Cfg: testutils.MockCfg{Responses: []mock.Response{
+					mock.SampleInternalError(),
+				}},
+			},
+			want: testutils.Assertion{
+				Err: errors.New("requires at least 1 arg(s), only received 0"),
+			},
+		},
+		{
+			name: "fails due to API error",
+			args: testutils.Args{
+				Cmd: showCmd,
+				Args: []string{
+					"show", "29337f77410e23ab30e15c280060facf",
+				},
+				Cfg: testutils.MockCfg{Responses: []mock.Response{
+					mock.SampleInternalError(),
+				}},
+			},
+			want: testutils.Assertion{
+				Err: mock.MultierrorInternalError,
+			},
+		},
+		{
+			name: "succeeds",
+			args: testutils.Args{
+				Cmd: showCmd,
+				Args: []string{
+					"show", "29337f77410e23ab30e15c280060facf",
+				},
+				Cfg: testutils.MockCfg{
+					OutputFormat: "json",
+					Responses: []mock.Response{
+						mock.New200ResponseAssertion(
+							&mock.RequestAssertion{
+								Header: api.DefaultReadMockHeaders,
+								Method: "GET",
+								Path:   "/api/v1/deployments/29337f77410e23ab30e15c280060facf",
+								Host:   api.DefaultMockHost,
+								Query: url.Values{
+									"convert_legacy_plans": {"false"},
+									"enrich_with_template": {"true"},
+									"show_metadata":        {"false"},
+									"show_plan_defaults":   {"false"},
+									"show_plan_history":    {"false"},
+									"show_plan_logs":       {"false"},
+									"show_plans":           {"false"},
+									"show_security":        {"false"},
+									"show_settings":        {"false"},
+									"show_system_alerts":   {"5"},
+								},
+							},
+							mock.NewByteBody(showRawResp),
+						),
+					},
+				},
+			},
+			want: testutils.Assertion{
+				Stdout: string(showJSONOutput) + "\n",
+			},
+		},
+		{
+			name: "succeeds with elasticsearch kind",
+			args: testutils.Args{
+				Cmd: showCmd,
+				Args: []string{
+					"show", "29337f77410e23ab30e15c280060facf",
+					"--kind=elasticsearch", "--ref-id=main-elasticsearch",
+				},
+				Cfg: testutils.MockCfg{
+					OutputFormat: "json",
+					Responses: []mock.Response{
+						mock.New200ResponseAssertion(
+							&mock.RequestAssertion{
+								Header: api.DefaultReadMockHeaders,
+								Method: "GET",
+								Path:   "/api/v1/deployments/29337f77410e23ab30e15c280060facf/elasticsearch/main-elasticsearch",
+								Host:   api.DefaultMockHost,
+								Query: url.Values{
+									"convert_legacy_plans": {"false"},
+									"enrich_with_template": {"true"},
+									"show_metadata":        {"false"},
+									"show_plan_defaults":   {"false"},
+									"show_plan_history":    {"false"},
+									"show_plan_logs":       {"false"},
+									"show_plans":           {"false"},
+									"show_security":        {"false"},
+									"show_settings":        {"false"},
+									"show_system_alerts":   {"5"},
+								},
+							},
+							mock.NewByteBody(showRawResp),
+						),
+					},
+				},
+			},
+			want: testutils.Assertion{
+				Stdout: string(showESJSONOutput) + "\n",
+			},
+		},
+		{
+			name: "succeeds with kibana kind",
+			args: testutils.Args{
+				Cmd: showCmd,
+				Args: []string{
+					"show", "29337f77410e23ab30e15c280060facf",
+					"--kind=kibana", "--ref-id=main-kibana",
+				},
+				Cfg: testutils.MockCfg{
+					OutputFormat: "json",
+					Responses: []mock.Response{
+						mock.New200ResponseAssertion(
+							&mock.RequestAssertion{
+								Header: api.DefaultReadMockHeaders,
+								Method: "GET",
+								Path:   "/api/v1/deployments/29337f77410e23ab30e15c280060facf/kibana/main-kibana",
+								Host:   api.DefaultMockHost,
+								Query: url.Values{
+									"convert_legacy_plans": {"false"},
+									"show_metadata":        {"false"},
+									"show_plan_defaults":   {"false"},
+									"show_plan_history":    {"false"},
+									"show_plan_logs":       {"false"},
+									"show_plans":           {"false"},
+									"show_settings":        {"false"},
+								},
+							},
+							mock.NewByteBody(showResourceRawResp),
+						),
+					},
+				},
+			},
+			want: testutils.Assertion{
+				Stdout: string(showKibanaJSONOutput) + "\n",
+			},
+		},
+		{
+			name: "succeeds with apm kind",
+			args: testutils.Args{
+				Cmd: showCmd,
+				Args: []string{
+					"show", "29337f77410e23ab30e15c280060facf",
+					"--kind=apm", "--ref-id=main-apm",
+				},
+				Cfg: testutils.MockCfg{
+					OutputFormat: "json",
+					Responses: []mock.Response{
+						mock.New200ResponseAssertion(
+							&mock.RequestAssertion{
+								Header: api.DefaultReadMockHeaders,
+								Method: "GET",
+								Path:   "/api/v1/deployments/29337f77410e23ab30e15c280060facf/apm/main-apm",
+								Host:   api.DefaultMockHost,
+								Query: url.Values{
+									"show_metadata":      {"false"},
+									"show_plan_defaults": {"false"},
+									"show_plan_history":  {"false"},
+									"show_plan_logs":     {"false"},
+									"show_plans":         {"false"},
+									"show_settings":      {"false"},
+								},
+							},
+							mock.NewByteBody(showResourceRawResp),
+						),
+					},
+				},
+			},
+			want: testutils.Assertion{
+				Stdout: string(showApmJSONOutput) + "\n",
+			},
+		},
+		{
+			name: "succeeds with appsearch kind",
+			args: testutils.Args{
+				Cmd: showCmd,
+				Args: []string{
+					"show", "29337f77410e23ab30e15c280060facf",
+					"--kind=appsearch", "--ref-id=main-appsearch",
+				},
+				Cfg: testutils.MockCfg{
+					OutputFormat: "json",
+					Responses: []mock.Response{
+						mock.New200ResponseAssertion(
+							&mock.RequestAssertion{
+								Header: api.DefaultReadMockHeaders,
+								Method: "GET",
+								Path:   "/api/v1/deployments/29337f77410e23ab30e15c280060facf/appsearch/main-appsearch",
+								Host:   api.DefaultMockHost,
+								Query: url.Values{
+									"show_metadata":      {"false"},
+									"show_plan_defaults": {"false"},
+									"show_plan_history":  {"false"},
+									"show_plan_logs":     {"false"},
+									"show_plans":         {"false"},
+									"show_settings":      {"false"},
+								},
+							},
+							mock.NewByteBody(showResourceRawResp),
+						),
+					},
+				},
+			},
+			want: testutils.Assertion{
+				Stdout: string(showAppSearchJSONOutput) + "\n",
+			},
+		},
+		{
+			name: "succeeds with enterprise_search kind",
+			args: testutils.Args{
+				Cmd: showCmd,
+				Args: []string{
+					"show", "29337f77410e23ab30e15c280060facf",
+					"--kind=enterprise_search", "--ref-id=main-enterprise_search",
+				},
+				Cfg: testutils.MockCfg{
+					OutputFormat: "json",
+					Responses: []mock.Response{
+						mock.New200ResponseAssertion(
+							&mock.RequestAssertion{
+								Header: api.DefaultReadMockHeaders,
+								Method: "GET",
+								Path:   "/api/v1/deployments/29337f77410e23ab30e15c280060facf/enterprise_search/main-enterprise_search",
+								Host:   api.DefaultMockHost,
+								Query: url.Values{
+									"show_metadata":      {"false"},
+									"show_plan_defaults": {"false"},
+									"show_plan_history":  {"false"},
+									"show_plan_logs":     {"false"},
+									"show_plans":         {"false"},
+									"show_settings":      {"false"},
+								},
+							},
+							mock.NewByteBody(showResourceRawResp),
+						),
+					},
+				},
+			},
+			want: testutils.Assertion{
+				Stdout: string(showEnterpriseSearchJSONOutput) + "\n",
+			},
+		},
+		{
+			name: "succeeds with show flags set",
+			args: testutils.Args{
+				Cmd: showCmd,
+				Args: []string{
+					"show", "29337f77410e23ab30e15c280060facf", "--plans",
+					"--plan-logs", "--plan-defaults", "--plan-history",
+					"--metadata", "--settings",
+				},
+				Cfg: testutils.MockCfg{
+					OutputFormat: "json",
+					Responses: []mock.Response{
+						mock.New200ResponseAssertion(
+							&mock.RequestAssertion{
+								Header: api.DefaultReadMockHeaders,
+								Method: "GET",
+								Path:   "/api/v1/deployments/29337f77410e23ab30e15c280060facf",
+								Host:   api.DefaultMockHost,
+								Query: url.Values{
+									"convert_legacy_plans": {"false"},
+									"enrich_with_template": {"true"},
+									"show_metadata":        {"true"},
+									"show_plan_defaults":   {"true"},
+									"show_plan_history":    {"true"},
+									"show_plan_logs":       {"true"},
+									"show_plans":           {"true"},
+									"show_security":        {"false"},
+									"show_settings":        {"true"},
+									"show_system_alerts":   {"5"},
+								},
+							},
+							mock.NewByteBody(showResourceRawResp),
+						),
+					},
+				},
+			},
+			want: testutils.Assertion{
+				Stdout: string(showJSONOutput) + "\n",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testutils.RunCmdAssertion(t, tt.args, tt.want)
+			tt.args.Cmd.ResetFlags()
+			defer initShowFlags()
+		})
+	}
+}

--- a/cmd/deployment/testdata/show-resource.json
+++ b/cmd/deployment/testdata/show-resource.json
@@ -1,0 +1,12 @@
+{
+    "healthy": true,
+    "id": "29337f77410e23ab30e15c280060facf",
+    "name": "29337f77410e23ab30e15c280060facf",
+    "resources": {
+        "apm": [],
+        "appsearch": [],
+        "elasticsearch": [],
+        "enterprise_search": [],
+        "kibana": []
+    }
+}

--- a/cmd/deployment/testdata/show.json
+++ b/cmd/deployment/testdata/show.json
@@ -1,0 +1,12 @@
+{
+    "healthy": true,
+    "id": "29337f77410e23ab30e15c280060facf",
+    "name": "29337f77410e23ab30e15c280060facf",
+    "resources": {
+        "apm": [],
+        "appsearch": [],
+        "elasticsearch": [],
+        "enterprise_search": [],
+        "kibana": []
+    }
+}

--- a/docs/ecctl_deployment_create.adoc
+++ b/docs/ecctl_deployment_create.adoc
@@ -28,7 +28,7 @@ ecctl deployment create {--file | --es-size <int> --es-zones <int> | --topology-
 ----
 ## Create a deployment with the default values for Elasticsearch, a Kibana instance with a modified size,
 and a default APM instance. While Elasticsearch and Kibana come enabled by default, APM, Enterprise Search and App Search need to be
-enabled by using the "--apm", "--enterprise-search" and "--appsearch" flags. The command will exit after the API response has been returned, without
+enabled by using the "--apm", "--enterprise_search" and "--appsearch" flags. The command will exit after the API response has been returned, without
 waiting until the deployment resources have been created.
 $ ecctl deployment create --name my-deployment --zones 2 --kibana-size 2048 --apm --apm-size 1024
 
@@ -71,10 +71,10 @@ $ ecctl deployment create --request-id=GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhG
       --appsearch-size int32              Memory (RAM) in MB that each of the App Search instances will have (default 2048)
       --appsearch-zones int32             Number of zones the App Search instances will span (default 1)
       --deployment-template string        Deployment template ID on which to base the deployment from
-      --enterprise-search                 Enables Enterprise Search for the deployment
-      --enterprise-search-ref-id string   Optional RefId for the Enterprise Search deployment (default "main-enterprise_search")
-      --enterprise-search-size int32      Memory (RAM) in MB that each of the Enterprise Search instances will have (default 4096)
-      --enterprise-search-zones int32     Number of zones the Enterprise Search instances will span (default 1)
+      --enterprise_search                 Enables Enterprise Search for the deployment
+      --enterprise_search-ref-id string   Optional RefId for the Enterprise Search deployment (default "main-enterprise_search")
+      --enterprise_search-size int32      Memory (RAM) in MB that each of the Enterprise Search instances will have (default 4096)
+      --enterprise_search-zones int32     Number of zones the Enterprise Search instances will span (default 1)
       --es-ref-id string                  Optional RefId for the Elasticsearch deployment (default "main-elasticsearch")
       --es-size int32                     Memory (RAM) in MB that each of the Elasticsearch instances will have (default 4096)
       --es-zones int32                    Number of zones the Elasticsearch instances will span (default 1)

--- a/docs/ecctl_deployment_create.md
+++ b/docs/ecctl_deployment_create.md
@@ -33,7 +33,7 @@ ecctl deployment create {--file | --es-size <int> --es-zones <int> | --topology-
 ```
 ## Create a deployment with the default values for Elasticsearch, a Kibana instance with a modified size, 
 and a default APM instance. While Elasticsearch and Kibana come enabled by default, APM, Enterprise Search and App Search need to be 
-enabled by using the "--apm", "--enterprise-search" and "--appsearch" flags. The command will exit after the API response has been returned, without 
+enabled by using the "--apm", "--enterprise_search" and "--appsearch" flags. The command will exit after the API response has been returned, without 
 waiting until the deployment resources have been created. 
 $ ecctl deployment create --name my-deployment --zones 2 --kibana-size 2048 --apm --apm-size 1024
 
@@ -75,10 +75,10 @@ $ ecctl deployment create --request-id=GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhG
       --appsearch-size int32              Memory (RAM) in MB that each of the App Search instances will have (default 2048)
       --appsearch-zones int32             Number of zones the App Search instances will span (default 1)
       --deployment-template string        Deployment template ID on which to base the deployment from
-      --enterprise-search                 Enables Enterprise Search for the deployment
-      --enterprise-search-ref-id string   Optional RefId for the Enterprise Search deployment (default "main-enterprise_search")
-      --enterprise-search-size int32      Memory (RAM) in MB that each of the Enterprise Search instances will have (default 4096)
-      --enterprise-search-zones int32     Number of zones the Enterprise Search instances will span (default 1)
+      --enterprise_search                 Enables Enterprise Search for the deployment
+      --enterprise_search-ref-id string   Optional RefId for the Enterprise Search deployment (default "main-enterprise_search")
+      --enterprise_search-size int32      Memory (RAM) in MB that each of the Enterprise Search instances will have (default 4096)
+      --enterprise_search-zones int32     Number of zones the Enterprise Search instances will span (default 1)
       --es-ref-id string                  Optional RefId for the Elasticsearch deployment (default "main-elasticsearch")
       --es-size int32                     Memory (RAM) in MB that each of the Elasticsearch instances will have (default 4096)
       --es-zones int32                    Number of zones the Elasticsearch instances will span (default 1)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
The Enterprise Search resource kind is used everywhere as `enterprise_search`.

In order to have feature parity with the API, the deployment create flags have changed 
to use this format as well.

Additionally, a small bug has been fixed where the `deployment list` command did not support
Enterprise Search. Instead of adding `enterprise_search` to the list of resource kinds,
It's preferable to remove that check altogether and let the API return the validation error
like the other commands that use a `--kind` flag

## Related Issues
https://github.com/elastic/ecctl/issues/335

## Motivation and Context
feature parity

## How Has This Been Tested?
unit tests and by manually running the commands

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
