### PR TITLE
Fix 1.2.0 release notes not building for docs/pull/2059

### DIFF
--- a/docs/release_notes/v1.2.0.adoc
+++ b/docs/release_notes/v1.2.0.adoc
@@ -4,7 +4,7 @@
 <titleabbrev>v1.2.0</titleabbrev>
 ++++
 
-<<{p}-release-notes-v1.2.0-whats-new,What's new>> | <<{p}-release-notes-v1.2.0-bug-fixes,Bug fixes>> | <<{p}-release-notes-v1.2.0-breaking-changes,Breaking changes>> | <<{p}-release-notes-v1.2.0-changelog,Changelog>>
+<<{p}-release-notes-v1.2.0-bug-fixes,Bug fixes>> | <<{p}-release-notes-v1.2.0-changelog,Changelog>>
 
 Welcome to the v1.2.0 release of {n}. This version brings new features, some breaking changes, and bug fixes.
 


### PR DESCRIPTION
https://github.com/elastic/ecctl/issues/436 does not build because of : 
```
WARNING: invalid reference: ecctl-release-notes-v1.2.0-whats-new
```

According to https://github.com/elastic/docs/pull/2059#issuecomment-779927833 this is the way to fix it