### PR TITLE
docs: Add asciidoc document validator in make docs

### DIFF
--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -55,3 +55,12 @@ for file in ecctl*.adoc; do
     fi
 done
 sort temp-index.adoc > ecctl-command-reference-index.adoc; rm temp-index.adoc
+
+echo "-> Validating ASCIIDOC files..."
+
+# Creating /shared/attributes.asciidoc is necessary since it's part of our
+# common doc build process, and the file is imported in docs/index.asciidoc.
+docker run -v $(pwd):/documents/ asciidoctor/docker-asciidoctor bash -c '
+shopt -s extglob
+mkdir -p /shared && touch /shared/attributes.asciidoc
+asciidoctor --failure-level ERROR -o /dev/null ?(*.adoc|*.asciidoc)'


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds an asciidoc document validator in the `make docs` target.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Resolves #289

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Documentation

