### PR TITLE
release: Fix changelog generator broken link

### DIFF
--- a/scripts/changelog.tpl.md
+++ b/scripts/changelog.tpl.md
@@ -16,4 +16,4 @@ Checksums are at [ecctl_VERSION_REPLACE_checksums.txt](https://download.elastic.
 
 ## Release notes
 
-<https://www.elastic.co/guide/en/ecctl/vVERSION_REPLACE/ecctl-release-notes-vVERSION_REPLACE.html>
+<https://www.elastic.co/guide/en/ecctl/VERSION_CROPPED_REPLACE/ecctl-release-notes-vVERSION_REPLACE.html>

--- a/scripts/generate-changelog.sh
+++ b/scripts/generate-changelog.sh
@@ -6,19 +6,21 @@ if [[ $(git status) == *"Your branch is behind"* ]]; then
 fi
 
 git fetch
-PREV_TAG=$(git tag -l | tail -1)
+PREV_TAG=$(git tag -l 'v[0-9-]*.[0-9-]*.[0-9-]'| tail -1)
 CHANGELOGFILE=notes/${VERSION}.md
 ADOC_CHANGELOG=docs/release_notes/${VERSION}.adoc
 ADOC_CHANGELOG_HISTORY=docs/ecctl-release-notes.asciidoc
 
 if [[ -z ${PREV_TAG} ]]; then echo "-> Exiting changelog generation since there's no previous tag"; exit 0; fi
 
+MAJORMINOR="$(echo ${VERSION} | tr -d 'v' |cut -d '.' -f1).$(echo $VERSION | tr -d 'v' |cut -d '.' -f2)"
+
 echo "=> Attempting to generate the changelog for release ${VERSION}..."
 read -p "=> Previous release was ${PREV_TAG}, is that correct? " -n 1 -r
 
 if [[ ${REPLY} =~ ^[Yy]$ ]]; then
     echo ""
-    sed "s/VERSION_REPLACE/$(echo ${VERSION}| sed 's/^v//')/g" scripts/changelog.tpl.md > ${CHANGELOGFILE}
+    sed "s/VERSION_REPLACE/$(echo ${VERSION}| sed 's/^v//')/g" scripts/changelog.tpl.md | sed "s/VERSION_CROPPED_REPLACE/${MAJORMINOR}/" > ${CHANGELOGFILE}
     sed "s/VERSION_REPLACE/$(echo ${VERSION}| sed 's/^v//')/g" scripts/changelog.tpl.adoc > ${ADOC_CHANGELOG}
     
     git -c log.showSignature=false log --pretty="https://github.com/elastic/ecctl/commit/%h[%h] %s" --no-decorate --no-color tags/${PREV_TAG}..master |\


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail. -->
Fixes  the interpolated version for the release document in the GitHub
release to equal to `$MAJOR.MINOR` rather than the whole version string.

Additionally, makes the git tag listing match full versions ignoring BCs,
Betas and tags with no `v` prefix.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Broken release notes link.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By running `make changelog`

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Documentation
