### PR TITLE
deployment: Stop making use of AsList field in deployment template get calls

### DIFF
--- a/cmd/deployment/create.go
+++ b/cmd/deployment/create.go
@@ -123,22 +123,20 @@ var createCmd = &cobra.Command{
 			}
 		}
 
-		dtAsList, _ := cmd.Flags().GetBool("dt-as-list")
 		if payload == nil {
 			var err error
 			payload, err = depresourceapi.NewPayload(depresourceapi.NewPayloadParams{
-				DeploymentTemplateAsList: dtAsList,
-				API:                      ecctl.Get().API,
-				Name:                     name,
-				DeploymentTemplateID:     dt,
-				Version:                  version,
-				Region:                   region,
-				Writer:                   ecctl.Get().Config.ErrorDevice,
-				Plugins:                  plugin,
-				TopologyElements:         topologyElements,
-				ApmEnable:                apmEnable,
-				AppsearchEnable:          appsearchEnable,
-				EnterpriseSearchEnable:   enterpriseSearchEnable,
+				API:                    ecctl.Get().API,
+				Name:                   name,
+				DeploymentTemplateID:   dt,
+				Version:                version,
+				Region:                 region,
+				Writer:                 ecctl.Get().Config.ErrorDevice,
+				Plugins:                plugin,
+				TopologyElements:       topologyElements,
+				ApmEnable:              apmEnable,
+				AppsearchEnable:        appsearchEnable,
+				EnterpriseSearchEnable: enterpriseSearchEnable,
 				ElasticsearchInstance: depresourceapi.InstanceParams{
 					RefID:     esRefID,
 					Size:      esSizeMB,
@@ -240,10 +238,6 @@ func initFlags() {
 	createCmd.Flags().String("enterprise_search-ref-id", "main-enterprise_search", "Optional RefId for the Enterprise Search deployment")
 	createCmd.Flags().Int32("enterprise_search-zones", 1, "Number of zones the Enterprise Search instances will span")
 	createCmd.Flags().String("enterprise_search-size", "4g", "Memory (RAM) in GB that each of the Enterprise Search instances will have")
-
-	// Remove in the next version.
-	createCmd.Flags().Bool("dt-as-list", true, "")
-	createCmd.Flags().MarkHidden("dt-as-list")
 }
 
 func setDefaultTemplate(region string) string {

--- a/cmd/deployment/create_test.go
+++ b/cmd/deployment/create_test.go
@@ -436,18 +436,15 @@ Deployment [%s] - [Apm][%s]: running step "waiting-for-some-step" (Plan duration
 					{
 						Response: http.Response{
 							StatusCode: 200,
-							Body: mock.NewStructBody([]models.DeploymentTemplateInfoV2{
-								defaultTemplateResponse,
-							}),
+							Body:       mock.NewStructBody(defaultTemplateResponse),
 						},
 						Assert: &mock.RequestAssertion{
 							Method: "GET",
 							Header: api.DefaultReadMockHeaders,
-							Path:   "/api/v1/deployments/templates",
+							Path:   "/api/v1/deployments/templates/default",
 							Host:   api.DefaultMockHost,
 							Query: url.Values{
 								"region":                       {"ece-region"},
-								"show_hidden":                  {"false"},
 								"show_instance_configurations": {"true"},
 							},
 						},
@@ -500,7 +497,6 @@ Deployment [%s] - [Apm][%s]: running step "waiting-for-some-step" (Plan duration
 				Cmd: createCmd,
 				Args: []string{
 					"create", "--request-id=some_request_id", "--version=7.8.0",
-					"--dt-as-list=false",
 				},
 				Cfg: testutils.MockCfg{Responses: []mock.Response{
 					{
@@ -562,7 +558,7 @@ Deployment [%s] - [Apm][%s]: running step "waiting-for-some-step" (Plan duration
 				Args: []string{
 					"create", "--request-id=some_request_id", "--version=7.8.0", "--es-node-topology",
 					`{"size": "1g", "zone_count": 2, "node_type": "data"}`, "--es-node-topology",
-					`{"size": "1g", "zone_count": 1, "node_type": "ml"}`, "--dt-as-list=false",
+					`{"size": "1g", "zone_count": 1, "node_type": "ml"}`,
 				},
 				Cfg: testutils.MockCfg{Responses: []mock.Response{
 					{
@@ -615,18 +611,15 @@ Deployment [%s] - [Apm][%s]: running step "waiting-for-some-step" (Plan duration
 					{
 						Response: http.Response{
 							StatusCode: 200,
-							Body: mock.NewStructBody([]models.DeploymentTemplateInfoV2{
-								defaultTemplateResponse,
-							}),
+							Body:       mock.NewStructBody(defaultTemplateResponse),
 						},
 						Assert: &mock.RequestAssertion{
 							Method: "GET",
 							Header: api.DefaultReadMockHeaders,
-							Path:   "/api/v1/deployments/templates",
+							Path:   "/api/v1/deployments/templates/default",
 							Host:   api.DefaultMockHost,
 							Query: url.Values{
 								"region":                       {"ece-region"},
-								"show_hidden":                  {"false"},
 								"show_instance_configurations": {"true"},
 							},
 						},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
As the bug with the GET deployments/template/{template_id} endpoint
has been fixed, we no longer need to use the AsList field when calling it.

## Motivation and Context
Stay up to date!

## How Has This Been Tested?
Manually and unit tests

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Refactoring (improves code quality but has no user-facing effect)

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
