### PR TITLE
docs: Add text next to ece icon

### DIFF
--- a/docs/ecctl.adoc
+++ b/docs/ecctl.adoc
@@ -35,7 +35,7 @@ Elastic Cloud Control
 * xref:ecctl_deployment[ecctl deployment]	 - Manages deployments
 * xref:ecctl_generate[ecctl generate]	 - Generates completions and docs
 * xref:ecctl_init[ecctl init]	 - Creates an initial configuration file.
-* xref:ecctl_platform[ecctl platform]	 - Manages the platform {ece-icon}
+* xref:ecctl_platform[ecctl platform]	 - Manages the platform {ece-icon} (Available for ECE only)
 * xref:ecctl_stack[ecctl stack]	 - Manages Elastic StackPacks
-* xref:ecctl_user[ecctl user]	 - Manages the platform users {ece-icon}
+* xref:ecctl_user[ecctl user]	 - Manages the platform users {ece-icon} (Available for ECE only)
 * xref:ecctl_version[ecctl version]	 - Shows ecctl version

--- a/docs/ecctl_deployment.adoc
+++ b/docs/ecctl_deployment.adoc
@@ -43,7 +43,7 @@ ecctl deployment [flags]
 
 * xref:ecctl[ecctl]	 - Elastic Cloud Control
 * xref:ecctl_deployment_create[ecctl deployment create]	 - Creates a deployment
-* xref:ecctl_deployment_delete[ecctl deployment delete]	 - Deletes a previously shutdown deployment {ece-icon}
+* xref:ecctl_deployment_delete[ecctl deployment delete]	 - Deletes a previously shutdown deployment {ece-icon} (Available for ECE only)
 * xref:ecctl_deployment_elasticsearch[ecctl deployment elasticsearch]	 - Manages Elasticsearch resources
 * xref:ecctl_deployment_list[ecctl deployment list]	 - Lists the platform's deployments
 * xref:ecctl_deployment_note[ecctl deployment note]	 - Manages a deployment's notes

--- a/docs/ecctl_deployment_delete.adoc
+++ b/docs/ecctl_deployment_delete.adoc
@@ -1,7 +1,7 @@
 [#ecctl_deployment_delete]
 == ecctl deployment delete
 
-Deletes a previously shutdown deployment {ece-icon}
+Deletes a previously shutdown deployment {ece-icon} (Available for ECE only)
 
 ----
 ecctl deployment delete <deployment-id> [flags]

--- a/docs/ecctl_deployment_template.adoc
+++ b/docs/ecctl_deployment_template.adoc
@@ -42,8 +42,8 @@ ecctl deployment template [flags]
 === SEE ALSO
 
 * xref:ecctl_deployment[ecctl deployment]	 - Manages deployments
-* xref:ecctl_deployment_template_create[ecctl deployment template create]	 - Creates a new deployment template {ece-icon}
-* xref:ecctl_deployment_template_delete[ecctl deployment template delete]	 - Deletes an existing deployment template {ece-icon}
+* xref:ecctl_deployment_template_create[ecctl deployment template create]	 - Creates a new deployment template {ece-icon} (Available for ECE only)
+* xref:ecctl_deployment_template_delete[ecctl deployment template delete]	 - Deletes an existing deployment template {ece-icon} (Available for ECE only)
 * xref:ecctl_deployment_template_list[ecctl deployment template list]	 - Lists deployment templates
-* xref:ecctl_deployment_template_show[ecctl deployment template show]	 - Displays a deployment template {ece-icon}
-* xref:ecctl_deployment_template_update[ecctl deployment template update]	 - Updates an existing deployment template {ece-icon}
+* xref:ecctl_deployment_template_show[ecctl deployment template show]	 - Displays a deployment template {ece-icon} (Available for ECE only)
+* xref:ecctl_deployment_template_update[ecctl deployment template update]	 - Updates an existing deployment template {ece-icon} (Available for ECE only)

--- a/docs/ecctl_deployment_template_create.adoc
+++ b/docs/ecctl_deployment_template_create.adoc
@@ -1,7 +1,7 @@
 [#ecctl_deployment_template_create]
 == ecctl deployment template create
 
-Creates a new deployment template {ece-icon}
+Creates a new deployment template {ece-icon} (Available for ECE only)
 
 ----
 ecctl deployment template create --file <definition.json> [flags]

--- a/docs/ecctl_deployment_template_delete.adoc
+++ b/docs/ecctl_deployment_template_delete.adoc
@@ -1,7 +1,7 @@
 [#ecctl_deployment_template_delete]
 == ecctl deployment template delete
 
-Deletes an existing deployment template {ece-icon}
+Deletes an existing deployment template {ece-icon} (Available for ECE only)
 
 ----
 ecctl deployment template delete --template-id <template id> [flags]

--- a/docs/ecctl_deployment_template_show.adoc
+++ b/docs/ecctl_deployment_template_show.adoc
@@ -1,7 +1,7 @@
 [#ecctl_deployment_template_show]
 == ecctl deployment template show
 
-Displays a deployment template {ece-icon}
+Displays a deployment template {ece-icon} (Available for ECE only)
 
 ----
 ecctl deployment template show --template-id <template id> [flags]

--- a/docs/ecctl_deployment_template_update.adoc
+++ b/docs/ecctl_deployment_template_update.adoc
@@ -1,7 +1,7 @@
 [#ecctl_deployment_template_update]
 == ecctl deployment template update
 
-Updates an existing deployment template {ece-icon}
+Updates an existing deployment template {ece-icon} (Available for ECE only)
 
 ----
 ecctl deployment template update --template-id <template id> --file <definition.json> [flags]

--- a/docs/ecctl_platform.adoc
+++ b/docs/ecctl_platform.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform]
 == ecctl platform
 
-Manages the platform {ece-icon}
+Manages the platform {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform [flags]
@@ -42,12 +42,12 @@ ecctl platform [flags]
 === SEE ALSO
 
 * xref:ecctl[ecctl]	 - Elastic Cloud Control
-* xref:ecctl_platform_allocator[ecctl platform allocator]	 - Manages allocators {ece-icon}
-* xref:ecctl_platform_constructor[ecctl platform constructor]	 - Manages constructors {ece-icon}
-* xref:ecctl_platform_enrollment-token[ecctl platform enrollment-token]	 - Manages tokens {ece-icon}
-* xref:ecctl_platform_info[ecctl platform info]	 - Shows information about the platform {ece-icon}
-* xref:ecctl_platform_instance-configuration[ecctl platform instance-configuration]	 - Manages instance configurations {ece-icon}
-* xref:ecctl_platform_proxy[ecctl platform proxy]	 - Manages proxies {ece-icon}
-* xref:ecctl_platform_repository[ecctl platform repository]	 - Manages snapshot repositories {ece-icon}
-* xref:ecctl_platform_role[ecctl platform role]	 - Manages platform roles {ece-icon}
-* xref:ecctl_platform_runner[ecctl platform runner]	 - Manages platform runners {ece-icon}
+* xref:ecctl_platform_allocator[ecctl platform allocator]	 - Manages allocators {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_constructor[ecctl platform constructor]	 - Manages constructors {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_enrollment-token[ecctl platform enrollment-token]	 - Manages tokens {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_info[ecctl platform info]	 - Shows information about the platform {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_instance-configuration[ecctl platform instance-configuration]	 - Manages instance configurations {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_proxy[ecctl platform proxy]	 - Manages proxies {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_repository[ecctl platform repository]	 - Manages snapshot repositories {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_role[ecctl platform role]	 - Manages platform roles {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_runner[ecctl platform runner]	 - Manages platform runners {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_allocator.adoc
+++ b/docs/ecctl_platform_allocator.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_allocator]
 == ecctl platform allocator
 
-Manages allocators {ece-icon}
+Manages allocators {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform allocator [flags]
@@ -41,10 +41,10 @@ ecctl platform allocator [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform[ecctl platform]	 - Manages the platform {ece-icon}
-* xref:ecctl_platform_allocator_list[ecctl platform allocator list]	 - Returns all allocators that have instances or are connected to the platform. Use --all flag or --output json to show all. Use --query to match any of the allocators properties. {ece-icon}
-* xref:ecctl_platform_allocator_maintenance[ecctl platform allocator maintenance]	 - Sets the allocator in Maintenance mode {ece-icon}
+* xref:ecctl_platform[ecctl platform]	 - Manages the platform {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_allocator_list[ecctl platform allocator list]	 - Returns all allocators that have instances or are connected to the platform. Use --all flag or --output json to show all. Use --query to match any of the allocators properties. {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_allocator_maintenance[ecctl platform allocator maintenance]	 - Sets the allocator in Maintenance mode {ece-icon} (Available for ECE only)
 * xref:ecctl_platform_allocator_metadata[ecctl platform allocator metadata]	 - Manages an allocator's metadata
-* xref:ecctl_platform_allocator_search[ecctl platform allocator search]	 - Performs advanced allocator searching {ece-icon}
-* xref:ecctl_platform_allocator_show[ecctl platform allocator show]	 - Returns information about the allocator {ece-icon}
-* xref:ecctl_platform_allocator_vacate[ecctl platform allocator vacate]	 - Moves all the resources from the specified allocator {ece-icon}
+* xref:ecctl_platform_allocator_search[ecctl platform allocator search]	 - Performs advanced allocator searching {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_allocator_show[ecctl platform allocator show]	 - Returns information about the allocator {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_allocator_vacate[ecctl platform allocator vacate]	 - Moves all the resources from the specified allocator {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_allocator_list.adoc
+++ b/docs/ecctl_platform_allocator_list.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_allocator_list]
 == ecctl platform allocator list
 
-Returns all allocators that have instances or are connected to the platform. Use --all flag or --output json to show all. Use --query to match any of the allocators properties. {ece-icon}
+Returns all allocators that have instances or are connected to the platform. Use --all flag or --output json to show all. Use --query to match any of the allocators properties. {ece-icon} (Available for ECE only)
 
 [float]
 === Synopsis
@@ -74,4 +74,4 @@ ecctl platform allocator list [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_allocator[ecctl platform allocator]	 - Manages allocators {ece-icon}
+* xref:ecctl_platform_allocator[ecctl platform allocator]	 - Manages allocators {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_allocator_maintenance.adoc
+++ b/docs/ecctl_platform_allocator_maintenance.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_allocator_maintenance]
 == ecctl platform allocator maintenance
 
-Sets the allocator in Maintenance mode {ece-icon}
+Sets the allocator in Maintenance mode {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform allocator maintenance <allocator id> [flags]
@@ -42,4 +42,4 @@ ecctl platform allocator maintenance <allocator id> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_allocator[ecctl platform allocator]	 - Manages allocators {ece-icon}
+* xref:ecctl_platform_allocator[ecctl platform allocator]	 - Manages allocators {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_allocator_metadata.adoc
+++ b/docs/ecctl_platform_allocator_metadata.adoc
@@ -41,7 +41,7 @@ ecctl platform allocator metadata [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_allocator[ecctl platform allocator]	 - Manages allocators {ece-icon}
+* xref:ecctl_platform_allocator[ecctl platform allocator]	 - Manages allocators {ece-icon} (Available for ECE only)
 * xref:ecctl_platform_allocator_metadata_delete[ecctl platform allocator metadata delete]	 - Deletes a single metadata item from a given allocators metadata
 * xref:ecctl_platform_allocator_metadata_set[ecctl platform allocator metadata set]	 - Sets or updates a single metadata item to a given allocators metadata
 * xref:ecctl_platform_allocator_metadata_show[ecctl platform allocator metadata show]	 - Shows allocator metadata

--- a/docs/ecctl_platform_allocator_search.adoc
+++ b/docs/ecctl_platform_allocator_search.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_allocator_search]
 == ecctl platform allocator search
 
-Performs advanced allocator searching {ece-icon}
+Performs advanced allocator searching {ece-icon} (Available for ECE only)
 
 [float]
 === Synopsis
@@ -48,4 +48,4 @@ ecctl platform allocator search [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_allocator[ecctl platform allocator]	 - Manages allocators {ece-icon}
+* xref:ecctl_platform_allocator[ecctl platform allocator]	 - Manages allocators {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_allocator_show.adoc
+++ b/docs/ecctl_platform_allocator_show.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_allocator_show]
 == ecctl platform allocator show
 
-Returns information about the allocator {ece-icon}
+Returns information about the allocator {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform allocator show <allocator id> [flags]
@@ -42,4 +42,4 @@ ecctl platform allocator show <allocator id> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_allocator[ecctl platform allocator]	 - Manages allocators {ece-icon}
+* xref:ecctl_platform_allocator[ecctl platform allocator]	 - Manages allocators {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_allocator_vacate.adoc
+++ b/docs/ecctl_platform_allocator_vacate.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_allocator_vacate]
 == ecctl platform allocator vacate
 
-Moves all the resources from the specified allocator {ece-icon}
+Moves all the resources from the specified allocator {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform allocator vacate <allocator-id> [flags]
@@ -92,4 +92,4 @@ ecctl platform allocator vacate <allocator-id> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_allocator[ecctl platform allocator]	 - Manages allocators {ece-icon}
+* xref:ecctl_platform_allocator[ecctl platform allocator]	 - Manages allocators {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_constructor.adoc
+++ b/docs/ecctl_platform_constructor.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_constructor]
 == ecctl platform constructor
 
-Manages constructors {ece-icon}
+Manages constructors {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform constructor [flags]
@@ -41,8 +41,8 @@ ecctl platform constructor [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform[ecctl platform]	 - Manages the platform {ece-icon}
-* xref:ecctl_platform_constructor_list[ecctl platform constructor list]	 - Returns all of the constructors in the platform {ece-icon}
-* xref:ecctl_platform_constructor_maintenance[ecctl platform constructor maintenance]	 - Sets/un-sets a constructor's maintenance mode {ece-icon}
-* xref:ecctl_platform_constructor_resync[ecctl platform constructor resync]	 - Resynchronizes the search index and cache for the selected constructor or all {ece-icon}
-* xref:ecctl_platform_constructor_show[ecctl platform constructor show]	 - Returns information about the constructor with given ID {ece-icon}
+* xref:ecctl_platform[ecctl platform]	 - Manages the platform {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_constructor_list[ecctl platform constructor list]	 - Returns all of the constructors in the platform {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_constructor_maintenance[ecctl platform constructor maintenance]	 - Sets/un-sets a constructor's maintenance mode {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_constructor_resync[ecctl platform constructor resync]	 - Resynchronizes the search index and cache for the selected constructor or all {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_constructor_show[ecctl platform constructor show]	 - Returns information about the constructor with given ID {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_constructor_list.adoc
+++ b/docs/ecctl_platform_constructor_list.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_constructor_list]
 == ecctl platform constructor list
 
-Returns all of the constructors in the platform {ece-icon}
+Returns all of the constructors in the platform {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform constructor list [flags]
@@ -41,4 +41,4 @@ ecctl platform constructor list [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_constructor[ecctl platform constructor]	 - Manages constructors {ece-icon}
+* xref:ecctl_platform_constructor[ecctl platform constructor]	 - Manages constructors {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_constructor_maintenance.adoc
+++ b/docs/ecctl_platform_constructor_maintenance.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_constructor_maintenance]
 == ecctl platform constructor maintenance
 
-Sets/un-sets a constructor's maintenance mode {ece-icon}
+Sets/un-sets a constructor's maintenance mode {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform constructor maintenance <constructor id> [flags]
@@ -42,4 +42,4 @@ ecctl platform constructor maintenance <constructor id> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_constructor[ecctl platform constructor]	 - Manages constructors {ece-icon}
+* xref:ecctl_platform_constructor[ecctl platform constructor]	 - Manages constructors {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_constructor_resync.adoc
+++ b/docs/ecctl_platform_constructor_resync.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_constructor_resync]
 == ecctl platform constructor resync
 
-Resynchronizes the search index and cache for the selected constructor or all {ece-icon}
+Resynchronizes the search index and cache for the selected constructor or all {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform constructor resync {<constructor id> | --all} [flags]
@@ -42,4 +42,4 @@ ecctl platform constructor resync {<constructor id> | --all} [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_constructor[ecctl platform constructor]	 - Manages constructors {ece-icon}
+* xref:ecctl_platform_constructor[ecctl platform constructor]	 - Manages constructors {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_constructor_show.adoc
+++ b/docs/ecctl_platform_constructor_show.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_constructor_show]
 == ecctl platform constructor show
 
-Returns information about the constructor with given ID {ece-icon}
+Returns information about the constructor with given ID {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform constructor show <constructor id> [flags]
@@ -41,4 +41,4 @@ ecctl platform constructor show <constructor id> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_constructor[ecctl platform constructor]	 - Manages constructors {ece-icon}
+* xref:ecctl_platform_constructor[ecctl platform constructor]	 - Manages constructors {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_enrollment-token.adoc
+++ b/docs/ecctl_platform_enrollment-token.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_enrollment-token]
 == ecctl platform enrollment-token
 
-Manages tokens {ece-icon}
+Manages tokens {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform enrollment-token [flags]
@@ -41,7 +41,7 @@ ecctl platform enrollment-token [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform[ecctl platform]	 - Manages the platform {ece-icon}
+* xref:ecctl_platform[ecctl platform]	 - Manages the platform {ece-icon} (Available for ECE only)
 * xref:ecctl_platform_enrollment-token_create[ecctl platform enrollment-token create]	 - Creates an enrollment token for role(s)
-* xref:ecctl_platform_enrollment-token_delete[ecctl platform enrollment-token delete]	 - Deletes an enrollment token {ece-icon}
-* xref:ecctl_platform_enrollment-token_list[ecctl platform enrollment-token list]	 - Retrieves a list of persistent enrollment tokens {ece-icon}
+* xref:ecctl_platform_enrollment-token_delete[ecctl platform enrollment-token delete]	 - Deletes an enrollment token {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_enrollment-token_list[ecctl platform enrollment-token list]	 - Retrieves a list of persistent enrollment tokens {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_enrollment-token_create.adoc
+++ b/docs/ecctl_platform_enrollment-token_create.adoc
@@ -14,7 +14,7 @@ ecctl platform enrollment-token create --role <ROLE> [flags]
   ecctl [globalFlags] enrollment-token create --role coordinator
   ecctl [globalFlags] enrollment-token create --role coordinator --role proxy
   ecctl [globalFlags] enrollment-token create --role allocator --validity 120s
-  ecctl [globalFlags] enrollment-token create --role allocator --validity 2h {ece-icon}
+  ecctl [globalFlags] enrollment-token create --role allocator --validity 2h {ece-icon} (Available for ECE only)
 ----
 
 [float]
@@ -53,4 +53,4 @@ ecctl platform enrollment-token create --role <ROLE> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_enrollment-token[ecctl platform enrollment-token]	 - Manages tokens {ece-icon}
+* xref:ecctl_platform_enrollment-token[ecctl platform enrollment-token]	 - Manages tokens {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_enrollment-token_delete.adoc
+++ b/docs/ecctl_platform_enrollment-token_delete.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_enrollment-token_delete]
 == ecctl platform enrollment-token delete
 
-Deletes an enrollment token {ece-icon}
+Deletes an enrollment token {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform enrollment-token delete <enrollment-token> [flags]
@@ -41,4 +41,4 @@ ecctl platform enrollment-token delete <enrollment-token> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_enrollment-token[ecctl platform enrollment-token]	 - Manages tokens {ece-icon}
+* xref:ecctl_platform_enrollment-token[ecctl platform enrollment-token]	 - Manages tokens {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_enrollment-token_list.adoc
+++ b/docs/ecctl_platform_enrollment-token_list.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_enrollment-token_list]
 == ecctl platform enrollment-token list
 
-Retrieves a list of persistent enrollment tokens {ece-icon}
+Retrieves a list of persistent enrollment tokens {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform enrollment-token list [flags]
@@ -41,4 +41,4 @@ ecctl platform enrollment-token list [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_enrollment-token[ecctl platform enrollment-token]	 - Manages tokens {ece-icon}
+* xref:ecctl_platform_enrollment-token[ecctl platform enrollment-token]	 - Manages tokens {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_info.adoc
+++ b/docs/ecctl_platform_info.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_info]
 == ecctl platform info
 
-Shows information about the platform {ece-icon}
+Shows information about the platform {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform info [flags]
@@ -41,4 +41,4 @@ ecctl platform info [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform[ecctl platform]	 - Manages the platform {ece-icon}
+* xref:ecctl_platform[ecctl platform]	 - Manages the platform {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_instance-configuration.adoc
+++ b/docs/ecctl_platform_instance-configuration.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_instance-configuration]
 == ecctl platform instance-configuration
 
-Manages instance configurations {ece-icon}
+Manages instance configurations {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform instance-configuration [flags]
@@ -41,10 +41,10 @@ ecctl platform instance-configuration [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform[ecctl platform]	 - Manages the platform {ece-icon}
-* xref:ecctl_platform_instance-configuration_create[ecctl platform instance-configuration create]	 - Creates a new instance configuration {ece-icon}
-* xref:ecctl_platform_instance-configuration_delete[ecctl platform instance-configuration delete]	 - Deletes an instance configuration {ece-icon}
-* xref:ecctl_platform_instance-configuration_list[ecctl platform instance-configuration list]	 - Lists the instance configurations {ece-icon}
-* xref:ecctl_platform_instance-configuration_pull[ecctl platform instance-configuration pull]	 - Downloads instance configuration into a local folder {ece-icon}
-* xref:ecctl_platform_instance-configuration_show[ecctl platform instance-configuration show]	 - Shows an instance configuration {ece-icon}
-* xref:ecctl_platform_instance-configuration_update[ecctl platform instance-configuration update]	 - Overwrites an instance configuration {ece-icon}
+* xref:ecctl_platform[ecctl platform]	 - Manages the platform {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_instance-configuration_create[ecctl platform instance-configuration create]	 - Creates a new instance configuration {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_instance-configuration_delete[ecctl platform instance-configuration delete]	 - Deletes an instance configuration {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_instance-configuration_list[ecctl platform instance-configuration list]	 - Lists the instance configurations {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_instance-configuration_pull[ecctl platform instance-configuration pull]	 - Downloads instance configuration into a local folder {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_instance-configuration_show[ecctl platform instance-configuration show]	 - Shows an instance configuration {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_instance-configuration_update[ecctl platform instance-configuration update]	 - Overwrites an instance configuration {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_instance-configuration_create.adoc
+++ b/docs/ecctl_platform_instance-configuration_create.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_instance-configuration_create]
 == ecctl platform instance-configuration create
 
-Creates a new instance configuration {ece-icon}
+Creates a new instance configuration {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform instance-configuration create -f <config.json> [flags]
@@ -43,4 +43,4 @@ ecctl platform instance-configuration create -f <config.json> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_instance-configuration[ecctl platform instance-configuration]	 - Manages instance configurations {ece-icon}
+* xref:ecctl_platform_instance-configuration[ecctl platform instance-configuration]	 - Manages instance configurations {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_instance-configuration_delete.adoc
+++ b/docs/ecctl_platform_instance-configuration_delete.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_instance-configuration_delete]
 == ecctl platform instance-configuration delete
 
-Deletes an instance configuration {ece-icon}
+Deletes an instance configuration {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform instance-configuration delete <config id> [flags]
@@ -41,4 +41,4 @@ ecctl platform instance-configuration delete <config id> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_instance-configuration[ecctl platform instance-configuration]	 - Manages instance configurations {ece-icon}
+* xref:ecctl_platform_instance-configuration[ecctl platform instance-configuration]	 - Manages instance configurations {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_instance-configuration_list.adoc
+++ b/docs/ecctl_platform_instance-configuration_list.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_instance-configuration_list]
 == ecctl platform instance-configuration list
 
-Lists the instance configurations {ece-icon}
+Lists the instance configurations {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform instance-configuration list [flags]
@@ -41,4 +41,4 @@ ecctl platform instance-configuration list [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_instance-configuration[ecctl platform instance-configuration]	 - Manages instance configurations {ece-icon}
+* xref:ecctl_platform_instance-configuration[ecctl platform instance-configuration]	 - Manages instance configurations {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_instance-configuration_pull.adoc
+++ b/docs/ecctl_platform_instance-configuration_pull.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_instance-configuration_pull]
 == ecctl platform instance-configuration pull
 
-Downloads instance configuration into a local folder {ece-icon}
+Downloads instance configuration into a local folder {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform instance-configuration pull --path <path> [flags]
@@ -42,4 +42,4 @@ ecctl platform instance-configuration pull --path <path> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_instance-configuration[ecctl platform instance-configuration]	 - Manages instance configurations {ece-icon}
+* xref:ecctl_platform_instance-configuration[ecctl platform instance-configuration]	 - Manages instance configurations {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_instance-configuration_show.adoc
+++ b/docs/ecctl_platform_instance-configuration_show.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_instance-configuration_show]
 == ecctl platform instance-configuration show
 
-Shows an instance configuration {ece-icon}
+Shows an instance configuration {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform instance-configuration show <config id> [flags]
@@ -41,4 +41,4 @@ ecctl platform instance-configuration show <config id> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_instance-configuration[ecctl platform instance-configuration]	 - Manages instance configurations {ece-icon}
+* xref:ecctl_platform_instance-configuration[ecctl platform instance-configuration]	 - Manages instance configurations {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_instance-configuration_update.adoc
+++ b/docs/ecctl_platform_instance-configuration_update.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_instance-configuration_update]
 == ecctl platform instance-configuration update
 
-Overwrites an instance configuration {ece-icon}
+Overwrites an instance configuration {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform instance-configuration update <config id> -f <config.json> [flags]
@@ -42,4 +42,4 @@ ecctl platform instance-configuration update <config id> -f <config.json> [flags
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_instance-configuration[ecctl platform instance-configuration]	 - Manages instance configurations {ece-icon}
+* xref:ecctl_platform_instance-configuration[ecctl platform instance-configuration]	 - Manages instance configurations {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_proxy.adoc
+++ b/docs/ecctl_platform_proxy.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_proxy]
 == ecctl platform proxy
 
-Manages proxies {ece-icon}
+Manages proxies {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform proxy [flags]
@@ -41,7 +41,7 @@ ecctl platform proxy [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform[ecctl platform]	 - Manages the platform {ece-icon}
-* xref:ecctl_platform_proxy_filtered-group[ecctl platform proxy filtered-group]	 - Manages proxies filtered group {ece-icon}
-* xref:ecctl_platform_proxy_list[ecctl platform proxy list]	 - Returns all of the proxies in the platform {ece-icon}
-* xref:ecctl_platform_proxy_show[ecctl platform proxy show]	 - Returns information about the proxy with given id {ece-icon}
+* xref:ecctl_platform[ecctl platform]	 - Manages the platform {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_proxy_filtered-group[ecctl platform proxy filtered-group]	 - Manages proxies filtered group {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_proxy_list[ecctl platform proxy list]	 - Returns all of the proxies in the platform {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_proxy_show[ecctl platform proxy show]	 - Returns information about the proxy with given id {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_proxy_filtered-group.adoc
+++ b/docs/ecctl_platform_proxy_filtered-group.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_proxy_filtered-group]
 == ecctl platform proxy filtered-group
 
-Manages proxies filtered group {ece-icon}
+Manages proxies filtered group {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform proxy filtered-group [flags]
@@ -41,9 +41,9 @@ ecctl platform proxy filtered-group [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_proxy[ecctl platform proxy]	 - Manages proxies {ece-icon}
-* xref:ecctl_platform_proxy_filtered-group_create[ecctl platform proxy filtered-group create]	 - Creates proxies filtered group {ece-icon}
-* xref:ecctl_platform_proxy_filtered-group_delete[ecctl platform proxy filtered-group delete]	 - Deletes proxies filtered group {ece-icon}
-* xref:ecctl_platform_proxy_filtered-group_list[ecctl platform proxy filtered-group list]	 - Returns all proxies filtered groups in the platform {ece-icon}
-* xref:ecctl_platform_proxy_filtered-group_show[ecctl platform proxy filtered-group show]	 - Shows details for proxies filtered group {ece-icon}
-* xref:ecctl_platform_proxy_filtered-group_update[ecctl platform proxy filtered-group update]	 - Updates proxies filtered group {ece-icon}
+* xref:ecctl_platform_proxy[ecctl platform proxy]	 - Manages proxies {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_proxy_filtered-group_create[ecctl platform proxy filtered-group create]	 - Creates proxies filtered group {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_proxy_filtered-group_delete[ecctl platform proxy filtered-group delete]	 - Deletes proxies filtered group {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_proxy_filtered-group_list[ecctl platform proxy filtered-group list]	 - Returns all proxies filtered groups in the platform {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_proxy_filtered-group_show[ecctl platform proxy filtered-group show]	 - Shows details for proxies filtered group {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_proxy_filtered-group_update[ecctl platform proxy filtered-group update]	 - Updates proxies filtered group {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_proxy_filtered-group_create.adoc
+++ b/docs/ecctl_platform_proxy_filtered-group_create.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_proxy_filtered-group_create]
 == ecctl platform proxy filtered-group create
 
-Creates proxies filtered group {ece-icon}
+Creates proxies filtered group {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform proxy filtered-group create <filtered group id> --filters <key1=value1,key2=value2> --expected-proxies-count <int> [flags]
@@ -43,4 +43,4 @@ ecctl platform proxy filtered-group create <filtered group id> --filters <key1=v
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_proxy_filtered-group[ecctl platform proxy filtered-group]	 - Manages proxies filtered group {ece-icon}
+* xref:ecctl_platform_proxy_filtered-group[ecctl platform proxy filtered-group]	 - Manages proxies filtered group {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_proxy_filtered-group_delete.adoc
+++ b/docs/ecctl_platform_proxy_filtered-group_delete.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_proxy_filtered-group_delete]
 == ecctl platform proxy filtered-group delete
 
-Deletes proxies filtered group {ece-icon}
+Deletes proxies filtered group {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform proxy filtered-group delete <filtered group id> [flags]
@@ -41,4 +41,4 @@ ecctl platform proxy filtered-group delete <filtered group id> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_proxy_filtered-group[ecctl platform proxy filtered-group]	 - Manages proxies filtered group {ece-icon}
+* xref:ecctl_platform_proxy_filtered-group[ecctl platform proxy filtered-group]	 - Manages proxies filtered group {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_proxy_filtered-group_list.adoc
+++ b/docs/ecctl_platform_proxy_filtered-group_list.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_proxy_filtered-group_list]
 == ecctl platform proxy filtered-group list
 
-Returns all proxies filtered groups in the platform {ece-icon}
+Returns all proxies filtered groups in the platform {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform proxy filtered-group list [flags]
@@ -41,4 +41,4 @@ ecctl platform proxy filtered-group list [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_proxy_filtered-group[ecctl platform proxy filtered-group]	 - Manages proxies filtered group {ece-icon}
+* xref:ecctl_platform_proxy_filtered-group[ecctl platform proxy filtered-group]	 - Manages proxies filtered group {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_proxy_filtered-group_show.adoc
+++ b/docs/ecctl_platform_proxy_filtered-group_show.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_proxy_filtered-group_show]
 == ecctl platform proxy filtered-group show
 
-Shows details for proxies filtered group {ece-icon}
+Shows details for proxies filtered group {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform proxy filtered-group show <filtered group id> [flags]
@@ -41,4 +41,4 @@ ecctl platform proxy filtered-group show <filtered group id> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_proxy_filtered-group[ecctl platform proxy filtered-group]	 - Manages proxies filtered group {ece-icon}
+* xref:ecctl_platform_proxy_filtered-group[ecctl platform proxy filtered-group]	 - Manages proxies filtered group {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_proxy_filtered-group_update.adoc
+++ b/docs/ecctl_platform_proxy_filtered-group_update.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_proxy_filtered-group_update]
 == ecctl platform proxy filtered-group update
 
-Updates proxies filtered group {ece-icon}
+Updates proxies filtered group {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform proxy filtered-group update <filtered group id> --filters <key1=value1,key2=value2> --expected-proxies-count <int> --version <int> [flags]
@@ -44,4 +44,4 @@ ecctl platform proxy filtered-group update <filtered group id> --filters <key1=v
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_proxy_filtered-group[ecctl platform proxy filtered-group]	 - Manages proxies filtered group {ece-icon}
+* xref:ecctl_platform_proxy_filtered-group[ecctl platform proxy filtered-group]	 - Manages proxies filtered group {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_proxy_list.adoc
+++ b/docs/ecctl_platform_proxy_list.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_proxy_list]
 == ecctl platform proxy list
 
-Returns all of the proxies in the platform {ece-icon}
+Returns all of the proxies in the platform {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform proxy list [flags]
@@ -41,4 +41,4 @@ ecctl platform proxy list [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_proxy[ecctl platform proxy]	 - Manages proxies {ece-icon}
+* xref:ecctl_platform_proxy[ecctl platform proxy]	 - Manages proxies {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_proxy_show.adoc
+++ b/docs/ecctl_platform_proxy_show.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_proxy_show]
 == ecctl platform proxy show
 
-Returns information about the proxy with given id {ece-icon}
+Returns information about the proxy with given id {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform proxy show <proxy id> [flags]
@@ -41,4 +41,4 @@ ecctl platform proxy show <proxy id> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_proxy[ecctl platform proxy]	 - Manages proxies {ece-icon}
+* xref:ecctl_platform_proxy[ecctl platform proxy]	 - Manages proxies {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_repository.adoc
+++ b/docs/ecctl_platform_repository.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_repository]
 == ecctl platform repository
 
-Manages snapshot repositories {ece-icon}
+Manages snapshot repositories {ece-icon} (Available for ECE only)
 
 [float]
 === Synopsis
@@ -47,8 +47,8 @@ ecctl platform repository [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform[ecctl platform]	 - Manages the platform {ece-icon}
-* xref:ecctl_platform_repository_create[ecctl platform repository create]	 - Creates / updates a snapshot repository {ece-icon}
-* xref:ecctl_platform_repository_delete[ecctl platform repository delete]	 - Deletes a snapshot repositories {ece-icon}
-* xref:ecctl_platform_repository_list[ecctl platform repository list]	 - Lists all the snapshot repositories {ece-icon}
-* xref:ecctl_platform_repository_show[ecctl platform repository show]	 - Obtains a snapshot repository config {ece-icon}
+* xref:ecctl_platform[ecctl platform]	 - Manages the platform {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_repository_create[ecctl platform repository create]	 - Creates / updates a snapshot repository {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_repository_delete[ecctl platform repository delete]	 - Deletes a snapshot repositories {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_repository_list[ecctl platform repository list]	 - Lists all the snapshot repositories {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_repository_show[ecctl platform repository show]	 - Obtains a snapshot repository config {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_repository_create.adoc
+++ b/docs/ecctl_platform_repository_create.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_repository_create]
 == ecctl platform repository create
 
-Creates / updates a snapshot repository {ece-icon}
+Creates / updates a snapshot repository {ece-icon} (Available for ECE only)
 
 [float]
 === Synopsis
@@ -67,4 +67,4 @@ ecctl platform repository create custom --type fs --settings settings.yml
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_repository[ecctl platform repository]	 - Manages snapshot repositories {ece-icon}
+* xref:ecctl_platform_repository[ecctl platform repository]	 - Manages snapshot repositories {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_repository_delete.adoc
+++ b/docs/ecctl_platform_repository_delete.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_repository_delete]
 == ecctl platform repository delete
 
-Deletes a snapshot repositories {ece-icon}
+Deletes a snapshot repositories {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform repository delete <repository name> [flags]
@@ -41,4 +41,4 @@ ecctl platform repository delete <repository name> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_repository[ecctl platform repository]	 - Manages snapshot repositories {ece-icon}
+* xref:ecctl_platform_repository[ecctl platform repository]	 - Manages snapshot repositories {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_repository_list.adoc
+++ b/docs/ecctl_platform_repository_list.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_repository_list]
 == ecctl platform repository list
 
-Lists all the snapshot repositories {ece-icon}
+Lists all the snapshot repositories {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform repository list [flags]
@@ -41,4 +41,4 @@ ecctl platform repository list [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_repository[ecctl platform repository]	 - Manages snapshot repositories {ece-icon}
+* xref:ecctl_platform_repository[ecctl platform repository]	 - Manages snapshot repositories {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_repository_show.adoc
+++ b/docs/ecctl_platform_repository_show.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_repository_show]
 == ecctl platform repository show
 
-Obtains a snapshot repository config {ece-icon}
+Obtains a snapshot repository config {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform repository show <repository name> [flags]
@@ -41,4 +41,4 @@ ecctl platform repository show <repository name> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_repository[ecctl platform repository]	 - Manages snapshot repositories {ece-icon}
+* xref:ecctl_platform_repository[ecctl platform repository]	 - Manages snapshot repositories {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_role.adoc
+++ b/docs/ecctl_platform_role.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_role]
 == ecctl platform role
 
-Manages platform roles {ece-icon}
+Manages platform roles {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform role [flags]
@@ -41,9 +41,9 @@ ecctl platform role [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform[ecctl platform]	 - Manages the platform {ece-icon}
-* xref:ecctl_platform_role_create[ecctl platform role create]	 - Creates a new platform role from a definition {ece-icon}
-* xref:ecctl_platform_role_delete[ecctl platform role delete]	 - Deletes an existing platform role {ece-icon}
-* xref:ecctl_platform_role_list[ecctl platform role list]	 - Lists the existing platform roles {ece-icon}
-* xref:ecctl_platform_role_show[ecctl platform role show]	 - Shows the existing platform roles {ece-icon}
+* xref:ecctl_platform[ecctl platform]	 - Manages the platform {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_role_create[ecctl platform role create]	 - Creates a new platform role from a definition {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_role_delete[ecctl platform role delete]	 - Deletes an existing platform role {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_role_list[ecctl platform role list]	 - Lists the existing platform roles {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_role_show[ecctl platform role show]	 - Shows the existing platform roles {ece-icon} (Available for ECE only)
 * xref:ecctl_platform_role_update[ecctl platform role update]	 - Updates an existing platform role

--- a/docs/ecctl_platform_role_create.adoc
+++ b/docs/ecctl_platform_role_create.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_role_create]
 == ecctl platform role create
 
-Creates a new platform role from a definition {ece-icon}
+Creates a new platform role from a definition {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform role create --file <filename.json> [flags]
@@ -42,4 +42,4 @@ ecctl platform role create --file <filename.json> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_role[ecctl platform role]	 - Manages platform roles {ece-icon}
+* xref:ecctl_platform_role[ecctl platform role]	 - Manages platform roles {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_role_delete.adoc
+++ b/docs/ecctl_platform_role_delete.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_role_delete]
 == ecctl platform role delete
 
-Deletes an existing platform role {ece-icon}
+Deletes an existing platform role {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform role delete <role> [flags]
@@ -41,4 +41,4 @@ ecctl platform role delete <role> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_role[ecctl platform role]	 - Manages platform roles {ece-icon}
+* xref:ecctl_platform_role[ecctl platform role]	 - Manages platform roles {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_role_list.adoc
+++ b/docs/ecctl_platform_role_list.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_role_list]
 == ecctl platform role list
 
-Lists the existing platform roles {ece-icon}
+Lists the existing platform roles {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform role list [flags]
@@ -41,4 +41,4 @@ ecctl platform role list [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_role[ecctl platform role]	 - Manages platform roles {ece-icon}
+* xref:ecctl_platform_role[ecctl platform role]	 - Manages platform roles {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_role_show.adoc
+++ b/docs/ecctl_platform_role_show.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_role_show]
 == ecctl platform role show
 
-Shows the existing platform roles {ece-icon}
+Shows the existing platform roles {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform role show <role> [flags]
@@ -41,4 +41,4 @@ ecctl platform role show <role> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_role[ecctl platform role]	 - Manages platform roles {ece-icon}
+* xref:ecctl_platform_role[ecctl platform role]	 - Manages platform roles {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_role_update.adoc
+++ b/docs/ecctl_platform_role_update.adoc
@@ -42,4 +42,4 @@ ecctl platform role update <role> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_role[ecctl platform role]	 - Manages platform roles {ece-icon}
+* xref:ecctl_platform_role[ecctl platform role]	 - Manages platform roles {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_runner.adoc
+++ b/docs/ecctl_platform_runner.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_runner]
 == ecctl platform runner
 
-Manages platform runners {ece-icon}
+Manages platform runners {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform runner [flags]
@@ -41,8 +41,8 @@ ecctl platform runner [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform[ecctl platform]	 - Manages the platform {ece-icon}
-* xref:ecctl_platform_runner_list[ecctl platform runner list]	 - Lists the existing platform runners {ece-icon}
-* xref:ecctl_platform_runner_resync[ecctl platform runner resync]	 - Resynchronizes the search index and cache for the selected runner or all {ece-icon}
-* xref:ecctl_platform_runner_search[ecctl platform runner search]	 - Performs advanced runner searching {ece-icon}
-* xref:ecctl_platform_runner_show[ecctl platform runner show]	 - Shows information about the specified runner {ece-icon}
+* xref:ecctl_platform[ecctl platform]	 - Manages the platform {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_runner_list[ecctl platform runner list]	 - Lists the existing platform runners {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_runner_resync[ecctl platform runner resync]	 - Resynchronizes the search index and cache for the selected runner or all {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_runner_search[ecctl platform runner search]	 - Performs advanced runner searching {ece-icon} (Available for ECE only)
+* xref:ecctl_platform_runner_show[ecctl platform runner show]	 - Shows information about the specified runner {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_runner_list.adoc
+++ b/docs/ecctl_platform_runner_list.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_runner_list]
 == ecctl platform runner list
 
-Lists the existing platform runners {ece-icon}
+Lists the existing platform runners {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform runner list [flags]
@@ -41,4 +41,4 @@ ecctl platform runner list [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_runner[ecctl platform runner]	 - Manages platform runners {ece-icon}
+* xref:ecctl_platform_runner[ecctl platform runner]	 - Manages platform runners {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_runner_resync.adoc
+++ b/docs/ecctl_platform_runner_resync.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_runner_resync]
 == ecctl platform runner resync
 
-Resynchronizes the search index and cache for the selected runner or all {ece-icon}
+Resynchronizes the search index and cache for the selected runner or all {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform runner resync {<runner id> | --all} [flags]
@@ -42,4 +42,4 @@ ecctl platform runner resync {<runner id> | --all} [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_runner[ecctl platform runner]	 - Manages platform runners {ece-icon}
+* xref:ecctl_platform_runner[ecctl platform runner]	 - Manages platform runners {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_runner_search.adoc
+++ b/docs/ecctl_platform_runner_search.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_runner_search]
 == ecctl platform runner search
 
-Performs advanced runner searching {ece-icon}
+Performs advanced runner searching {ece-icon} (Available for ECE only)
 
 [float]
 === Synopsis
@@ -48,4 +48,4 @@ ecctl platform runner search [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_runner[ecctl platform runner]	 - Manages platform runners {ece-icon}
+* xref:ecctl_platform_runner[ecctl platform runner]	 - Manages platform runners {ece-icon} (Available for ECE only)

--- a/docs/ecctl_platform_runner_show.adoc
+++ b/docs/ecctl_platform_runner_show.adoc
@@ -1,7 +1,7 @@
 [#ecctl_platform_runner_show]
 == ecctl platform runner show
 
-Shows information about the specified runner {ece-icon}
+Shows information about the specified runner {ece-icon} (Available for ECE only)
 
 ----
 ecctl platform runner show <runner id> [flags]
@@ -41,4 +41,4 @@ ecctl platform runner show <runner id> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_platform_runner[ecctl platform runner]	 - Manages platform runners {ece-icon}
+* xref:ecctl_platform_runner[ecctl platform runner]	 - Manages platform runners {ece-icon} (Available for ECE only)

--- a/docs/ecctl_stack.adoc
+++ b/docs/ecctl_stack.adoc
@@ -42,7 +42,7 @@ ecctl stack [flags]
 === SEE ALSO
 
 * xref:ecctl[ecctl]	 - Elastic Cloud Control
-* xref:ecctl_stack_delete[ecctl stack delete]	 - Deletes an Elastic StackPack {ece-icon}
+* xref:ecctl_stack_delete[ecctl stack delete]	 - Deletes an Elastic StackPack {ece-icon} (Available for ECE only)
 * xref:ecctl_stack_list[ecctl stack list]	 - Lists Elastic StackPacks
 * xref:ecctl_stack_show[ecctl stack show]	 - Shows information about an Elastic StackPack
-* xref:ecctl_stack_upload[ecctl stack upload]	 - Uploads an Elastic StackPack {ece-icon}
+* xref:ecctl_stack_upload[ecctl stack upload]	 - Uploads an Elastic StackPack {ece-icon} (Available for ECE only)

--- a/docs/ecctl_stack_delete.adoc
+++ b/docs/ecctl_stack_delete.adoc
@@ -1,7 +1,7 @@
 [#ecctl_stack_delete]
 == ecctl stack delete
 
-Deletes an Elastic StackPack {ece-icon}
+Deletes an Elastic StackPack {ece-icon} (Available for ECE only)
 
 ----
 ecctl stack delete [flags]

--- a/docs/ecctl_stack_upload.adoc
+++ b/docs/ecctl_stack_upload.adoc
@@ -1,7 +1,7 @@
 [#ecctl_stack_upload]
 == ecctl stack upload
 
-Uploads an Elastic StackPack {ece-icon}
+Uploads an Elastic StackPack {ece-icon} (Available for ECE only)
 
 ----
 ecctl stack upload [flags]

--- a/docs/ecctl_user.adoc
+++ b/docs/ecctl_user.adoc
@@ -1,7 +1,7 @@
 [#ecctl_user]
 == ecctl user
 
-Manages the platform users {ece-icon}
+Manages the platform users {ece-icon} (Available for ECE only)
 
 ----
 ecctl user [flags]
@@ -42,11 +42,11 @@ ecctl user [flags]
 === SEE ALSO
 
 * xref:ecctl[ecctl]	 - Elastic Cloud Control
-* xref:ecctl_user_create[ecctl user create]	 - Creates a new platform user {ece-icon}
-* xref:ecctl_user_delete[ecctl user delete]	 - Deletes one or more platform users {ece-icon}
-* xref:ecctl_user_disable[ecctl user disable]	 - Disables a platform user {ece-icon}
-* xref:ecctl_user_enable[ecctl user enable]	 - Enables a previously disabled platform user {ece-icon}
+* xref:ecctl_user_create[ecctl user create]	 - Creates a new platform user {ece-icon} (Available for ECE only)
+* xref:ecctl_user_delete[ecctl user delete]	 - Deletes one or more platform users {ece-icon} (Available for ECE only)
+* xref:ecctl_user_disable[ecctl user disable]	 - Disables a platform user {ece-icon} (Available for ECE only)
+* xref:ecctl_user_enable[ecctl user enable]	 - Enables a previously disabled platform user {ece-icon} (Available for ECE only)
 * xref:ecctl_user_key[ecctl user key]	 - Manages the API keys of a platform user
-* xref:ecctl_user_list[ecctl user list]	 - Lists all platform users {ece-icon}
-* xref:ecctl_user_show[ecctl user show]	 - Shows details of a specified user {ece-icon}
-* xref:ecctl_user_update[ecctl user update]	 - Updates a platform user {ece-icon}
+* xref:ecctl_user_list[ecctl user list]	 - Lists all platform users {ece-icon} (Available for ECE only)
+* xref:ecctl_user_show[ecctl user show]	 - Shows details of a specified user {ece-icon} (Available for ECE only)
+* xref:ecctl_user_update[ecctl user update]	 - Updates a platform user {ece-icon} (Available for ECE only)

--- a/docs/ecctl_user_create.adoc
+++ b/docs/ecctl_user_create.adoc
@@ -1,7 +1,7 @@
 [#ecctl_user_create]
 == ecctl user create
 
-Creates a new platform user {ece-icon}
+Creates a new platform user {ece-icon} (Available for ECE only)
 
 ----
 ecctl user create --username <username> --role <role> [flags]
@@ -56,4 +56,4 @@ ecctl user create --username <username> --role <role> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_user[ecctl user]	 - Manages the platform users {ece-icon}
+* xref:ecctl_user[ecctl user]	 - Manages the platform users {ece-icon} (Available for ECE only)

--- a/docs/ecctl_user_delete.adoc
+++ b/docs/ecctl_user_delete.adoc
@@ -1,7 +1,7 @@
 [#ecctl_user_delete]
 == ecctl user delete
 
-Deletes one or more platform users {ece-icon}
+Deletes one or more platform users {ece-icon} (Available for ECE only)
 
 ----
 ecctl user delete <user name> <user name>... [flags]
@@ -41,4 +41,4 @@ ecctl user delete <user name> <user name>... [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_user[ecctl user]	 - Manages the platform users {ece-icon}
+* xref:ecctl_user[ecctl user]	 - Manages the platform users {ece-icon} (Available for ECE only)

--- a/docs/ecctl_user_disable.adoc
+++ b/docs/ecctl_user_disable.adoc
@@ -1,7 +1,7 @@
 [#ecctl_user_disable]
 == ecctl user disable
 
-Disables a platform user {ece-icon}
+Disables a platform user {ece-icon} (Available for ECE only)
 
 ----
 ecctl user disable <username> [flags]
@@ -41,4 +41,4 @@ ecctl user disable <username> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_user[ecctl user]	 - Manages the platform users {ece-icon}
+* xref:ecctl_user[ecctl user]	 - Manages the platform users {ece-icon} (Available for ECE only)

--- a/docs/ecctl_user_enable.adoc
+++ b/docs/ecctl_user_enable.adoc
@@ -1,7 +1,7 @@
 [#ecctl_user_enable]
 == ecctl user enable
 
-Enables a previously disabled platform user {ece-icon}
+Enables a previously disabled platform user {ece-icon} (Available for ECE only)
 
 ----
 ecctl user enable <username> [flags]
@@ -41,4 +41,4 @@ ecctl user enable <username> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_user[ecctl user]	 - Manages the platform users {ece-icon}
+* xref:ecctl_user[ecctl user]	 - Manages the platform users {ece-icon} (Available for ECE only)

--- a/docs/ecctl_user_key.adoc
+++ b/docs/ecctl_user_key.adoc
@@ -41,7 +41,7 @@ ecctl user key [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_user[ecctl user]	 - Manages the platform users {ece-icon}
+* xref:ecctl_user[ecctl user]	 - Manages the platform users {ece-icon} (Available for ECE only)
 * xref:ecctl_user_key_delete[ecctl user key delete]	 - Deletes an existing API key for the specified user
 * xref:ecctl_user_key_list[ecctl user key list]	 - Lists the API keys for the specified user, or all platform users
 * xref:ecctl_user_key_show[ecctl user key show]	 - Shows the API key details for the specified user

--- a/docs/ecctl_user_list.adoc
+++ b/docs/ecctl_user_list.adoc
@@ -1,7 +1,7 @@
 [#ecctl_user_list]
 == ecctl user list
 
-Lists all platform users {ece-icon}
+Lists all platform users {ece-icon} (Available for ECE only)
 
 ----
 ecctl user list [flags]
@@ -41,4 +41,4 @@ ecctl user list [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_user[ecctl user]	 - Manages the platform users {ece-icon}
+* xref:ecctl_user[ecctl user]	 - Manages the platform users {ece-icon} (Available for ECE only)

--- a/docs/ecctl_user_show.adoc
+++ b/docs/ecctl_user_show.adoc
@@ -1,7 +1,7 @@
 [#ecctl_user_show]
 == ecctl user show
 
-Shows details of a specified user {ece-icon}
+Shows details of a specified user {ece-icon} (Available for ECE only)
 
 ----
 ecctl user show <user name> [flags]
@@ -42,4 +42,4 @@ ecctl user show <user name> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_user[ecctl user]	 - Manages the platform users {ece-icon}
+* xref:ecctl_user[ecctl user]	 - Manages the platform users {ece-icon} (Available for ECE only)

--- a/docs/ecctl_user_update.adoc
+++ b/docs/ecctl_user_update.adoc
@@ -1,7 +1,7 @@
 [#ecctl_user_update]
 == ecctl user update
 
-Updates a platform user {ece-icon}
+Updates a platform user {ece-icon} (Available for ECE only)
 
 ----
 ecctl user update <username> --role <role> [flags]
@@ -61,4 +61,4 @@ ecctl user update <username> --role <role> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_user[ecctl user]	 - Manages the platform users {ece-icon}
+* xref:ecctl_user[ecctl user]	 - Manages the platform users {ece-icon} (Available for ECE only)

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -40,7 +40,7 @@ done
 sed -i'.bak' -e 's/\.adoc//g' ecctl*.adoc
 
 # Replace ECE availability text for ece icon
-sed -i'.bak' -e 's/(Available for ECE only)/{ece-icon}/g' ecctl*.adoc
+sed -i'.bak' -e 's/(Available for ECE only)/{ece-icon} (Available for ECE only)/g' ecctl*.adoc
 
 # Add [float] tags to H3 sections to keep content together
 sed -i'.bak' -e 's/===/\[float]\


### PR DESCRIPTION
## Description
Adds (Available for ECE only) message next to ECE icons to all command docs.

This is a port for the changes made in https://github.com/elastic/ecctl/pull/425.
