### PR TITLE
release: Add hub.protocol https to script

### DIFF
--- a/scripts/update-brew-tap.sh
+++ b/scripts/update-brew-tap.sh
@@ -32,6 +32,7 @@ hub add Formula/ecctl.rb
 hub checkout -b f/update-ecctl-formula-to-${VERSION}
 git config user.email "${GIT_AUTHOR_EMAIL}"
 git config user.name "${GIT_AUTHOR_NAME}"
+git config --global hub.protocol https
 git commit -m "Update ecctl version to ${VERSION}"
 hub push fork f/update-ecctl-formula-to-${VERSION}
 hub pull-request -m "Update ecctl version to ${VERSION}" -m "Created through automation by update-brew-tap.sh"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds a `git config --global hub.protocol https` to the `update-brew-tap`
script which was failing with:

    fatal: could not read Username for 'https://github.com': No such
    device or address

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
#382 

