### PR TITLE
Removes invalid references from release notes

### DIFF
--- a/docs/release_notes/v1.2.0.adoc
+++ b/docs/release_notes/v1.2.0.adoc
@@ -4,7 +4,7 @@
 <titleabbrev>v1.2.0</titleabbrev>
 ++++
 
-<<{p}-release-notes-v1.2.0-bug-fixes,Bug fixes>> | <<{p}-release-notes-v1.2.0-breaking-changes,Breaking changes>> | <<{p}-release-notes-v1.2.0-changelog,Changelog>>
+<<{p}-release-notes-v1.2.0-bug-fixes,Bug fixes>> | <<{p}-release-notes-v1.2.0-changelog,Changelog>>
 
 Welcome to the v1.2.0 release of {n}. This version brings new features, some breaking changes, and bug fixes.
 

--- a/docs/release_notes/v1.2.0.adoc
+++ b/docs/release_notes/v1.2.0.adoc
@@ -4,7 +4,7 @@
 <titleabbrev>v1.2.0</titleabbrev>
 ++++
 
-<<{p}-release-notes-v1.2.0-whats-new,What's new>> | <<{p}-release-notes-v1.2.0-bug-fixes,Bug fixes>> | <<{p}-release-notes-v1.2.0-breaking-changes,Breaking changes>> | <<{p}-release-notes-v1.2.0-changelog,Changelog>>
+<<{p}-release-notes-v1.2.0-bug-fixes,Bug fixes>> | <<{p}-release-notes-v1.2.0-breaking-changes,Breaking changes>> | <<{p}-release-notes-v1.2.0-changelog,Changelog>>
 
 Welcome to the v1.2.0 release of {n}. This version brings new features, some breaking changes, and bug fixes.
 


### PR DESCRIPTION
## Description

Removes two invalid in-page references from `docs/release_notes/v1.2.0.adoc`.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
