### PR TITLE
deployment: Change of terminology for create command

### DIFF
--- a/cmd/deployment/create.go
+++ b/cmd/deployment/create.go
@@ -34,7 +34,7 @@ import (
 )
 
 var createCmd = &cobra.Command{
-	Use:     "create {--file | --es-size <int> --es-zones <int> | --topology-element <obj>}",
+	Use:     "create {--file | --es-size <int> --es-zones <int> | --es-node-topology <obj>}",
 	Short:   "Creates a deployment",
 	PreRunE: cobra.NoArgs,
 	Long:    createLong,
@@ -51,7 +51,7 @@ var createCmd = &cobra.Command{
 		var esZoneCount, _ = cmd.Flags().GetInt32("es-zones")
 		var esSize, _ = cmd.Flags().GetInt32("es-size")
 		var esRefID, _ = cmd.Flags().GetString("es-ref-id")
-		var te, _ = cmd.Flags().GetStringArray("topology-element")
+		var topologyElements, _ = cmd.Flags().GetStringArray("es-node-topology")
 		var plugin, _ = cmd.Flags().GetStringSlice("plugin")
 
 		var kibanaZoneCount, _ = cmd.Flags().GetInt32("kibana-zones")
@@ -101,7 +101,7 @@ var createCmd = &cobra.Command{
 				Region:                   region,
 				Writer:                   ecctl.Get().Config.ErrorDevice,
 				Plugins:                  plugin,
-				TopologyElements:         te,
+				TopologyElements:         topologyElements,
 				ApmEnable:                apmEnable,
 				AppsearchEnable:          appsearchEnable,
 				EnterpriseSearchEnable:   enterpriseSearchEnable,
@@ -185,7 +185,7 @@ func initFlags() {
 	createCmd.Flags().String("es-ref-id", "main-elasticsearch", "Optional RefId for the Elasticsearch deployment")
 	createCmd.Flags().Int32("es-zones", 1, "Number of zones the Elasticsearch instances will span")
 	createCmd.Flags().Int32("es-size", 4096, "Memory (RAM) in MB that each of the Elasticsearch instances will have")
-	createCmd.Flags().StringArrayP("topology-element", "e", nil, "Optional Elasticsearch topology element definition. See help for more information")
+	createCmd.Flags().StringArrayP("es-node-topology", "e", nil, "Optional Elasticsearch node topology element definition. See help for more information")
 	createCmd.Flags().StringSlice("plugin", nil, "Additional plugins to add to the Elasticsearch deployment")
 
 	createCmd.Flags().String("kibana-ref-id", "main-kibana", "Optional RefId for the Kibana deployment")

--- a/cmd/deployment/create_help.go
+++ b/cmd/deployment/create_help.go
@@ -25,11 +25,11 @@ When version is not specified, the latest available stack version will automatic
 These are the available options:
 
   * Simplified flags to set size and zone count for each instance type (Elasticsearch, Kibana, APM, Enterprise Search and App Search). 
-  * Advanced flag for different Elasticsearch node types: --topology-element <json obj> (shorthand: -e).
+  * Advanced flag for different Elasticsearch node types: --es-node-topology <json obj> (shorthand: -e).
     Note that the flag can be specified multiple times for complex topologies.
     The JSON object has the following format:
     {
-      "name": "["data", "master", "ml"]" # type string
+      "node_type": "["data", "master", "ml"]" # type string
       "size": 1024 # type int32
       "zone_count": 1 # type int32
     }
@@ -53,10 +53,10 @@ $ deployment create --name my-deployment --track
 Deployment [b6ecbea3d5c84124b7dca457f2892086] - [Elasticsearch][b6ecbea3d5c84124b7dca457f2892086]: finished running all the plan steps (Total plan duration: 5m11.s)
 Deployment [91c4d60acb804ba0a27651fac02780ec] - [Kibana][8a9d9916cd6e46a7bb0912211d76e2af]: finished running all the plan steps (Total plan duration: 4m29.58s)
 
-## Additionally, a more advanced topology for Elasticsearch can be created through "--topology-element" or shorthand "-e".
+## Additionally, a more advanced topology for Elasticsearch can be created through "--es-node-topology" or shorthand "-e".
 The following command will create a deployment with two 1GB Elasticsearch instances of the type "data" and 
 one 1GB Elasticsearch instance of the type "ml".
-$ ecctl deployment create --name my-deployment --topology-element '{"size": 1024, "zone_count": 2, "name": "data"}' --topology-element '{"size": 1024, "zone_count": 1, "name": "ml"}'
+$ ecctl deployment create --name my-deployment --es-node-topology '{"size": 1024, "zone_count": 2, "node_type": "data"}' --es-node-topology '{"size": 1024, "zone_count": 1, "node_type": "ml"}'
 
 ## In order to use the "--deployment-template" flag, you'll need to know which deployment templates ara available to you.
 You'll need to run the following command to view your deployment templates:

--- a/docs/ecctl_deployment_create.adoc
+++ b/docs/ecctl_deployment_create.adoc
@@ -12,14 +12,14 @@ When version is not specified, the latest available stack version will automatic
 These are the available options:
 
 * Simplified flags to set size and zone count for each instance type (Elasticsearch, Kibana, APM, Enterprise Search and App Search).
-* Advanced flag for different Elasticsearch node types: --topology-element +++<json obj="">+++(shorthand: -e). Note that the flag can be specified multiple times for complex topologies. The JSON object has the following format: { "name": "["data", "master", "ml"]" # type string "size": 1024 # type int32 "zone_count": 1 # type int32 }+++</json>+++
+* Advanced flag for different Elasticsearch node types: --es-node-topology +++<json obj="">+++(shorthand: -e). Note that the flag can be specified multiple times for complex topologies. The JSON object has the following format: { "node_type": "["data", "master", "ml"]" # type string "size": 1024 # type int32 "zone_count": 1 # type int32 }+++</json>+++
 * File definition: --file=+++<file path="">+++(shorthand: -f). You can create a definition by using the sample JSON seen here: https://elastic.co/guide/en/cloud/current/ec-api-deployment-crud.html#ec_create_a_deployment+++</file>+++
 
 As an option "--generate-payload" can be used in order to obtain the generated payload that would be sent as a request.
 Save it, update or extend the topology and create a deployment using the saved payload with the "--file" flag.
 
 ----
-ecctl deployment create {--file | --es-size <int> --es-zones <int> | --topology-element <obj>} [flags]
+ecctl deployment create {--file | --es-size <int> --es-zones <int> | --es-node-topology <obj>} [flags]
 ----
 
 [float]
@@ -39,10 +39,10 @@ $ deployment create --name my-deployment --track
 Deployment [b6ecbea3d5c84124b7dca457f2892086] - [Elasticsearch][b6ecbea3d5c84124b7dca457f2892086]: finished running all the plan steps (Total plan duration: 5m11.s)
 Deployment [91c4d60acb804ba0a27651fac02780ec] - [Kibana][8a9d9916cd6e46a7bb0912211d76e2af]: finished running all the plan steps (Total plan duration: 4m29.58s)
 
-## Additionally, a more advanced topology for Elasticsearch can be created through "--topology-element" or shorthand "-e".
+## Additionally, a more advanced topology for Elasticsearch can be created through "--es-node-topology" or shorthand "-e".
 The following command will create a deployment with two 1GB Elasticsearch instances of the type "data" and
 one 1GB Elasticsearch instance of the type "ml".
-$ ecctl deployment create --name my-deployment --topology-element '{"size": 1024, "zone_count": 2, "name": "data"}' --topology-element '{"size": 1024, "zone_count": 1, "name": "ml"}'
+$ ecctl deployment create --name my-deployment --es-node-topology '{"size": 1024, "zone_count": 2, "node_type": "data"}' --es-node-topology '{"size": 1024, "zone_count": 1, "node_type": "ml"}'
 
 ## In order to use the "--deployment-template" flag, you'll need to know which deployment templates ara available to you.
 You'll need to run the following command to view your deployment templates:
@@ -75,6 +75,7 @@ $ ecctl deployment create --request-id=GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhG
       --enterprise_search-ref-id string   Optional RefId for the Enterprise Search deployment (default "main-enterprise_search")
       --enterprise_search-size int32      Memory (RAM) in MB that each of the Enterprise Search instances will have (default 4096)
       --enterprise_search-zones int32     Number of zones the Enterprise Search instances will span (default 1)
+  -e, --es-node-topology stringArray      Optional Elasticsearch node topology element definition. See help for more information
       --es-ref-id string                  Optional RefId for the Elasticsearch deployment (default "main-elasticsearch")
       --es-size int32                     Memory (RAM) in MB that each of the Elasticsearch instances will have (default 4096)
       --es-zones int32                    Number of zones the Elasticsearch instances will span (default 1)
@@ -87,7 +88,6 @@ $ ecctl deployment create --request-id=GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhG
       --name string                       Optional name for the deployment
       --plugin strings                    Additional plugins to add to the Elasticsearch deployment
       --request-id string                 Optional request ID - Can be found in the Stderr device when a previous deployment creation failed. For more information see the examples in the help command page
-  -e, --topology-element stringArray      Optional Elasticsearch topology element definition. See help for more information
   -t, --track                             Tracks the progress of the performed task
       --version string                    Version to use, if not specified, the latest available stack version will be used
 ----

--- a/docs/ecctl_deployment_create.md
+++ b/docs/ecctl_deployment_create.md
@@ -10,11 +10,11 @@ When version is not specified, the latest available stack version will automatic
 These are the available options:
 
   * Simplified flags to set size and zone count for each instance type (Elasticsearch, Kibana, APM, Enterprise Search and App Search). 
-  * Advanced flag for different Elasticsearch node types: --topology-element <json obj> (shorthand: -e).
+  * Advanced flag for different Elasticsearch node types: --es-node-topology <json obj> (shorthand: -e).
     Note that the flag can be specified multiple times for complex topologies.
     The JSON object has the following format:
     {
-      "name": "["data", "master", "ml"]" # type string
+      "node_type": "["data", "master", "ml"]" # type string
       "size": 1024 # type int32
       "zone_count": 1 # type int32
     }
@@ -25,7 +25,7 @@ As an option "--generate-payload" can be used in order to obtain the generated p
 Save it, update or extend the topology and create a deployment using the saved payload with the "--file" flag.
 
 ```
-ecctl deployment create {--file | --es-size <int> --es-zones <int> | --topology-element <obj>} [flags]
+ecctl deployment create {--file | --es-size <int> --es-zones <int> | --es-node-topology <obj>} [flags]
 ```
 
 ### Examples
@@ -44,10 +44,10 @@ $ deployment create --name my-deployment --track
 Deployment [b6ecbea3d5c84124b7dca457f2892086] - [Elasticsearch][b6ecbea3d5c84124b7dca457f2892086]: finished running all the plan steps (Total plan duration: 5m11.s)
 Deployment [91c4d60acb804ba0a27651fac02780ec] - [Kibana][8a9d9916cd6e46a7bb0912211d76e2af]: finished running all the plan steps (Total plan duration: 4m29.58s)
 
-## Additionally, a more advanced topology for Elasticsearch can be created through "--topology-element" or shorthand "-e".
+## Additionally, a more advanced topology for Elasticsearch can be created through "--es-node-topology" or shorthand "-e".
 The following command will create a deployment with two 1GB Elasticsearch instances of the type "data" and 
 one 1GB Elasticsearch instance of the type "ml".
-$ ecctl deployment create --name my-deployment --topology-element '{"size": 1024, "zone_count": 2, "name": "data"}' --topology-element '{"size": 1024, "zone_count": 1, "name": "ml"}'
+$ ecctl deployment create --name my-deployment --es-node-topology '{"size": 1024, "zone_count": 2, "node_type": "data"}' --es-node-topology '{"size": 1024, "zone_count": 1, "node_type": "ml"}'
 
 ## In order to use the "--deployment-template" flag, you'll need to know which deployment templates ara available to you.
 You'll need to run the following command to view your deployment templates:
@@ -79,6 +79,7 @@ $ ecctl deployment create --request-id=GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhG
       --enterprise_search-ref-id string   Optional RefId for the Enterprise Search deployment (default "main-enterprise_search")
       --enterprise_search-size int32      Memory (RAM) in MB that each of the Enterprise Search instances will have (default 4096)
       --enterprise_search-zones int32     Number of zones the Enterprise Search instances will span (default 1)
+  -e, --es-node-topology stringArray      Optional Elasticsearch node topology element definition. See help for more information
       --es-ref-id string                  Optional RefId for the Elasticsearch deployment (default "main-elasticsearch")
       --es-size int32                     Memory (RAM) in MB that each of the Elasticsearch instances will have (default 4096)
       --es-zones int32                    Number of zones the Elasticsearch instances will span (default 1)
@@ -91,7 +92,6 @@ $ ecctl deployment create --request-id=GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhG
       --name string                       Optional name for the deployment
       --plugin strings                    Additional plugins to add to the Elasticsearch deployment
       --request-id string                 Optional request ID - Can be found in the Stderr device when a previous deployment creation failed. For more information see the examples in the help command page
-  -e, --topology-element stringArray      Optional Elasticsearch topology element definition. See help for more information
   -t, --track                             Tracks the progress of the performed task
       --version string                    Version to use, if not specified, the latest available stack version will be used
 ```

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535
-	github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200722001835-e81a08e9ee6e
+	github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200727044318-7ae1b542fda2
 	github.com/go-openapi/runtime v0.19.20
 	github.com/go-openapi/strfmt v0.19.5
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200722001835-e81a08e9ee6e h1:0/5K0jfesaU/uN+ddk5iIIah3s1mADEbVCOnPK/Aeb8=
-github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200722001835-e81a08e9ee6e/go.mod h1:Lh6StXmfcUQj5TGl53rAmSjryzYEiOW6IjyAvHcuBLk=
+github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200727044318-7ae1b542fda2 h1:+l/xm/UrwRJ+Ke/ppJLmtJAxxn9LxiRQshaTcqy3tzc=
+github.com/elastic/cloud-sdk-go v1.0.0-beta3.0.20200727044318-7ae1b542fda2/go.mod h1:Lh6StXmfcUQj5TGl53rAmSjryzYEiOW6IjyAvHcuBLk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
The `Name` field in the elasticsearch topology element has changed to `NodeType`
This patch updates the documentation to take that change into account, as well as
changing the `--topology-element` flag to `--es-node-topology` as an UX improvement.

## Related Issues
https://github.com/elastic/cloud-sdk-go/pull/182
https://github.com/elastic/ecctl/issues/335

## Motivation and Context
UX

## How Has This Been Tested?
by running the command and unit test

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
