### PR TITLE
cmd: Add region parameter to allocator metadata

### DIFF
--- a/cmd/platform/allocator/metadata/command.go
+++ b/cmd/platform/allocator/metadata/command.go
@@ -63,9 +63,10 @@ var allocatorMetadataDeleteCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		var params = &allocatorapi.MetadataDeleteParams{
-			API: ecctl.Get().API,
-			ID:  args[0],
-			Key: args[1],
+			API:    ecctl.Get().API,
+			ID:     args[0],
+			Key:    args[1],
+			Region: ecctl.Get().Config.Region,
 		}
 		err := allocatorapi.DeleteAllocatorMetadataItem(*params)
 
@@ -82,8 +83,9 @@ var allocatorMetadataShowCmd = &cobra.Command{
 	PreRunE: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var params = allocatorapi.MetadataGetParams{
-			API: ecctl.Get().API,
-			ID:  args[0],
+			API:    ecctl.Get().API,
+			ID:     args[0],
+			Region: ecctl.Get().Config.Region,
 		}
 		res, err := allocatorapi.GetAllocatorMetadata(params)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Fixes an issue where the `ecctl platform allocator metadata {delete | show}`
commands where not setting the `Region` field.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
