### PR TITLE
cmd: Fix deployment note commands

### DIFF
--- a/cmd/deployment/note/command.go
+++ b/cmd/deployment/note/command.go
@@ -161,9 +161,9 @@ func init() {
 // `deployments/DEPLOYMENT_ID/notes` endpoint is not specific to elasticsearch.
 // For the time being the command layer will fetch the ES ID until the endpoint
 // accepts deployment IDs.
-func getElasticsearchID(deploymentID string, api *api.API) (string, error) {
+func getElasticsearchID(deploymentID string, ecAPI *api.API) (string, error) {
 	esID, err := deploymentapi.GetElasticsearchID(deploymentapi.GetParams{
-		API:          api,
+		API:          ecAPI,
 		DeploymentID: deploymentID,
 	})
 	if err != nil {

--- a/cmd/deployment/note/command.go
+++ b/cmd/deployment/note/command.go
@@ -162,13 +162,8 @@ func init() {
 // For the time being the command layer will fetch the ES ID until the endpoint
 // accepts deployment IDs.
 func getElasticsearchID(deploymentID string, ecAPI *api.API) (string, error) {
-	esID, err := deploymentapi.GetElasticsearchID(deploymentapi.GetParams{
+	return deploymentapi.GetElasticsearchID(deploymentapi.GetParams{
 		API:          ecAPI,
 		DeploymentID: deploymentID,
 	})
-	if err != nil {
-		return "", err
-	}
-
-	return esID, nil
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Fixes an issue where the `ecctl deployment note` commands did not have the
`Region` parameter set.

Additionally, a small bug has been fixed where the ID that is meant to be passed to
the API is the Elasticsearch ID, not the deployment ID.

## How Has This Been Tested?
Manually running all the commands against an ECE environment.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
