### PR TITLE
build: Fix release GH action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Install hub
         uses: geertvdc/setup-hub@master
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
       - name: Update AWS cli
         uses: chrislennon/action-aws-cli@v1.1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Adds a new `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment var to 
fix the release GH action which was unable to install hub.

https://github.com/elastic/ecctl/actions/runs/557220539

## Motivation and Context
I don't want to release `1.2.0` manually.

## How Has This Been Tested?
I can't test this manually, the release job will have to be run again

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
