### PR TITLE
cmd: Rename apikey to api-key and EC_API_KEY

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -108,7 +108,7 @@ func init() {
 	RootCmd.PersistentFlags().String("host", "", "Base URL to use")
 	RootCmd.PersistentFlags().String("user", "", "Username to use to authenticate (If empty will look for EC_USER environment variable)")
 	RootCmd.PersistentFlags().String("pass", "", "Password to use to authenticate (If empty will look for EC_PASS environment variable)")
-	RootCmd.PersistentFlags().String("apikey", "", "API key to use to authenticate (If empty will look for EC_APIKEY environment variable)")
+	RootCmd.PersistentFlags().String("api-key", "", "API key to use to authenticate (If empty will look for EC_API_KEY environment variable)")
 	RootCmd.PersistentFlags().Bool("verbose", false, "Enable verbose mode")
 	RootCmd.PersistentFlags().String("output", "text", "Output format [text|json]")
 	RootCmd.PersistentFlags().Bool("force", false, "Do not ask for confirmation")

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -200,7 +200,7 @@ func TestInitApp(t *testing.T) {
 				multierror.NewPrefixed(
 					"invalid configuration options specified",
 					errors.New("output must be one either json or text"),
-					errors.New("apikey or user and pass must be specified"),
+					errors.New("api_key or user and pass must be specified"),
 				),
 			),
 		},

--- a/docs/ecctl-getting-started.asciidoc
+++ b/docs/ecctl-getting-started.asciidoc
@@ -154,7 +154,7 @@ authenticated clients. The preferred authentication method is API keys.
 There are two ways to authenticate against the Elasticsearch Service or the Elastic Cloud Enterprise APIs
 {p}:
 
-* By specifying an API key using the `--apikey` flag
+* By specifying an API key using the `--api-key` flag
 * By specifying the `--user` and `--pass` flags
 
 The first method requires the user to already have an API key, if this
@@ -179,8 +179,8 @@ the binary for Elastic Cloud:
 host: https://api.elastic-cloud.com # URL of your Elasticsearch Service or Elastic Cloud Enterprise API endpoint
 
 # Credentials
-## apikey is the preferred authentication mechanism.
-apikey: bWFyYzo4ZTJmNmZkNjY5ZmQ0MDBkOTQ3ZjI3MTg3ZWI5MWZhYjpOQktHY05jclE0cTBzcUlnTXg3QTd3
+## api_key is the preferred authentication mechanism.
+api_key: bWFyYzo4ZTJmNmZkNjY5ZmQ0MDBkOTQ3ZjI3MTg3ZWI5MWZhYjpOQktHY05jclE0cTBzcUlnTXg3QTd3
 
 ## username and password can be used when no API key is available.
 user: username
@@ -198,7 +198,7 @@ i.e. `EC_HOST` or `EC_USER`.
 
 [source,sh]
 ----
-export EC_APIKEY=bWFyYzo4ZTJmNmZkNjY5ZmQ0MDBkOTQ3ZjI3MTg3ZWI5MWZhYjpOQktHY05jclE0cTBzcUlnTXg3QTd3
+export EC_API_KEY=bWFyYzo4ZTJmNmZkNjY5ZmQ0MDBkOTQ3ZjI3MTg3ZWI5MWZhYjpOQktHY05jclE0cTBzcUlnTXg3QTd3
 ----
 
 [float]

--- a/docs/ecctl.adoc
+++ b/docs/ecctl.adoc
@@ -12,7 +12,7 @@ Elastic Cloud Control
 === Options
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl.md
+++ b/docs/ecctl.md
@@ -9,7 +9,7 @@ Elastic Cloud Control
 ### Options
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_auth.adoc
+++ b/docs/ecctl_auth.adoc
@@ -23,7 +23,7 @@ ecctl auth [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_auth.md
+++ b/docs/ecctl_auth.md
@@ -19,7 +19,7 @@ ecctl auth [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_auth_key.adoc
+++ b/docs/ecctl_auth_key.adoc
@@ -23,7 +23,7 @@ ecctl auth key [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_auth_key.md
+++ b/docs/ecctl_auth_key.md
@@ -19,7 +19,7 @@ ecctl auth key [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_auth_key_create.adoc
+++ b/docs/ecctl_auth_key_create.adoc
@@ -25,7 +25,7 @@ ecctl auth key create [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_auth_key_create.md
+++ b/docs/ecctl_auth_key_create.md
@@ -21,7 +21,7 @@ ecctl auth key create [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_auth_key_delete.adoc
+++ b/docs/ecctl_auth_key_delete.adoc
@@ -23,7 +23,7 @@ ecctl auth key delete <key id> <key id> ... [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_auth_key_delete.md
+++ b/docs/ecctl_auth_key_delete.md
@@ -19,7 +19,7 @@ ecctl auth key delete <key id> <key id> ... [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_auth_key_list.adoc
+++ b/docs/ecctl_auth_key_list.adoc
@@ -23,7 +23,7 @@ ecctl auth key list [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_auth_key_list.md
+++ b/docs/ecctl_auth_key_list.md
@@ -19,7 +19,7 @@ ecctl auth key list [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_auth_key_show.adoc
+++ b/docs/ecctl_auth_key_show.adoc
@@ -23,7 +23,7 @@ ecctl auth key show <key id> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_auth_key_show.md
+++ b/docs/ecctl_auth_key_show.md
@@ -19,7 +19,7 @@ ecctl auth key show <key id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment.adoc
+++ b/docs/ecctl_deployment.adoc
@@ -23,7 +23,7 @@ ecctl deployment [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment.md
+++ b/docs/ecctl_deployment.md
@@ -19,7 +19,7 @@ ecctl deployment [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_create.adoc
+++ b/docs/ecctl_deployment_create.adoc
@@ -96,7 +96,7 @@ $ ecctl deployment create --request-id=GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhG
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_create.md
+++ b/docs/ecctl_deployment_create.md
@@ -99,7 +99,7 @@ $ ecctl deployment create --request-id=GMZPMRrcMYqHdmxjIQkHbdjnhPIeBElcwrHwzVlhG
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_delete.adoc
+++ b/docs/ecctl_deployment_delete.adoc
@@ -23,7 +23,7 @@ ecctl deployment delete <deployment-id> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_delete.md
+++ b/docs/ecctl_deployment_delete.md
@@ -19,7 +19,7 @@ ecctl deployment delete <deployment-id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_elasticsearch.adoc
+++ b/docs/ecctl_deployment_elasticsearch.adoc
@@ -23,7 +23,7 @@ ecctl deployment elasticsearch [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_elasticsearch.md
+++ b/docs/ecctl_deployment_elasticsearch.md
@@ -19,7 +19,7 @@ ecctl deployment elasticsearch [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_elasticsearch_keystore.adoc
+++ b/docs/ecctl_deployment_elasticsearch_keystore.adoc
@@ -23,7 +23,7 @@ ecctl deployment elasticsearch keystore [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_elasticsearch_keystore.md
+++ b/docs/ecctl_deployment_elasticsearch_keystore.md
@@ -19,7 +19,7 @@ ecctl deployment elasticsearch keystore [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_elasticsearch_keystore_show.adoc
+++ b/docs/ecctl_deployment_elasticsearch_keystore_show.adoc
@@ -24,7 +24,7 @@ ecctl deployment elasticsearch keystore show <deployment id> [--ref-id <ref-id>]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_elasticsearch_keystore_show.md
+++ b/docs/ecctl_deployment_elasticsearch_keystore_show.md
@@ -20,7 +20,7 @@ ecctl deployment elasticsearch keystore show <deployment id> [--ref-id <ref-id>]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_elasticsearch_keystore_update.adoc
+++ b/docs/ecctl_deployment_elasticsearch_keystore_update.adoc
@@ -28,7 +28,7 @@ ecctl deployment elasticsearch keystore update <deployment id> [--ref-id <ref-id
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_elasticsearch_keystore_update.md
+++ b/docs/ecctl_deployment_elasticsearch_keystore_update.md
@@ -24,7 +24,7 @@ ecctl deployment elasticsearch keystore update <deployment id> [--ref-id <ref-id
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_list.adoc
+++ b/docs/ecctl_deployment_list.adoc
@@ -23,7 +23,7 @@ ecctl deployment list [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_list.md
+++ b/docs/ecctl_deployment_list.md
@@ -19,7 +19,7 @@ ecctl deployment list [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_note.adoc
+++ b/docs/ecctl_deployment_note.adoc
@@ -23,7 +23,7 @@ ecctl deployment note [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_note.md
+++ b/docs/ecctl_deployment_note.md
@@ -19,7 +19,7 @@ ecctl deployment note [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_note_create.adoc
+++ b/docs/ecctl_deployment_note_create.adoc
@@ -24,7 +24,7 @@ ecctl deployment note create <deployment id> --comment <comment content> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_note_create.md
+++ b/docs/ecctl_deployment_note_create.md
@@ -20,7 +20,7 @@ ecctl deployment note create <deployment id> --comment <comment content> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_note_list.adoc
+++ b/docs/ecctl_deployment_note_list.adoc
@@ -23,7 +23,7 @@ ecctl deployment note list <deployment id> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_note_list.md
+++ b/docs/ecctl_deployment_note_list.md
@@ -19,7 +19,7 @@ ecctl deployment note list <deployment id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_note_show.adoc
+++ b/docs/ecctl_deployment_note_show.adoc
@@ -24,7 +24,7 @@ ecctl deployment note show <deployment id> --id <note id> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_note_show.md
+++ b/docs/ecctl_deployment_note_show.md
@@ -20,7 +20,7 @@ ecctl deployment note show <deployment id> --id <note id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_note_update.adoc
+++ b/docs/ecctl_deployment_note_update.adoc
@@ -25,7 +25,7 @@ ecctl deployment note update <deployment id> --id <note id> --comment <comment c
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_note_update.md
+++ b/docs/ecctl_deployment_note_update.md
@@ -21,7 +21,7 @@ ecctl deployment note update <deployment id> --id <note id> --comment <comment c
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_plan.adoc
+++ b/docs/ecctl_deployment_plan.adoc
@@ -23,7 +23,7 @@ ecctl deployment plan [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_plan.md
+++ b/docs/ecctl_deployment_plan.md
@@ -19,7 +19,7 @@ ecctl deployment plan [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_plan_cancel.adoc
+++ b/docs/ecctl_deployment_plan_cancel.adoc
@@ -25,7 +25,7 @@ ecctl deployment plan cancel <deployment id> --kind <kind> [--ref-id <ref-id>] [
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_plan_cancel.md
+++ b/docs/ecctl_deployment_plan_cancel.md
@@ -21,7 +21,7 @@ ecctl deployment plan cancel <deployment id> --kind <kind> [--ref-id <ref-id>] [
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_resource.adoc
+++ b/docs/ecctl_deployment_resource.adoc
@@ -23,7 +23,7 @@ ecctl deployment resource [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_resource.md
+++ b/docs/ecctl_deployment_resource.md
@@ -19,7 +19,7 @@ ecctl deployment resource [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_resource_delete.adoc
+++ b/docs/ecctl_deployment_resource_delete.adoc
@@ -25,7 +25,7 @@ ecctl deployment resource delete <deployment id> --kind <kind> --ref-id <ref-id>
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_resource_delete.md
+++ b/docs/ecctl_deployment_resource_delete.md
@@ -21,7 +21,7 @@ ecctl deployment resource delete <deployment id> --kind <kind> --ref-id <ref-id>
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_resource_restore.adoc
+++ b/docs/ecctl_deployment_resource_restore.adoc
@@ -26,7 +26,7 @@ ecctl deployment resource restore <deployment id> --kind <kind> --ref-id <ref-id
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_resource_restore.md
+++ b/docs/ecctl_deployment_resource_restore.md
@@ -22,7 +22,7 @@ ecctl deployment resource restore <deployment id> --kind <kind> --ref-id <ref-id
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_resource_shutdown.adoc
+++ b/docs/ecctl_deployment_resource_shutdown.adoc
@@ -28,7 +28,7 @@ ecctl deployment resource shutdown <deployment id> --kind <kind> --ref-id <ref-i
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_resource_shutdown.md
+++ b/docs/ecctl_deployment_resource_shutdown.md
@@ -24,7 +24,7 @@ ecctl deployment resource shutdown <deployment id> --kind <kind> --ref-id <ref-i
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_resource_start-maintenance.adoc
+++ b/docs/ecctl_deployment_resource_start-maintenance.adoc
@@ -28,7 +28,7 @@ ecctl deployment resource start-maintenance <deployment id> --kind <kind> [--all
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_resource_start-maintenance.md
+++ b/docs/ecctl_deployment_resource_start-maintenance.md
@@ -24,7 +24,7 @@ ecctl deployment resource start-maintenance <deployment id> --kind <kind> [--all
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_resource_start.adoc
+++ b/docs/ecctl_deployment_resource_start.adoc
@@ -28,7 +28,7 @@ ecctl deployment resource start <deployment id> --kind <kind> [--all|--i <instan
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_resource_start.md
+++ b/docs/ecctl_deployment_resource_start.md
@@ -24,7 +24,7 @@ ecctl deployment resource start <deployment id> --kind <kind> [--all|--i <instan
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_resource_stop-maintenance.adoc
+++ b/docs/ecctl_deployment_resource_stop-maintenance.adoc
@@ -28,7 +28,7 @@ ecctl deployment resource stop-maintenance <deployment id> --kind <kind> [--all|
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_resource_stop-maintenance.md
+++ b/docs/ecctl_deployment_resource_stop-maintenance.md
@@ -24,7 +24,7 @@ ecctl deployment resource stop-maintenance <deployment id> --kind <kind> [--all|
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_resource_stop.adoc
+++ b/docs/ecctl_deployment_resource_stop.adoc
@@ -28,7 +28,7 @@ ecctl deployment resource stop <deployment id> --kind <kind> [--all|--i <instanc
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_resource_stop.md
+++ b/docs/ecctl_deployment_resource_stop.md
@@ -24,7 +24,7 @@ ecctl deployment resource stop <deployment id> --kind <kind> [--all|--i <instanc
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_resource_upgrade.adoc
+++ b/docs/ecctl_deployment_resource_upgrade.adoc
@@ -27,7 +27,7 @@ ecctl deployment resource upgrade <deployment id> --kind <kind> --ref-id <ref-id
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_resource_upgrade.md
+++ b/docs/ecctl_deployment_resource_upgrade.md
@@ -23,7 +23,7 @@ ecctl deployment resource upgrade <deployment id> --kind <kind> --ref-id <ref-id
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_restore.adoc
+++ b/docs/ecctl_deployment_restore.adoc
@@ -32,7 +32,7 @@ ecctl deployment restore <deployment-id> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_restore.md
+++ b/docs/ecctl_deployment_restore.md
@@ -30,7 +30,7 @@ $ ecctl deployment restore 5c17ad7c8df73206baa54b6e2829d9bc
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_resync.adoc
+++ b/docs/ecctl_deployment_resync.adoc
@@ -24,7 +24,7 @@ ecctl deployment resync {<deployment id> | --all} [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_resync.md
+++ b/docs/ecctl_deployment_resync.md
@@ -20,7 +20,7 @@ ecctl deployment resync {<deployment id> | --all} [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_search.adoc
+++ b/docs/ecctl_deployment_search.adoc
@@ -38,7 +38,7 @@ ecctl deployment search -f <query file.json> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_search.md
+++ b/docs/ecctl_deployment_search.md
@@ -35,7 +35,7 @@ $ ecctl deployment search -f query_string_query.json
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_show.adoc
+++ b/docs/ecctl_deployment_show.adoc
@@ -47,7 +47,7 @@ ecctl deployment show <deployment-id> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_show.md
+++ b/docs/ecctl_deployment_show.md
@@ -42,7 +42,7 @@ ecctl deployment show <deployment-id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_shutdown.adoc
+++ b/docs/ecctl_deployment_shutdown.adoc
@@ -25,7 +25,7 @@ ecctl deployment shutdown <deployment-id> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_shutdown.md
+++ b/docs/ecctl_deployment_shutdown.md
@@ -21,7 +21,7 @@ ecctl deployment shutdown <deployment-id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_template.adoc
+++ b/docs/ecctl_deployment_template.adoc
@@ -23,7 +23,7 @@ ecctl deployment template [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_template.md
+++ b/docs/ecctl_deployment_template.md
@@ -19,7 +19,7 @@ ecctl deployment template [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_template_create.adoc
+++ b/docs/ecctl_deployment_template_create.adoc
@@ -26,7 +26,7 @@ ecctl deployment template create --file <definition.json> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_template_create.md
+++ b/docs/ecctl_deployment_template_create.md
@@ -22,7 +22,7 @@ ecctl deployment template create --file <definition.json> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_template_delete.adoc
+++ b/docs/ecctl_deployment_template_delete.adoc
@@ -24,7 +24,7 @@ ecctl deployment template delete --template-id <template id> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_template_delete.md
+++ b/docs/ecctl_deployment_template_delete.md
@@ -20,7 +20,7 @@ ecctl deployment template delete --template-id <template id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_template_list.adoc
+++ b/docs/ecctl_deployment_template_list.adoc
@@ -26,7 +26,7 @@ ecctl deployment template list [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_template_list.md
+++ b/docs/ecctl_deployment_template_list.md
@@ -22,7 +22,7 @@ ecctl deployment template list [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_template_show.adoc
+++ b/docs/ecctl_deployment_template_show.adoc
@@ -26,7 +26,7 @@ ecctl deployment template show --template-id <template id> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_template_show.md
+++ b/docs/ecctl_deployment_template_show.md
@@ -22,7 +22,7 @@ ecctl deployment template show --template-id <template id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_template_update.adoc
+++ b/docs/ecctl_deployment_template_update.adoc
@@ -26,7 +26,7 @@ ecctl deployment template update --template-id <template id> --file <definition.
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_template_update.md
+++ b/docs/ecctl_deployment_template_update.md
@@ -22,7 +22,7 @@ ecctl deployment template update --template-id <template id> --file <definition.
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_update.adoc
+++ b/docs/ecctl_deployment_update.adoc
@@ -82,7 +82,7 @@ setting --prune-orphans to "true" will cause any resources not specified in the 
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_deployment_update.md
+++ b/docs/ecctl_deployment_update.md
@@ -77,7 +77,7 @@ setting --prune-orphans to "true" will cause any resources not specified in the 
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_generate.adoc
+++ b/docs/ecctl_generate.adoc
@@ -23,7 +23,7 @@ ecctl generate [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_generate.md
+++ b/docs/ecctl_generate.md
@@ -19,7 +19,7 @@ ecctl generate [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_generate_completions.adoc
+++ b/docs/ecctl_generate_completions.adoc
@@ -25,7 +25,7 @@ ecctl generate completions [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_generate_completions.md
+++ b/docs/ecctl_generate_completions.md
@@ -21,7 +21,7 @@ ecctl generate completions [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_generate_docs.adoc
+++ b/docs/ecctl_generate_docs.adoc
@@ -24,7 +24,7 @@ ecctl generate docs [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_generate_docs.md
+++ b/docs/ecctl_generate_docs.md
@@ -20,7 +20,7 @@ ecctl generate docs [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_init.adoc
+++ b/docs/ecctl_init.adoc
@@ -23,7 +23,7 @@ ecctl init [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_init.md
+++ b/docs/ecctl_init.md
@@ -19,7 +19,7 @@ ecctl init [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform.adoc
+++ b/docs/ecctl_platform.adoc
@@ -23,7 +23,7 @@ ecctl platform [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform.md
+++ b/docs/ecctl_platform.md
@@ -19,7 +19,7 @@ ecctl platform [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_allocator.adoc
+++ b/docs/ecctl_platform_allocator.adoc
@@ -23,7 +23,7 @@ ecctl platform allocator [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_allocator.md
+++ b/docs/ecctl_platform_allocator.md
@@ -19,7 +19,7 @@ ecctl platform allocator [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_allocator_list.adoc
+++ b/docs/ecctl_platform_allocator_list.adoc
@@ -50,7 +50,7 @@ ecctl platform allocator list [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_allocator_list.md
+++ b/docs/ecctl_platform_allocator_list.md
@@ -44,7 +44,7 @@ ecctl platform allocator list [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_allocator_maintenance.adoc
+++ b/docs/ecctl_platform_allocator_maintenance.adoc
@@ -24,7 +24,7 @@ ecctl platform allocator maintenance <allocator id> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_allocator_maintenance.md
+++ b/docs/ecctl_platform_allocator_maintenance.md
@@ -20,7 +20,7 @@ ecctl platform allocator maintenance <allocator id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_allocator_metadata.adoc
+++ b/docs/ecctl_platform_allocator_metadata.adoc
@@ -23,7 +23,7 @@ ecctl platform allocator metadata [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_allocator_metadata.md
+++ b/docs/ecctl_platform_allocator_metadata.md
@@ -19,7 +19,7 @@ ecctl platform allocator metadata [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_allocator_metadata_delete.adoc
+++ b/docs/ecctl_platform_allocator_metadata_delete.adoc
@@ -23,7 +23,7 @@ ecctl platform allocator metadata delete <allocator id> <key> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_allocator_metadata_delete.md
+++ b/docs/ecctl_platform_allocator_metadata_delete.md
@@ -19,7 +19,7 @@ ecctl platform allocator metadata delete <allocator id> <key> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_allocator_metadata_set.adoc
+++ b/docs/ecctl_platform_allocator_metadata_set.adoc
@@ -23,7 +23,7 @@ ecctl platform allocator metadata set <allocator id> <key> <value> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_allocator_metadata_set.md
+++ b/docs/ecctl_platform_allocator_metadata_set.md
@@ -19,7 +19,7 @@ ecctl platform allocator metadata set <allocator id> <key> <value> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_allocator_metadata_show.adoc
+++ b/docs/ecctl_platform_allocator_metadata_show.adoc
@@ -23,7 +23,7 @@ ecctl platform allocator metadata show <allocator id> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_allocator_metadata_show.md
+++ b/docs/ecctl_platform_allocator_metadata_show.md
@@ -19,7 +19,7 @@ ecctl platform allocator metadata show <allocator id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_allocator_search.adoc
+++ b/docs/ecctl_platform_allocator_search.adoc
@@ -25,7 +25,7 @@ ecctl platform allocator search [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_allocator_search.md
+++ b/docs/ecctl_platform_allocator_search.md
@@ -21,7 +21,7 @@ ecctl platform allocator search [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_allocator_show.adoc
+++ b/docs/ecctl_platform_allocator_show.adoc
@@ -24,7 +24,7 @@ ecctl platform allocator show <allocator id> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_allocator_show.md
+++ b/docs/ecctl_platform_allocator_show.md
@@ -20,7 +20,7 @@ ecctl platform allocator show <allocator id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_allocator_vacate.adoc
+++ b/docs/ecctl_platform_allocator_vacate.adoc
@@ -74,7 +74,7 @@ ecctl platform allocator vacate <allocator-id> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_allocator_vacate.md
+++ b/docs/ecctl_platform_allocator_vacate.md
@@ -70,7 +70,7 @@ ecctl platform allocator vacate <allocator-id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_constructor.adoc
+++ b/docs/ecctl_platform_constructor.adoc
@@ -23,7 +23,7 @@ ecctl platform constructor [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_constructor.md
+++ b/docs/ecctl_platform_constructor.md
@@ -19,7 +19,7 @@ ecctl platform constructor [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_constructor_list.adoc
+++ b/docs/ecctl_platform_constructor_list.adoc
@@ -23,7 +23,7 @@ ecctl platform constructor list [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_constructor_list.md
+++ b/docs/ecctl_platform_constructor_list.md
@@ -19,7 +19,7 @@ ecctl platform constructor list [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_constructor_maintenance.adoc
+++ b/docs/ecctl_platform_constructor_maintenance.adoc
@@ -24,7 +24,7 @@ ecctl platform constructor maintenance <constructor id> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_constructor_maintenance.md
+++ b/docs/ecctl_platform_constructor_maintenance.md
@@ -20,7 +20,7 @@ ecctl platform constructor maintenance <constructor id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_constructor_resync.adoc
+++ b/docs/ecctl_platform_constructor_resync.adoc
@@ -24,7 +24,7 @@ ecctl platform constructor resync {<constructor id> | --all} [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_constructor_resync.md
+++ b/docs/ecctl_platform_constructor_resync.md
@@ -20,7 +20,7 @@ ecctl platform constructor resync {<constructor id> | --all} [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_constructor_show.adoc
+++ b/docs/ecctl_platform_constructor_show.adoc
@@ -23,7 +23,7 @@ ecctl platform constructor show <constructor id> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_constructor_show.md
+++ b/docs/ecctl_platform_constructor_show.md
@@ -19,7 +19,7 @@ ecctl platform constructor show <constructor id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_enrollment-token.adoc
+++ b/docs/ecctl_platform_enrollment-token.adoc
@@ -23,7 +23,7 @@ ecctl platform enrollment-token [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_enrollment-token.md
+++ b/docs/ecctl_platform_enrollment-token.md
@@ -19,7 +19,7 @@ ecctl platform enrollment-token [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_enrollment-token_create.adoc
+++ b/docs/ecctl_platform_enrollment-token_create.adoc
@@ -35,7 +35,7 @@ ecctl platform enrollment-token create --role <ROLE> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_enrollment-token_create.md
+++ b/docs/ecctl_platform_enrollment-token_create.md
@@ -30,7 +30,7 @@ ecctl platform enrollment-token create --role <ROLE> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_enrollment-token_delete.adoc
+++ b/docs/ecctl_platform_enrollment-token_delete.adoc
@@ -23,7 +23,7 @@ ecctl platform enrollment-token delete <enrollment-token> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_enrollment-token_delete.md
+++ b/docs/ecctl_platform_enrollment-token_delete.md
@@ -19,7 +19,7 @@ ecctl platform enrollment-token delete <enrollment-token> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_enrollment-token_list.adoc
+++ b/docs/ecctl_platform_enrollment-token_list.adoc
@@ -23,7 +23,7 @@ ecctl platform enrollment-token list [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_enrollment-token_list.md
+++ b/docs/ecctl_platform_enrollment-token_list.md
@@ -19,7 +19,7 @@ ecctl platform enrollment-token list [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_info.adoc
+++ b/docs/ecctl_platform_info.adoc
@@ -23,7 +23,7 @@ ecctl platform info [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_info.md
+++ b/docs/ecctl_platform_info.md
@@ -19,7 +19,7 @@ ecctl platform info [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_instance-configuration.adoc
+++ b/docs/ecctl_platform_instance-configuration.adoc
@@ -23,7 +23,7 @@ ecctl platform instance-configuration [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_instance-configuration.md
+++ b/docs/ecctl_platform_instance-configuration.md
@@ -19,7 +19,7 @@ ecctl platform instance-configuration [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_instance-configuration_create.adoc
+++ b/docs/ecctl_platform_instance-configuration_create.adoc
@@ -25,7 +25,7 @@ ecctl platform instance-configuration create -f <config.json> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_instance-configuration_create.md
+++ b/docs/ecctl_platform_instance-configuration_create.md
@@ -21,7 +21,7 @@ ecctl platform instance-configuration create -f <config.json> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_instance-configuration_delete.adoc
+++ b/docs/ecctl_platform_instance-configuration_delete.adoc
@@ -23,7 +23,7 @@ ecctl platform instance-configuration delete <config id> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_instance-configuration_delete.md
+++ b/docs/ecctl_platform_instance-configuration_delete.md
@@ -19,7 +19,7 @@ ecctl platform instance-configuration delete <config id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_instance-configuration_list.adoc
+++ b/docs/ecctl_platform_instance-configuration_list.adoc
@@ -23,7 +23,7 @@ ecctl platform instance-configuration list [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_instance-configuration_list.md
+++ b/docs/ecctl_platform_instance-configuration_list.md
@@ -19,7 +19,7 @@ ecctl platform instance-configuration list [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_instance-configuration_pull.adoc
+++ b/docs/ecctl_platform_instance-configuration_pull.adoc
@@ -24,7 +24,7 @@ ecctl platform instance-configuration pull --path <path> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_instance-configuration_pull.md
+++ b/docs/ecctl_platform_instance-configuration_pull.md
@@ -20,7 +20,7 @@ ecctl platform instance-configuration pull --path <path> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_instance-configuration_show.adoc
+++ b/docs/ecctl_platform_instance-configuration_show.adoc
@@ -23,7 +23,7 @@ ecctl platform instance-configuration show <config id> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_instance-configuration_show.md
+++ b/docs/ecctl_platform_instance-configuration_show.md
@@ -19,7 +19,7 @@ ecctl platform instance-configuration show <config id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_instance-configuration_update.adoc
+++ b/docs/ecctl_platform_instance-configuration_update.adoc
@@ -24,7 +24,7 @@ ecctl platform instance-configuration update <config id> -f <config.json> [flags
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_instance-configuration_update.md
+++ b/docs/ecctl_platform_instance-configuration_update.md
@@ -20,7 +20,7 @@ ecctl platform instance-configuration update <config id> -f <config.json> [flags
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_proxy.adoc
+++ b/docs/ecctl_platform_proxy.adoc
@@ -23,7 +23,7 @@ ecctl platform proxy [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_proxy.md
+++ b/docs/ecctl_platform_proxy.md
@@ -19,7 +19,7 @@ ecctl platform proxy [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_proxy_filtered-group.adoc
+++ b/docs/ecctl_platform_proxy_filtered-group.adoc
@@ -23,7 +23,7 @@ ecctl platform proxy filtered-group [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_proxy_filtered-group.md
+++ b/docs/ecctl_platform_proxy_filtered-group.md
@@ -19,7 +19,7 @@ ecctl platform proxy filtered-group [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_proxy_filtered-group_create.adoc
+++ b/docs/ecctl_platform_proxy_filtered-group_create.adoc
@@ -25,7 +25,7 @@ ecctl platform proxy filtered-group create <filtered group id> --filters <key1=v
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_proxy_filtered-group_create.md
+++ b/docs/ecctl_platform_proxy_filtered-group_create.md
@@ -21,7 +21,7 @@ ecctl platform proxy filtered-group create <filtered group id> --filters <key1=v
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_proxy_filtered-group_delete.adoc
+++ b/docs/ecctl_platform_proxy_filtered-group_delete.adoc
@@ -23,7 +23,7 @@ ecctl platform proxy filtered-group delete <filtered group id> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_proxy_filtered-group_delete.md
+++ b/docs/ecctl_platform_proxy_filtered-group_delete.md
@@ -19,7 +19,7 @@ ecctl platform proxy filtered-group delete <filtered group id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_proxy_filtered-group_list.adoc
+++ b/docs/ecctl_platform_proxy_filtered-group_list.adoc
@@ -23,7 +23,7 @@ ecctl platform proxy filtered-group list [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_proxy_filtered-group_list.md
+++ b/docs/ecctl_platform_proxy_filtered-group_list.md
@@ -19,7 +19,7 @@ ecctl platform proxy filtered-group list [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_proxy_filtered-group_show.adoc
+++ b/docs/ecctl_platform_proxy_filtered-group_show.adoc
@@ -23,7 +23,7 @@ ecctl platform proxy filtered-group show <filtered group id> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_proxy_filtered-group_show.md
+++ b/docs/ecctl_platform_proxy_filtered-group_show.md
@@ -19,7 +19,7 @@ ecctl platform proxy filtered-group show <filtered group id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_proxy_filtered-group_update.adoc
+++ b/docs/ecctl_platform_proxy_filtered-group_update.adoc
@@ -26,7 +26,7 @@ ecctl platform proxy filtered-group update <filtered group id> --filters <key1=v
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_proxy_filtered-group_update.md
+++ b/docs/ecctl_platform_proxy_filtered-group_update.md
@@ -22,7 +22,7 @@ ecctl platform proxy filtered-group update <filtered group id> --filters <key1=v
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_proxy_list.adoc
+++ b/docs/ecctl_platform_proxy_list.adoc
@@ -23,7 +23,7 @@ ecctl platform proxy list [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_proxy_list.md
+++ b/docs/ecctl_platform_proxy_list.md
@@ -19,7 +19,7 @@ ecctl platform proxy list [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_proxy_show.adoc
+++ b/docs/ecctl_platform_proxy_show.adoc
@@ -23,7 +23,7 @@ ecctl platform proxy show <proxy id> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_proxy_show.md
+++ b/docs/ecctl_platform_proxy_show.md
@@ -19,7 +19,7 @@ ecctl platform proxy show <proxy id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_repository.adoc
+++ b/docs/ecctl_platform_repository.adoc
@@ -24,7 +24,7 @@ ecctl platform repository [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_repository.md
+++ b/docs/ecctl_platform_repository.md
@@ -21,7 +21,7 @@ ecctl platform repository [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_repository_create.adoc
+++ b/docs/ecctl_platform_repository_create.adoc
@@ -44,7 +44,7 @@ ecctl platform repository create custom --type fs --settings settings.yml
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_repository_create.md
+++ b/docs/ecctl_platform_repository_create.md
@@ -41,7 +41,7 @@ ecctl platform repository create custom --type fs --settings settings.yml
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_repository_delete.adoc
+++ b/docs/ecctl_platform_repository_delete.adoc
@@ -23,7 +23,7 @@ ecctl platform repository delete <repository name> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_repository_delete.md
+++ b/docs/ecctl_platform_repository_delete.md
@@ -19,7 +19,7 @@ ecctl platform repository delete <repository name> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_repository_list.adoc
+++ b/docs/ecctl_platform_repository_list.adoc
@@ -23,7 +23,7 @@ ecctl platform repository list [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_repository_list.md
+++ b/docs/ecctl_platform_repository_list.md
@@ -19,7 +19,7 @@ ecctl platform repository list [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_repository_show.adoc
+++ b/docs/ecctl_platform_repository_show.adoc
@@ -23,7 +23,7 @@ ecctl platform repository show <repository name> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_repository_show.md
+++ b/docs/ecctl_platform_repository_show.md
@@ -19,7 +19,7 @@ ecctl platform repository show <repository name> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_role.adoc
+++ b/docs/ecctl_platform_role.adoc
@@ -23,7 +23,7 @@ ecctl platform role [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_role.md
+++ b/docs/ecctl_platform_role.md
@@ -19,7 +19,7 @@ ecctl platform role [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_role_create.adoc
+++ b/docs/ecctl_platform_role_create.adoc
@@ -24,7 +24,7 @@ ecctl platform role create --file <filename.json> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_role_create.md
+++ b/docs/ecctl_platform_role_create.md
@@ -20,7 +20,7 @@ ecctl platform role create --file <filename.json> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_role_delete.adoc
+++ b/docs/ecctl_platform_role_delete.adoc
@@ -23,7 +23,7 @@ ecctl platform role delete <role> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_role_delete.md
+++ b/docs/ecctl_platform_role_delete.md
@@ -19,7 +19,7 @@ ecctl platform role delete <role> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_role_list.adoc
+++ b/docs/ecctl_platform_role_list.adoc
@@ -23,7 +23,7 @@ ecctl platform role list [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_role_list.md
+++ b/docs/ecctl_platform_role_list.md
@@ -19,7 +19,7 @@ ecctl platform role list [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_role_show.adoc
+++ b/docs/ecctl_platform_role_show.adoc
@@ -23,7 +23,7 @@ ecctl platform role show <role> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_role_show.md
+++ b/docs/ecctl_platform_role_show.md
@@ -19,7 +19,7 @@ ecctl platform role show <role> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_runner.adoc
+++ b/docs/ecctl_platform_runner.adoc
@@ -23,7 +23,7 @@ ecctl platform runner [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_runner.md
+++ b/docs/ecctl_platform_runner.md
@@ -19,7 +19,7 @@ ecctl platform runner [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_runner_list.adoc
+++ b/docs/ecctl_platform_runner_list.adoc
@@ -23,7 +23,7 @@ ecctl platform runner list [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_runner_list.md
+++ b/docs/ecctl_platform_runner_list.md
@@ -19,7 +19,7 @@ ecctl platform runner list [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_runner_resync.adoc
+++ b/docs/ecctl_platform_runner_resync.adoc
@@ -24,7 +24,7 @@ ecctl platform runner resync {<runner id> | --all} [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_runner_resync.md
+++ b/docs/ecctl_platform_runner_resync.md
@@ -20,7 +20,7 @@ ecctl platform runner resync {<runner id> | --all} [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_runner_search.adoc
+++ b/docs/ecctl_platform_runner_search.adoc
@@ -25,7 +25,7 @@ ecctl platform runner search [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_runner_search.md
+++ b/docs/ecctl_platform_runner_search.md
@@ -21,7 +21,7 @@ ecctl platform runner search [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_runner_show.adoc
+++ b/docs/ecctl_platform_runner_show.adoc
@@ -23,7 +23,7 @@ ecctl platform runner show <runner id> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_platform_runner_show.md
+++ b/docs/ecctl_platform_runner_show.md
@@ -19,7 +19,7 @@ ecctl platform runner show <runner id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_stack.adoc
+++ b/docs/ecctl_stack.adoc
@@ -23,7 +23,7 @@ ecctl stack [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_stack.md
+++ b/docs/ecctl_stack.md
@@ -19,7 +19,7 @@ ecctl stack [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_stack_delete.adoc
+++ b/docs/ecctl_stack_delete.adoc
@@ -23,7 +23,7 @@ ecctl stack delete [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_stack_delete.md
+++ b/docs/ecctl_stack_delete.md
@@ -19,7 +19,7 @@ ecctl stack delete [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_stack_list.adoc
+++ b/docs/ecctl_stack_list.adoc
@@ -24,7 +24,7 @@ ecctl stack list [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_stack_list.md
+++ b/docs/ecctl_stack_list.md
@@ -20,7 +20,7 @@ ecctl stack list [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_stack_show.adoc
+++ b/docs/ecctl_stack_show.adoc
@@ -23,7 +23,7 @@ ecctl stack show [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_stack_show.md
+++ b/docs/ecctl_stack_show.md
@@ -19,7 +19,7 @@ ecctl stack show [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_stack_upload.adoc
+++ b/docs/ecctl_stack_upload.adoc
@@ -23,7 +23,7 @@ ecctl stack upload [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_stack_upload.md
+++ b/docs/ecctl_stack_upload.md
@@ -19,7 +19,7 @@ ecctl stack upload [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_user.adoc
+++ b/docs/ecctl_user.adoc
@@ -23,7 +23,7 @@ ecctl user [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_user.md
+++ b/docs/ecctl_user.md
@@ -19,7 +19,7 @@ ecctl user [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_user_create.adoc
+++ b/docs/ecctl_user_create.adoc
@@ -38,7 +38,7 @@ ecctl user create --username <username> --role <role> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_user_create.md
+++ b/docs/ecctl_user_create.md
@@ -34,7 +34,7 @@ ecctl user create --username <username> --role <role> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_user_delete.adoc
+++ b/docs/ecctl_user_delete.adoc
@@ -23,7 +23,7 @@ ecctl user delete <user name> <user name>... [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_user_delete.md
+++ b/docs/ecctl_user_delete.md
@@ -19,7 +19,7 @@ ecctl user delete <user name> <user name>... [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_user_disable.adoc
+++ b/docs/ecctl_user_disable.adoc
@@ -23,7 +23,7 @@ ecctl user disable <username> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_user_disable.md
+++ b/docs/ecctl_user_disable.md
@@ -19,7 +19,7 @@ ecctl user disable <username> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_user_enable.adoc
+++ b/docs/ecctl_user_enable.adoc
@@ -23,7 +23,7 @@ ecctl user enable <username> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_user_enable.md
+++ b/docs/ecctl_user_enable.md
@@ -19,7 +19,7 @@ ecctl user enable <username> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_user_key.adoc
+++ b/docs/ecctl_user_key.adoc
@@ -23,7 +23,7 @@ ecctl user key [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_user_key.md
+++ b/docs/ecctl_user_key.md
@@ -19,7 +19,7 @@ ecctl user key [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_user_key_delete.adoc
+++ b/docs/ecctl_user_key_delete.adoc
@@ -23,7 +23,7 @@ ecctl user key delete --user=<user id> <key id> <key id>... [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_user_key_delete.md
+++ b/docs/ecctl_user_key_delete.md
@@ -19,7 +19,7 @@ ecctl user key delete --user=<user id> <key id> <key id>... [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_user_key_list.adoc
+++ b/docs/ecctl_user_key_list.adoc
@@ -24,7 +24,7 @@ ecctl user key list --user=<user id>|--all [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_user_key_list.md
+++ b/docs/ecctl_user_key_list.md
@@ -20,7 +20,7 @@ ecctl user key list --user=<user id>|--all [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_user_key_show.adoc
+++ b/docs/ecctl_user_key_show.adoc
@@ -23,7 +23,7 @@ ecctl user key show --user=<user id> <key id> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_user_key_show.md
+++ b/docs/ecctl_user_key_show.md
@@ -19,7 +19,7 @@ ecctl user key show --user=<user id> <key id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_user_list.adoc
+++ b/docs/ecctl_user_list.adoc
@@ -23,7 +23,7 @@ ecctl user list [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_user_list.md
+++ b/docs/ecctl_user_list.md
@@ -19,7 +19,7 @@ ecctl user list [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_user_show.adoc
+++ b/docs/ecctl_user_show.adoc
@@ -24,7 +24,7 @@ ecctl user show <user name> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_user_show.md
+++ b/docs/ecctl_user_show.md
@@ -20,7 +20,7 @@ ecctl user show <user name> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_user_update.adoc
+++ b/docs/ecctl_user_update.adoc
@@ -43,7 +43,7 @@ ecctl user update <username> --role <role> [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_user_update.md
+++ b/docs/ecctl_user_update.md
@@ -39,7 +39,7 @@ ecctl user update <username> --role <role> [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_version.adoc
+++ b/docs/ecctl_version.adoc
@@ -23,7 +23,7 @@ ecctl version [flags]
 === Options inherited from parent commands
 
 ----
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/docs/ecctl_version.md
+++ b/docs/ecctl_version.md
@@ -19,7 +19,7 @@ ecctl version [flags]
 ### Options inherited from parent commands
 
 ```
-      --apikey string      API key to use to authenticate (If empty will look for EC_APIKEY environment variable)
+      --api-key string     API key to use to authenticate (If empty will look for EC_API_KEY environment variable)
       --config string      Config name, used to have multiple configs in $HOME/.ecctl/<env> (default "config")
       --force              Do not ask for confirmation
       --format string      Formats the output using a Go template

--- a/pkg/ecctl/config.go
+++ b/pkg/ecctl/config.go
@@ -40,8 +40,8 @@ var (
 	errInvalidOutputFormat                    = errors.New("output must be one either json or text")
 	errInvalidOutputDevice                    = errors.New("output device must not be nil")
 	errInvalidErrorDevice                     = errors.New("error device must not be nil")
-	errInvalidEmptyAuthenticaitonSettings     = errors.New("apikey or user and pass must be specified")
-	errInvalidBothAuthenticaitonSettings      = errors.New("cannot specify both apikey and user / pass")
+	errInvalidEmptyAuthenticaitonSettings     = errors.New("api_key or user and pass must be specified")
+	errInvalidBothAuthenticaitonSettings      = errors.New("cannot specify both api_key and user / pass")
 )
 
 // Config contains the application configuration
@@ -49,7 +49,7 @@ type Config struct {
 	User    string `json:"user,omitempty"`
 	Pass    string `json:"pass,omitempty"`
 	Host    string `json:"host,omitempty"`
-	APIKey  string `json:"apikey,omitempty"`
+	APIKey  string `json:"api_key,omitempty" mapstructure:"api_key"`
 	Region  string `json:"region,omitempty"`
 	Output  string `json:"output,omitempty"`
 	Message string `json:"message,omitempty"`

--- a/pkg/ecctl/init_test.go
+++ b/pkg/ecctl/init_test.go
@@ -109,7 +109,7 @@ func TestInitConfig(t *testing.T) {
 	apikeyConfig.SetConfigName("apikey")
 	var apikeyConfigContents = `{
   "host": "https://localhost",
-  "apikey": "[REDACTED]",
+  "api_key": "[REDACTED]",
   "verbose": true
 }`
 	var userPassConfig = viper.New()
@@ -141,7 +141,7 @@ func TestInitConfig(t *testing.T) {
 	apiKeyConfigToModify.SetConfigName("apikeymodif")
 	var apiKeyConfigToModifyContents = `{
   "host": "https://localhost",
-  "apikey": "[REDACTED]",
+  "api_key": "[REDACTED]",
   "output": "json"
 }`
 
@@ -196,7 +196,7 @@ func TestInitConfig(t *testing.T) {
 				hostConfigContents + "\n" + existingConfigMsg,
 		},
 		{
-			name: "finds a config file, prints the contents with obscured apikey and user skips the creation of one",
+			name: "finds a config file, prints the contents with obscured api_key and user skips the creation of one",
 			args: args{params: InitConfigParams{
 				Viper:            apikeyConfig,
 				Reader:           strings.NewReader("n\n"),
@@ -206,7 +206,7 @@ func TestInitConfig(t *testing.T) {
 				Client:           new(http.Client),
 			}},
 			wantSettings: map[string]interface{}{
-				"apikey":  "someapikey",
+				"api_key": "someapikey",
 				"host":    "https://localhost",
 				"verbose": true,
 			},
@@ -256,7 +256,7 @@ func TestInitConfig(t *testing.T) {
 				}))),
 			}},
 			wantSettings: map[string]interface{}{
-				"apikey":   "somekey",
+				"api_key":  "somekey",
 				"host":     "https://api.elastic-cloud.com",
 				"insecure": true,
 				"output":   "text",
@@ -407,7 +407,7 @@ func TestInitConfig(t *testing.T) {
 				}))),
 			}},
 			wantSettings: map[string]interface{}{
-				"apikey":   "somekey",
+				"api_key":  "somekey",
 				"host":     "https://ahost",
 				"insecure": true,
 				"output":   "text",
@@ -420,7 +420,7 @@ func TestInitConfig(t *testing.T) {
 				"\n" + "\n" + fmt.Sprintf(validCredentialsMsg, "anacleto") + finalMsg + "\n",
 		},
 		{
-			name: "finds a config file and user changes the values, from apikey to user/pass",
+			name: "finds a config file and user changes the values, from api_key to user/pass",
 			args: args{params: InitConfigParams{
 				Viper:    apiKeyConfigToModify,
 				FilePath: filepath.Join(testFiles, "doesnt_matter"),

--- a/pkg/ecctl/test_files/apikey.yaml.orig
+++ b/pkg/ecctl/test_files/apikey.yaml.orig
@@ -1,3 +1,3 @@
 host: https://localhost
-apikey: someapikey
+api_key: someapikey
 verbose: true

--- a/pkg/ecctl/test_files/apikeymodif.yaml.orig
+++ b/pkg/ecctl/test_files/apikeymodif.yaml.orig
@@ -1,3 +1,3 @@
 host: https://localhost
-apikey: someapikey
+api_key: someapikey
 output: json


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail. -->
In order to align the environment variables to match the existing cloud
documentation, this patch renames the `--apikey` flag to `--api-key`,
which also makes the `EC_APIKEY` be changed to the desired `EC_API_KEY`
environment variable.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
elastic/terraform-provider-ec#39

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Aligning the config settings across products.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
