### PR TITLE
deployment: Support memory in GB for create command

### DIFF
--- a/cmd/deployment/create.go
+++ b/cmd/deployment/create.go
@@ -18,11 +18,13 @@
 package cmddeployment
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi"
+	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/deploymentsize"
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/depresourceapi"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"
@@ -49,28 +51,28 @@ var createCmd = &cobra.Command{
 		var region = ecctl.Get().Config.Region
 
 		var esZoneCount, _ = cmd.Flags().GetInt32("es-zones")
-		var esSize, _ = cmd.Flags().GetInt32("es-size")
+		var esSize, _ = cmd.Flags().GetString("es-size")
 		var esRefID, _ = cmd.Flags().GetString("es-ref-id")
 		var topologyElements, _ = cmd.Flags().GetStringArray("es-node-topology")
 		var plugin, _ = cmd.Flags().GetStringSlice("plugin")
 
 		var kibanaZoneCount, _ = cmd.Flags().GetInt32("kibana-zones")
-		var kibanaSize, _ = cmd.Flags().GetInt32("kibana-size")
+		var kibanaSize, _ = cmd.Flags().GetString("kibana-size")
 		var kibanaRefID, _ = cmd.Flags().GetString("kibana-ref-id")
 
 		var apmEnable, _ = cmd.Flags().GetBool("apm")
 		var apmZoneCount, _ = cmd.Flags().GetInt32("apm-zones")
-		var apmSize, _ = cmd.Flags().GetInt32("apm-size")
+		var apmSize, _ = cmd.Flags().GetString("apm-size")
 		var apmRefID, _ = cmd.Flags().GetString("apm-ref-id")
 
 		var appsearchEnable, _ = cmd.Flags().GetBool("appsearch")
 		var appsearchZoneCount, _ = cmd.Flags().GetInt32("appsearch-zones")
-		var appsearchSize, _ = cmd.Flags().GetInt32("appsearch-size")
+		var appsearchSize, _ = cmd.Flags().GetString("appsearch-size")
 		var appsearchRefID, _ = cmd.Flags().GetString("appsearch-ref-id")
 
 		var enterpriseSearchEnable, _ = cmd.Flags().GetBool("enterprise_search")
 		var enterpriseSearchZoneCount, _ = cmd.Flags().GetInt32("enterprise_search-zones")
-		var enterpriseSearchSize, _ = cmd.Flags().GetInt32("enterprise_search-size")
+		var enterpriseSearchSize, _ = cmd.Flags().GetString("enterprise_search-size")
 		var enterpriseSearchRefID, _ = cmd.Flags().GetString("enterprise_search-ref-id")
 
 		var payload *models.DeploymentCreateRequest
@@ -87,6 +89,38 @@ var createCmd = &cobra.Command{
 
 		if dt == "" {
 			dt = setDefaultTemplate(region)
+		}
+
+		apmSizeMB, err := deploymentsize.ParseGb(apmSize)
+		if err != nil {
+			return err
+		}
+
+		appsearchSizeMB, err := deploymentsize.ParseGb(appsearchSize)
+		if err != nil {
+			return err
+		}
+
+		esSizeMB, err := deploymentsize.ParseGb(esSize)
+		if err != nil {
+			return err
+		}
+
+		enterpriseSearchSizeMB, err := deploymentsize.ParseGb(enterpriseSearchSize)
+		if err != nil {
+			return err
+		}
+
+		kibanaSizeMB, err := deploymentsize.ParseGb(kibanaSize)
+		if err != nil {
+			return err
+		}
+
+		if topologyElements != nil {
+			topologyElements, err = esTopologyParseGB(topologyElements)
+			if err != nil {
+				return err
+			}
 		}
 
 		dtAsList, _ := cmd.Flags().GetBool("dt-as-list")
@@ -107,27 +141,27 @@ var createCmd = &cobra.Command{
 				EnterpriseSearchEnable:   enterpriseSearchEnable,
 				ElasticsearchInstance: depresourceapi.InstanceParams{
 					RefID:     esRefID,
-					Size:      esSize,
+					Size:      esSizeMB,
 					ZoneCount: esZoneCount,
 				},
 				KibanaInstance: depresourceapi.InstanceParams{
 					RefID:     kibanaRefID,
-					Size:      kibanaSize,
+					Size:      kibanaSizeMB,
 					ZoneCount: kibanaZoneCount,
 				},
 				ApmInstance: depresourceapi.InstanceParams{
 					RefID:     apmRefID,
-					Size:      apmSize,
+					Size:      apmSizeMB,
 					ZoneCount: apmZoneCount,
 				},
 				AppsearchInstance: depresourceapi.InstanceParams{
 					RefID:     appsearchRefID,
-					Size:      appsearchSize,
+					Size:      appsearchSizeMB,
 					ZoneCount: appsearchZoneCount,
 				},
 				EnterpriseSearchInstance: depresourceapi.InstanceParams{
 					RefID:     enterpriseSearchRefID,
-					Size:      enterpriseSearchSize,
+					Size:      enterpriseSearchSizeMB,
 					ZoneCount: enterpriseSearchZoneCount,
 				},
 			})
@@ -184,28 +218,28 @@ func initFlags() {
 
 	createCmd.Flags().String("es-ref-id", "main-elasticsearch", "Optional RefId for the Elasticsearch deployment")
 	createCmd.Flags().Int32("es-zones", 1, "Number of zones the Elasticsearch instances will span")
-	createCmd.Flags().Int32("es-size", 4096, "Memory (RAM) in MB that each of the Elasticsearch instances will have")
+	createCmd.Flags().String("es-size", "4g", "Memory (RAM) in MB that each of the Elasticsearch instances will have")
 	createCmd.Flags().StringArrayP("es-node-topology", "e", nil, "Optional Elasticsearch node topology element definition. See help for more information")
 	createCmd.Flags().StringSlice("plugin", nil, "Additional plugins to add to the Elasticsearch deployment")
 
 	createCmd.Flags().String("kibana-ref-id", "main-kibana", "Optional RefId for the Kibana deployment")
 	createCmd.Flags().Int32("kibana-zones", 1, "Number of zones the Kibana instances will span")
-	createCmd.Flags().Int32("kibana-size", 1024, "Memory (RAM) in MB that each of the Kibana instances will have")
+	createCmd.Flags().String("kibana-size", "1g", "Memory (RAM) in MB that each of the Kibana instances will have")
 
 	createCmd.Flags().Bool("apm", false, "Enables APM for the deployment")
 	createCmd.Flags().String("apm-ref-id", "main-apm", "Optional RefId for the APM deployment")
 	createCmd.Flags().Int32("apm-zones", 1, "Number of zones the APM instances will span")
-	createCmd.Flags().Int32("apm-size", 512, "Memory (RAM) in MB that each of the APM instances will have")
+	createCmd.Flags().String("apm-size", "0.5g", "Memory (RAM) in MB that each of the APM instances will have")
 
 	createCmd.Flags().Bool("appsearch", false, "Enables App Search for the deployment")
 	createCmd.Flags().String("appsearch-ref-id", "main-appsearch", "Optional RefId for the App Search deployment")
 	createCmd.Flags().Int32("appsearch-zones", 1, "Number of zones the App Search instances will span")
-	createCmd.Flags().Int32("appsearch-size", 2048, "Memory (RAM) in MB that each of the App Search instances will have")
+	createCmd.Flags().String("appsearch-size", "2g", "Memory (RAM) in MB that each of the App Search instances will have")
 
 	createCmd.Flags().Bool("enterprise_search", false, "Enables Enterprise Search for the deployment")
 	createCmd.Flags().String("enterprise_search-ref-id", "main-enterprise_search", "Optional RefId for the Enterprise Search deployment")
 	createCmd.Flags().Int32("enterprise_search-zones", 1, "Number of zones the Enterprise Search instances will span")
-	createCmd.Flags().Int32("enterprise_search-size", 4096, "Memory (RAM) in MB that each of the Enterprise Search instances will have")
+	createCmd.Flags().String("enterprise_search-size", "4g", "Memory (RAM) in MB that each of the Enterprise Search instances will have")
 
 	// Remove in the next version.
 	createCmd.Flags().Bool("dt-as-list", true, "")
@@ -231,4 +265,41 @@ func setDefaultTemplate(region string) string {
 	default:
 		return "aws-io-optimized-v2"
 	}
+}
+
+type elasticsearchTopologyElement struct {
+	NodeType  string `json:"node_type"`
+	Size      string `json:"size"`
+	ZoneCount int32  `json:"zone_count,omitempty"`
+}
+
+func esTopologyParseGB(topology []string) ([]string, error) {
+	var t = make([]string, 0, len(topology))
+	for _, rawElement := range topology {
+		var element elasticsearchTopologyElement
+		if err := json.Unmarshal([]byte(rawElement), &element); err != nil {
+			return nil, fmt.Errorf("failed unpacking raw topology: %s", err)
+		}
+
+		elementSizeMB, err := deploymentsize.ParseGb(element.Size)
+		if err != nil {
+			return nil, err
+		}
+
+		esTopologyElement := depresourceapi.ElasticsearchTopologyElement{
+			NodeType:  element.NodeType,
+			ZoneCount: element.ZoneCount,
+			Size:      elementSizeMB,
+		}
+
+		b, err := json.Marshal(esTopologyElement)
+		if err != nil {
+			return nil, fmt.Errorf("failed unpacking topology: %s", err)
+		}
+		parsedElement := string(b)
+
+		t = append(t, parsedElement)
+	}
+
+	return t, nil
 }

--- a/cmd/deployment/create.go
+++ b/cmd/deployment/create.go
@@ -281,6 +281,10 @@ func esTopologyParseGB(topology []string) ([]string, error) {
 			return nil, fmt.Errorf("failed unpacking raw topology: %s", err)
 		}
 
+		if len(element.Size) == 0 {
+			return nil, errors.New("memory size cannot be empty")
+		}
+
 		elementSizeMB, err := deploymentsize.ParseGb(element.Size)
 		if err != nil {
 			return nil, err

--- a/cmd/deployment/create.go
+++ b/cmd/deployment/create.go
@@ -218,28 +218,28 @@ func initFlags() {
 
 	createCmd.Flags().String("es-ref-id", "main-elasticsearch", "Optional RefId for the Elasticsearch deployment")
 	createCmd.Flags().Int32("es-zones", 1, "Number of zones the Elasticsearch instances will span")
-	createCmd.Flags().String("es-size", "4g", "Memory (RAM) in MB that each of the Elasticsearch instances will have")
+	createCmd.Flags().String("es-size", "4g", "Memory (RAM) in GB that each of the Elasticsearch instances will have")
 	createCmd.Flags().StringArrayP("es-node-topology", "e", nil, "Optional Elasticsearch node topology element definition. See help for more information")
 	createCmd.Flags().StringSlice("plugin", nil, "Additional plugins to add to the Elasticsearch deployment")
 
 	createCmd.Flags().String("kibana-ref-id", "main-kibana", "Optional RefId for the Kibana deployment")
 	createCmd.Flags().Int32("kibana-zones", 1, "Number of zones the Kibana instances will span")
-	createCmd.Flags().String("kibana-size", "1g", "Memory (RAM) in MB that each of the Kibana instances will have")
+	createCmd.Flags().String("kibana-size", "1g", "Memory (RAM) in GB that each of the Kibana instances will have")
 
 	createCmd.Flags().Bool("apm", false, "Enables APM for the deployment")
 	createCmd.Flags().String("apm-ref-id", "main-apm", "Optional RefId for the APM deployment")
 	createCmd.Flags().Int32("apm-zones", 1, "Number of zones the APM instances will span")
-	createCmd.Flags().String("apm-size", "0.5g", "Memory (RAM) in MB that each of the APM instances will have")
+	createCmd.Flags().String("apm-size", "0.5g", "Memory (RAM) in GB that each of the APM instances will have")
 
 	createCmd.Flags().Bool("appsearch", false, "Enables App Search for the deployment")
 	createCmd.Flags().String("appsearch-ref-id", "main-appsearch", "Optional RefId for the App Search deployment")
 	createCmd.Flags().Int32("appsearch-zones", 1, "Number of zones the App Search instances will span")
-	createCmd.Flags().String("appsearch-size", "2g", "Memory (RAM) in MB that each of the App Search instances will have")
+	createCmd.Flags().String("appsearch-size", "2g", "Memory (RAM) in GB that each of the App Search instances will have")
 
 	createCmd.Flags().Bool("enterprise_search", false, "Enables Enterprise Search for the deployment")
 	createCmd.Flags().String("enterprise_search-ref-id", "main-enterprise_search", "Optional RefId for the Enterprise Search deployment")
 	createCmd.Flags().Int32("enterprise_search-zones", 1, "Number of zones the Enterprise Search instances will span")
-	createCmd.Flags().String("enterprise_search-size", "4g", "Memory (RAM) in MB that each of the Enterprise Search instances will have")
+	createCmd.Flags().String("enterprise_search-size", "4g", "Memory (RAM) in GB that each of the Enterprise Search instances will have")
 
 	// Remove in the next version.
 	createCmd.Flags().Bool("dt-as-list", true, "")
@@ -278,11 +278,11 @@ func esTopologyParseGB(topology []string) ([]string, error) {
 	for _, rawElement := range topology {
 		var element elasticsearchTopologyElement
 		if err := json.Unmarshal([]byte(rawElement), &element); err != nil {
-			return nil, fmt.Errorf("failed unpacking raw topology: %s", err)
+			return nil, fmt.Errorf("failed unpacking raw elasticsearch node topology: %s", err)
 		}
 
 		if element.Size == "" {
-			return nil, errors.New("memory size cannot be empty")
+			return nil, errors.New("elasticsearch node topology: memory size cannot be empty")
 		}
 
 		elementSizeMB, err := deploymentsize.ParseGb(element.Size)
@@ -298,7 +298,7 @@ func esTopologyParseGB(topology []string) ([]string, error) {
 
 		b, err := json.Marshal(esTopologyElement)
 		if err != nil {
-			return nil, fmt.Errorf("failed unpacking topology: %s", err)
+			return nil, fmt.Errorf("failed unpacking elasticsearch node topology: %s", err)
 		}
 		parsedElement := string(b)
 

--- a/cmd/deployment/create.go
+++ b/cmd/deployment/create.go
@@ -281,7 +281,7 @@ func esTopologyParseGB(topology []string) ([]string, error) {
 			return nil, fmt.Errorf("failed unpacking raw topology: %s", err)
 		}
 
-		if len(element.Size) == 0 {
+		if element.Size == "" {
 			return nil, errors.New("memory size cannot be empty")
 		}
 

--- a/cmd/deployment/create_help.go
+++ b/cmd/deployment/create_help.go
@@ -30,7 +30,7 @@ These are the available options:
     The JSON object has the following format:
     {
       "node_type": "["data", "master", "ml"]" # type string
-      "size": 1024 # type int32
+      "size": "1g" # type string
       "zone_count": 1 # type int32
     }
   * File definition: --file=<file path> (shorthand: -f). You can create a definition by using the sample JSON seen here:
@@ -44,7 +44,7 @@ Save it, update or extend the topology and create a deployment using the saved p
 and a default APM instance. While Elasticsearch and Kibana come enabled by default, APM, Enterprise Search and App Search need to be 
 enabled by using the "--apm", "--enterprise_search" and "--appsearch" flags. The command will exit after the API response has been returned, without 
 waiting until the deployment resources have been created. 
-$ ecctl deployment create --name my-deployment --zones 2 --kibana-size 2048 --apm --apm-size 1024
+$ ecctl deployment create --name my-deployment --zones 2 --kibana-size 2g --apm --apm-size 0.5g
 
 ## To make the command wait until the resources have been created use the "--track" flag, which will output 
 the current stage on which the deployment resources are in.
@@ -56,14 +56,14 @@ Deployment [91c4d60acb804ba0a27651fac02780ec] - [Kibana][8a9d9916cd6e46a7bb09122
 ## Additionally, a more advanced topology for Elasticsearch can be created through "--es-node-topology" or shorthand "-e".
 The following command will create a deployment with two 1GB Elasticsearch instances of the type "data" and 
 one 1GB Elasticsearch instance of the type "ml".
-$ ecctl deployment create --name my-deployment --es-node-topology '{"size": 1024, "zone_count": 2, "node_type": "data"}' --es-node-topology '{"size": 1024, "zone_count": 1, "node_type": "ml"}'
+$ ecctl deployment create --name my-deployment --es-node-topology '{"size": "1g", "zone_count": 2, "node_type": "data"}' --es-node-topology '{"size": "1g", "zone_count": 1, "node_type": "ml"}'
 
 ## In order to use the "--deployment-template" flag, you'll need to know which deployment templates ara available to you.
 You'll need to run the following command to view your deployment templates:
 $ ecctl platform deployment-template list
 
 ## Use the "--generate-payload" flag to save the definition to a file for later use.
-$ ecctl deployment create --name my-deployment --size 1024 --track --generate-payload --zones 2 > create_example.json
+$ ecctl deployment create --name my-deployment --size 1g --track --generate-payload --zones 2 > create_example.json
 
 ## Create a deployment through the file definition.
 $ ecctl deployment create --file create_example.json --track

--- a/cmd/deployment/create_test.go
+++ b/cmd/deployment/create_test.go
@@ -548,8 +548,8 @@ Deployment [%s] - [Apm][%s]: running step "waiting-for-some-step" (Plan duration
 				Cmd: createCmd,
 				Args: []string{
 					"create", "--request-id=some_request_id", "--version=7.8.0", "--es-node-topology",
-					`{"size": 1024, "zone_count": 2, "node_type": "data"}`, "--es-node-topology",
-					`{"size": 1024, "zone_count": 1, "node_type": "ml"}`, "--dt-as-list=false",
+					`{"size": "1g", "zone_count": 2, "node_type": "data"}`, "--es-node-topology",
+					`{"size": "1g", "zone_count": 1, "node_type": "ml"}`, "--dt-as-list=false",
 				},
 				Cfg: testutils.MockCfg{Responses: []mock.Response{
 					{

--- a/cmd/deployment/create_test.go
+++ b/cmd/deployment/create_test.go
@@ -552,7 +552,7 @@ Deployment [%s] - [Apm][%s]: running step "waiting-for-some-step" (Plan duration
 				},
 			},
 			want: testutils.Assertion{
-				Err: errors.New("memory size cannot be empty"),
+				Err: errors.New("elasticsearch node topology: memory size cannot be empty"),
 			},
 		},
 		{

--- a/cmd/deployment/create_test.go
+++ b/cmd/deployment/create_test.go
@@ -543,6 +543,19 @@ Deployment [%s] - [Apm][%s]: running step "waiting-for-some-step" (Plan duration
 			},
 		},
 		{
+			name: "fails creating a deployment with ES topology element when size is missing (Normal GetCall)",
+			args: testutils.Args{
+				Cmd: createCmd,
+				Args: []string{
+					"create", "--request-id=some_request_id", "--version=7.8.0", "--es-node-topology",
+					`{"zone_count": 2, "node_type": "data"}`,
+				},
+			},
+			want: testutils.Assertion{
+				Err: errors.New("memory size cannot be empty"),
+			},
+		},
+		{
 			name: "succeeds creating a deployment with ES topology element and without tracking (Normal GetCall)",
 			args: testutils.Args{
 				Cmd: createCmd,

--- a/docs/ecctl_deployment_create.adoc
+++ b/docs/ecctl_deployment_create.adoc
@@ -12,7 +12,7 @@ When version is not specified, the latest available stack version will automatic
 These are the available options:
 
 * Simplified flags to set size and zone count for each instance type (Elasticsearch, Kibana, APM, Enterprise Search and App Search).
-* Advanced flag for different Elasticsearch node types: --es-node-topology +++<json obj="">+++(shorthand: -e). Note that the flag can be specified multiple times for complex topologies. The JSON object has the following format: { "node_type": "["data", "master", "ml"]" # type string "size": 1024 # type int32 "zone_count": 1 # type int32 }+++</json>+++
+* Advanced flag for different Elasticsearch node types: --es-node-topology +++<json obj="">+++(shorthand: -e). Note that the flag can be specified multiple times for complex topologies. The JSON object has the following format: { "node_type": "["data", "master", "ml"]" # type string "size": "1g" # type string "zone_count": 1 # type int32 }+++</json>+++
 * File definition: --file=+++<file path="">+++(shorthand: -f). You can create a definition by using the sample JSON seen here: https://elastic.co/guide/en/cloud/current/ec-api-deployment-crud.html#ec_create_a_deployment+++</file>+++
 
 As an option "--generate-payload" can be used in order to obtain the generated payload that would be sent as a request.
@@ -30,7 +30,7 @@ ecctl deployment create {--file | --es-size <int> --es-zones <int> | --es-node-t
 and a default APM instance. While Elasticsearch and Kibana come enabled by default, APM, Enterprise Search and App Search need to be
 enabled by using the "--apm", "--enterprise_search" and "--appsearch" flags. The command will exit after the API response has been returned, without
 waiting until the deployment resources have been created.
-$ ecctl deployment create --name my-deployment --zones 2 --kibana-size 2048 --apm --apm-size 1024
+$ ecctl deployment create --name my-deployment --zones 2 --kibana-size 2g --apm --apm-size 0.5g
 
 ## To make the command wait until the resources have been created use the "--track" flag, which will output
 the current stage on which the deployment resources are in.
@@ -42,14 +42,14 @@ Deployment [91c4d60acb804ba0a27651fac02780ec] - [Kibana][8a9d9916cd6e46a7bb09122
 ## Additionally, a more advanced topology for Elasticsearch can be created through "--es-node-topology" or shorthand "-e".
 The following command will create a deployment with two 1GB Elasticsearch instances of the type "data" and
 one 1GB Elasticsearch instance of the type "ml".
-$ ecctl deployment create --name my-deployment --es-node-topology '{"size": 1024, "zone_count": 2, "node_type": "data"}' --es-node-topology '{"size": 1024, "zone_count": 1, "node_type": "ml"}'
+$ ecctl deployment create --name my-deployment --es-node-topology '{"size": "1g", "zone_count": 2, "node_type": "data"}' --es-node-topology '{"size": "1g", "zone_count": 1, "node_type": "ml"}'
 
 ## In order to use the "--deployment-template" flag, you'll need to know which deployment templates ara available to you.
 You'll need to run the following command to view your deployment templates:
 $ ecctl platform deployment-template list
 
 ## Use the "--generate-payload" flag to save the definition to a file for later use.
-$ ecctl deployment create --name my-deployment --size 1024 --track --generate-payload --zones 2 > create_example.json
+$ ecctl deployment create --name my-deployment --size 1g --track --generate-payload --zones 2 > create_example.json
 
 ## Create a deployment through the file definition.
 $ ecctl deployment create --file create_example.json --track
@@ -64,26 +64,26 @@ $ ecctl deployment create --request-id=GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhG
 ----
       --apm                               Enables APM for the deployment
       --apm-ref-id string                 Optional RefId for the APM deployment (default "main-apm")
-      --apm-size int32                    Memory (RAM) in MB that each of the APM instances will have (default 512)
+      --apm-size string                   Memory (RAM) in MB that each of the APM instances will have (default "0.5g")
       --apm-zones int32                   Number of zones the APM instances will span (default 1)
       --appsearch                         Enables App Search for the deployment
       --appsearch-ref-id string           Optional RefId for the App Search deployment (default "main-appsearch")
-      --appsearch-size int32              Memory (RAM) in MB that each of the App Search instances will have (default 2048)
+      --appsearch-size string             Memory (RAM) in MB that each of the App Search instances will have (default "2g")
       --appsearch-zones int32             Number of zones the App Search instances will span (default 1)
       --deployment-template string        Deployment template ID on which to base the deployment from
       --enterprise_search                 Enables Enterprise Search for the deployment
       --enterprise_search-ref-id string   Optional RefId for the Enterprise Search deployment (default "main-enterprise_search")
-      --enterprise_search-size int32      Memory (RAM) in MB that each of the Enterprise Search instances will have (default 4096)
+      --enterprise_search-size string     Memory (RAM) in MB that each of the Enterprise Search instances will have (default "4g")
       --enterprise_search-zones int32     Number of zones the Enterprise Search instances will span (default 1)
   -e, --es-node-topology stringArray      Optional Elasticsearch node topology element definition. See help for more information
       --es-ref-id string                  Optional RefId for the Elasticsearch deployment (default "main-elasticsearch")
-      --es-size int32                     Memory (RAM) in MB that each of the Elasticsearch instances will have (default 4096)
+      --es-size string                    Memory (RAM) in MB that each of the Elasticsearch instances will have (default "4g")
       --es-zones int32                    Number of zones the Elasticsearch instances will span (default 1)
   -f, --file string                       DeploymentCreateRequest file definition. See help for more information
       --generate-payload                  Returns the deployment payload without actually creating the deployment resources
   -h, --help                              help for create
       --kibana-ref-id string              Optional RefId for the Kibana deployment (default "main-kibana")
-      --kibana-size int32                 Memory (RAM) in MB that each of the Kibana instances will have (default 1024)
+      --kibana-size string                Memory (RAM) in MB that each of the Kibana instances will have (default "1g")
       --kibana-zones int32                Number of zones the Kibana instances will span (default 1)
       --name string                       Optional name for the deployment
       --plugin strings                    Additional plugins to add to the Elasticsearch deployment

--- a/docs/ecctl_deployment_create.adoc
+++ b/docs/ecctl_deployment_create.adoc
@@ -64,26 +64,26 @@ $ ecctl deployment create --request-id=GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhG
 ----
       --apm                               Enables APM for the deployment
       --apm-ref-id string                 Optional RefId for the APM deployment (default "main-apm")
-      --apm-size string                   Memory (RAM) in MB that each of the APM instances will have (default "0.5g")
+      --apm-size string                   Memory (RAM) in GB that each of the APM instances will have (default "0.5g")
       --apm-zones int32                   Number of zones the APM instances will span (default 1)
       --appsearch                         Enables App Search for the deployment
       --appsearch-ref-id string           Optional RefId for the App Search deployment (default "main-appsearch")
-      --appsearch-size string             Memory (RAM) in MB that each of the App Search instances will have (default "2g")
+      --appsearch-size string             Memory (RAM) in GB that each of the App Search instances will have (default "2g")
       --appsearch-zones int32             Number of zones the App Search instances will span (default 1)
       --deployment-template string        Deployment template ID on which to base the deployment from
       --enterprise_search                 Enables Enterprise Search for the deployment
       --enterprise_search-ref-id string   Optional RefId for the Enterprise Search deployment (default "main-enterprise_search")
-      --enterprise_search-size string     Memory (RAM) in MB that each of the Enterprise Search instances will have (default "4g")
+      --enterprise_search-size string     Memory (RAM) in GB that each of the Enterprise Search instances will have (default "4g")
       --enterprise_search-zones int32     Number of zones the Enterprise Search instances will span (default 1)
   -e, --es-node-topology stringArray      Optional Elasticsearch node topology element definition. See help for more information
       --es-ref-id string                  Optional RefId for the Elasticsearch deployment (default "main-elasticsearch")
-      --es-size string                    Memory (RAM) in MB that each of the Elasticsearch instances will have (default "4g")
+      --es-size string                    Memory (RAM) in GB that each of the Elasticsearch instances will have (default "4g")
       --es-zones int32                    Number of zones the Elasticsearch instances will span (default 1)
   -f, --file string                       DeploymentCreateRequest file definition. See help for more information
       --generate-payload                  Returns the deployment payload without actually creating the deployment resources
   -h, --help                              help for create
       --kibana-ref-id string              Optional RefId for the Kibana deployment (default "main-kibana")
-      --kibana-size string                Memory (RAM) in MB that each of the Kibana instances will have (default "1g")
+      --kibana-size string                Memory (RAM) in GB that each of the Kibana instances will have (default "1g")
       --kibana-zones int32                Number of zones the Kibana instances will span (default 1)
       --name string                       Optional name for the deployment
       --plugin strings                    Additional plugins to add to the Elasticsearch deployment

--- a/docs/ecctl_deployment_create.md
+++ b/docs/ecctl_deployment_create.md
@@ -68,26 +68,26 @@ $ ecctl deployment create --request-id=GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhG
 ```
       --apm                               Enables APM for the deployment
       --apm-ref-id string                 Optional RefId for the APM deployment (default "main-apm")
-      --apm-size string                   Memory (RAM) in MB that each of the APM instances will have (default "0.5g")
+      --apm-size string                   Memory (RAM) in GB that each of the APM instances will have (default "0.5g")
       --apm-zones int32                   Number of zones the APM instances will span (default 1)
       --appsearch                         Enables App Search for the deployment
       --appsearch-ref-id string           Optional RefId for the App Search deployment (default "main-appsearch")
-      --appsearch-size string             Memory (RAM) in MB that each of the App Search instances will have (default "2g")
+      --appsearch-size string             Memory (RAM) in GB that each of the App Search instances will have (default "2g")
       --appsearch-zones int32             Number of zones the App Search instances will span (default 1)
       --deployment-template string        Deployment template ID on which to base the deployment from
       --enterprise_search                 Enables Enterprise Search for the deployment
       --enterprise_search-ref-id string   Optional RefId for the Enterprise Search deployment (default "main-enterprise_search")
-      --enterprise_search-size string     Memory (RAM) in MB that each of the Enterprise Search instances will have (default "4g")
+      --enterprise_search-size string     Memory (RAM) in GB that each of the Enterprise Search instances will have (default "4g")
       --enterprise_search-zones int32     Number of zones the Enterprise Search instances will span (default 1)
   -e, --es-node-topology stringArray      Optional Elasticsearch node topology element definition. See help for more information
       --es-ref-id string                  Optional RefId for the Elasticsearch deployment (default "main-elasticsearch")
-      --es-size string                    Memory (RAM) in MB that each of the Elasticsearch instances will have (default "4g")
+      --es-size string                    Memory (RAM) in GB that each of the Elasticsearch instances will have (default "4g")
       --es-zones int32                    Number of zones the Elasticsearch instances will span (default 1)
   -f, --file string                       DeploymentCreateRequest file definition. See help for more information
       --generate-payload                  Returns the deployment payload without actually creating the deployment resources
   -h, --help                              help for create
       --kibana-ref-id string              Optional RefId for the Kibana deployment (default "main-kibana")
-      --kibana-size string                Memory (RAM) in MB that each of the Kibana instances will have (default "1g")
+      --kibana-size string                Memory (RAM) in GB that each of the Kibana instances will have (default "1g")
       --kibana-zones int32                Number of zones the Kibana instances will span (default 1)
       --name string                       Optional name for the deployment
       --plugin strings                    Additional plugins to add to the Elasticsearch deployment

--- a/docs/ecctl_deployment_create.md
+++ b/docs/ecctl_deployment_create.md
@@ -15,7 +15,7 @@ These are the available options:
     The JSON object has the following format:
     {
       "node_type": "["data", "master", "ml"]" # type string
-      "size": 1024 # type int32
+      "size": "1g" # type string
       "zone_count": 1 # type int32
     }
   * File definition: --file=<file path> (shorthand: -f). You can create a definition by using the sample JSON seen here:
@@ -35,7 +35,7 @@ ecctl deployment create {--file | --es-size <int> --es-zones <int> | --es-node-t
 and a default APM instance. While Elasticsearch and Kibana come enabled by default, APM, Enterprise Search and App Search need to be 
 enabled by using the "--apm", "--enterprise_search" and "--appsearch" flags. The command will exit after the API response has been returned, without 
 waiting until the deployment resources have been created. 
-$ ecctl deployment create --name my-deployment --zones 2 --kibana-size 2048 --apm --apm-size 1024
+$ ecctl deployment create --name my-deployment --zones 2 --kibana-size 2g --apm --apm-size 0.5g
 
 ## To make the command wait until the resources have been created use the "--track" flag, which will output 
 the current stage on which the deployment resources are in.
@@ -47,14 +47,14 @@ Deployment [91c4d60acb804ba0a27651fac02780ec] - [Kibana][8a9d9916cd6e46a7bb09122
 ## Additionally, a more advanced topology for Elasticsearch can be created through "--es-node-topology" or shorthand "-e".
 The following command will create a deployment with two 1GB Elasticsearch instances of the type "data" and 
 one 1GB Elasticsearch instance of the type "ml".
-$ ecctl deployment create --name my-deployment --es-node-topology '{"size": 1024, "zone_count": 2, "node_type": "data"}' --es-node-topology '{"size": 1024, "zone_count": 1, "node_type": "ml"}'
+$ ecctl deployment create --name my-deployment --es-node-topology '{"size": "1g", "zone_count": 2, "node_type": "data"}' --es-node-topology '{"size": "1g", "zone_count": 1, "node_type": "ml"}'
 
 ## In order to use the "--deployment-template" flag, you'll need to know which deployment templates ara available to you.
 You'll need to run the following command to view your deployment templates:
 $ ecctl platform deployment-template list
 
 ## Use the "--generate-payload" flag to save the definition to a file for later use.
-$ ecctl deployment create --name my-deployment --size 1024 --track --generate-payload --zones 2 > create_example.json
+$ ecctl deployment create --name my-deployment --size 1g --track --generate-payload --zones 2 > create_example.json
 
 ## Create a deployment through the file definition.
 $ ecctl deployment create --file create_example.json --track
@@ -68,26 +68,26 @@ $ ecctl deployment create --request-id=GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhG
 ```
       --apm                               Enables APM for the deployment
       --apm-ref-id string                 Optional RefId for the APM deployment (default "main-apm")
-      --apm-size int32                    Memory (RAM) in MB that each of the APM instances will have (default 512)
+      --apm-size string                   Memory (RAM) in MB that each of the APM instances will have (default "0.5g")
       --apm-zones int32                   Number of zones the APM instances will span (default 1)
       --appsearch                         Enables App Search for the deployment
       --appsearch-ref-id string           Optional RefId for the App Search deployment (default "main-appsearch")
-      --appsearch-size int32              Memory (RAM) in MB that each of the App Search instances will have (default 2048)
+      --appsearch-size string             Memory (RAM) in MB that each of the App Search instances will have (default "2g")
       --appsearch-zones int32             Number of zones the App Search instances will span (default 1)
       --deployment-template string        Deployment template ID on which to base the deployment from
       --enterprise_search                 Enables Enterprise Search for the deployment
       --enterprise_search-ref-id string   Optional RefId for the Enterprise Search deployment (default "main-enterprise_search")
-      --enterprise_search-size int32      Memory (RAM) in MB that each of the Enterprise Search instances will have (default 4096)
+      --enterprise_search-size string     Memory (RAM) in MB that each of the Enterprise Search instances will have (default "4g")
       --enterprise_search-zones int32     Number of zones the Enterprise Search instances will span (default 1)
   -e, --es-node-topology stringArray      Optional Elasticsearch node topology element definition. See help for more information
       --es-ref-id string                  Optional RefId for the Elasticsearch deployment (default "main-elasticsearch")
-      --es-size int32                     Memory (RAM) in MB that each of the Elasticsearch instances will have (default 4096)
+      --es-size string                    Memory (RAM) in MB that each of the Elasticsearch instances will have (default "4g")
       --es-zones int32                    Number of zones the Elasticsearch instances will span (default 1)
   -f, --file string                       DeploymentCreateRequest file definition. See help for more information
       --generate-payload                  Returns the deployment payload without actually creating the deployment resources
   -h, --help                              help for create
       --kibana-ref-id string              Optional RefId for the Kibana deployment (default "main-kibana")
-      --kibana-size int32                 Memory (RAM) in MB that each of the Kibana instances will have (default 1024)
+      --kibana-size string                Memory (RAM) in MB that each of the Kibana instances will have (default "1g")
       --kibana-zones int32                Number of zones the Kibana instances will span (default 1)
       --name string                       Optional name for the deployment
       --plugin strings                    Additional plugins to add to the Elasticsearch deployment


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
In order to improve UX, all size flags take memory size in gigabytes instead
of megabytes.

Rather than making large modifications in the SDK, a helper function has 
been added to the command layer.

## Related Issues
https://github.com/elastic/ecctl/issues/335

## Motivation and Context
UX

## How Has This Been Tested?
manually and unit tests

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
