### PR TITLE
docs: Set deployment node command as ECE only

### DIFF
--- a/cmd/deployment/note/command.go
+++ b/cmd/deployment/note/command.go
@@ -23,16 +23,17 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi"
 	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/noteapi"
-	"github.com/elastic/cloud-sdk-go/pkg/util/cmdutil"
+	sdkcmdutil "github.com/elastic/cloud-sdk-go/pkg/util/cmdutil"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
 // Command represents the deployment note subcommand.
 var Command = &cobra.Command{
 	Use:     "note",
-	Short:   "Manages a deployment's notes",
+	Short:   cmdutil.AdminReqDescription("Manages a deployment's notes"),
 	PreRunE: cobra.MaximumNArgs(0),
 	Run:     func(cmd *cobra.Command, args []string) { cmd.Help() },
 }
@@ -40,8 +41,8 @@ var Command = &cobra.Command{
 var deploymentNoteCreateCmd = &cobra.Command{
 	Use:     "create <deployment id> --comment <comment content>",
 	Aliases: []string{"add"},
-	Short:   "Adds a note to a deployment",
-	PreRunE: cmdutil.MinimumNArgsAndUUID(1),
+	Short:   cmdutil.AdminReqDescription("Adds a note to a deployment"),
+	PreRunE: sdkcmdutil.MinimumNArgsAndUUID(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		comment, _ := cmd.Flags().GetString("comment")
 		esID, err := getElasticsearchID(args[0], ecctl.Get().API)
@@ -63,8 +64,8 @@ var deploymentNoteCreateCmd = &cobra.Command{
 
 var deploymentNoteListCmd = &cobra.Command{
 	Use:     "list <deployment id>",
-	Short:   "Lists the deployment notes",
-	PreRunE: cmdutil.MinimumNArgsAndUUID(1),
+	Short:   cmdutil.AdminReqDescription("Lists the deployment notes"),
+	PreRunE: sdkcmdutil.MinimumNArgsAndUUID(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		esID, err := getElasticsearchID(args[0], ecctl.Get().API)
 		if err != nil {
@@ -86,8 +87,8 @@ var deploymentNoteListCmd = &cobra.Command{
 
 var deploymentNoteUpdateCmd = &cobra.Command{
 	Use:     "update <deployment id> --id <note id> --comment <comment content>",
-	Short:   "Updates the deployment notes",
-	PreRunE: cmdutil.MinimumNArgsAndUUID(1),
+	Short:   cmdutil.AdminReqDescription("Updates the deployment notes"),
+	PreRunE: sdkcmdutil.MinimumNArgsAndUUID(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		comment, _ := cmd.Flags().GetString("comment")
 		noteID, _ := cmd.Flags().GetString("id")
@@ -113,8 +114,8 @@ var deploymentNoteUpdateCmd = &cobra.Command{
 
 var deploymentNoteShowCmd = &cobra.Command{
 	Use:     "show <deployment id> --id <note id>",
-	Short:   "Shows a deployment note",
-	PreRunE: cmdutil.MinimumNArgsAndUUID(1),
+	Short:   cmdutil.AdminReqDescription("Shows a deployment note"),
+	PreRunE: sdkcmdutil.MinimumNArgsAndUUID(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		noteID, _ := cmd.Flags().GetString("id")
 		esID, err := getElasticsearchID(args[0], ecctl.Get().API)

--- a/docs/ecctl_deployment.adoc
+++ b/docs/ecctl_deployment.adoc
@@ -46,7 +46,7 @@ ecctl deployment [flags]
 * xref:ecctl_deployment_delete[ecctl deployment delete]	 - Deletes a previously shutdown deployment {ece-icon} (Available for ECE only)
 * xref:ecctl_deployment_elasticsearch[ecctl deployment elasticsearch]	 - Manages Elasticsearch resources
 * xref:ecctl_deployment_list[ecctl deployment list]	 - Lists the platform's deployments
-* xref:ecctl_deployment_note[ecctl deployment note]	 - Manages a deployment's notes
+* xref:ecctl_deployment_note[ecctl deployment note]	 - Manages a deployment's notes {ece-icon} (Available for ECE only)
 * xref:ecctl_deployment_plan[ecctl deployment plan]	 - Manages deployment plans
 * xref:ecctl_deployment_resource[ecctl deployment resource]	 - Manages deployment resources
 * xref:ecctl_deployment_restore[ecctl deployment restore]	 - Restores a previously shut down deployment and all of its associated sub-resources

--- a/docs/ecctl_deployment.md
+++ b/docs/ecctl_deployment.md
@@ -42,7 +42,7 @@ ecctl deployment [flags]
 * [ecctl deployment delete](ecctl_deployment_delete.md)	 - Deletes a previously shutdown deployment (Available for ECE only)
 * [ecctl deployment elasticsearch](ecctl_deployment_elasticsearch.md)	 - Manages Elasticsearch resources
 * [ecctl deployment list](ecctl_deployment_list.md)	 - Lists the platform's deployments
-* [ecctl deployment note](ecctl_deployment_note.md)	 - Manages a deployment's notes
+* [ecctl deployment note](ecctl_deployment_note.md)	 - Manages a deployment's notes (Available for ECE only)
 * [ecctl deployment plan](ecctl_deployment_plan.md)	 - Manages deployment plans
 * [ecctl deployment resource](ecctl_deployment_resource.md)	 - Manages deployment resources
 * [ecctl deployment restore](ecctl_deployment_restore.md)	 - Restores a previously shut down deployment and all of its associated sub-resources

--- a/docs/ecctl_deployment_note.adoc
+++ b/docs/ecctl_deployment_note.adoc
@@ -1,7 +1,7 @@
 [#ecctl_deployment_note]
 == ecctl deployment note
 
-Manages a deployment's notes
+Manages a deployment's notes {ece-icon} (Available for ECE only)
 
 ----
 ecctl deployment note [flags]
@@ -42,7 +42,7 @@ ecctl deployment note [flags]
 === SEE ALSO
 
 * xref:ecctl_deployment[ecctl deployment]	 - Manages deployments
-* xref:ecctl_deployment_note_create[ecctl deployment note create]	 - Adds a note to a deployment
-* xref:ecctl_deployment_note_list[ecctl deployment note list]	 - Lists the deployment notes
-* xref:ecctl_deployment_note_show[ecctl deployment note show]	 - Shows a deployment note
-* xref:ecctl_deployment_note_update[ecctl deployment note update]	 - Updates the deployment notes
+* xref:ecctl_deployment_note_create[ecctl deployment note create]	 - Adds a note to a deployment {ece-icon} (Available for ECE only)
+* xref:ecctl_deployment_note_list[ecctl deployment note list]	 - Lists the deployment notes {ece-icon} (Available for ECE only)
+* xref:ecctl_deployment_note_show[ecctl deployment note show]	 - Shows a deployment note {ece-icon} (Available for ECE only)
+* xref:ecctl_deployment_note_update[ecctl deployment note update]	 - Updates the deployment notes {ece-icon} (Available for ECE only)

--- a/docs/ecctl_deployment_note.md
+++ b/docs/ecctl_deployment_note.md
@@ -1,6 +1,6 @@
 ## ecctl deployment note
 
-Manages a deployment's notes
+Manages a deployment's notes (Available for ECE only)
 
 ```
 ecctl deployment note [flags]
@@ -38,8 +38,8 @@ ecctl deployment note [flags]
 ### SEE ALSO
 
 * [ecctl deployment](ecctl_deployment.md)	 - Manages deployments
-* [ecctl deployment note create](ecctl_deployment_note_create.md)	 - Adds a note to a deployment
-* [ecctl deployment note list](ecctl_deployment_note_list.md)	 - Lists the deployment notes
-* [ecctl deployment note show](ecctl_deployment_note_show.md)	 - Shows a deployment note
-* [ecctl deployment note update](ecctl_deployment_note_update.md)	 - Updates the deployment notes
+* [ecctl deployment note create](ecctl_deployment_note_create.md)	 - Adds a note to a deployment (Available for ECE only)
+* [ecctl deployment note list](ecctl_deployment_note_list.md)	 - Lists the deployment notes (Available for ECE only)
+* [ecctl deployment note show](ecctl_deployment_note_show.md)	 - Shows a deployment note (Available for ECE only)
+* [ecctl deployment note update](ecctl_deployment_note_update.md)	 - Updates the deployment notes (Available for ECE only)
 

--- a/docs/ecctl_deployment_note_create.adoc
+++ b/docs/ecctl_deployment_note_create.adoc
@@ -1,7 +1,7 @@
 [#ecctl_deployment_note_create]
 == ecctl deployment note create
 
-Adds a note to a deployment
+Adds a note to a deployment {ece-icon} (Available for ECE only)
 
 ----
 ecctl deployment note create <deployment id> --comment <comment content> [flags]
@@ -42,4 +42,4 @@ ecctl deployment note create <deployment id> --comment <comment content> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_deployment_note[ecctl deployment note]	 - Manages a deployment's notes
+* xref:ecctl_deployment_note[ecctl deployment note]	 - Manages a deployment's notes {ece-icon} (Available for ECE only)

--- a/docs/ecctl_deployment_note_create.md
+++ b/docs/ecctl_deployment_note_create.md
@@ -1,6 +1,6 @@
 ## ecctl deployment note create
 
-Adds a note to a deployment
+Adds a note to a deployment (Available for ECE only)
 
 ```
 ecctl deployment note create <deployment id> --comment <comment content> [flags]
@@ -38,5 +38,5 @@ ecctl deployment note create <deployment id> --comment <comment content> [flags]
 
 ### SEE ALSO
 
-* [ecctl deployment note](ecctl_deployment_note.md)	 - Manages a deployment's notes
+* [ecctl deployment note](ecctl_deployment_note.md)	 - Manages a deployment's notes (Available for ECE only)
 

--- a/docs/ecctl_deployment_note_list.adoc
+++ b/docs/ecctl_deployment_note_list.adoc
@@ -1,7 +1,7 @@
 [#ecctl_deployment_note_list]
 == ecctl deployment note list
 
-Lists the deployment notes
+Lists the deployment notes {ece-icon} (Available for ECE only)
 
 ----
 ecctl deployment note list <deployment id> [flags]
@@ -41,4 +41,4 @@ ecctl deployment note list <deployment id> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_deployment_note[ecctl deployment note]	 - Manages a deployment's notes
+* xref:ecctl_deployment_note[ecctl deployment note]	 - Manages a deployment's notes {ece-icon} (Available for ECE only)

--- a/docs/ecctl_deployment_note_list.md
+++ b/docs/ecctl_deployment_note_list.md
@@ -1,6 +1,6 @@
 ## ecctl deployment note list
 
-Lists the deployment notes
+Lists the deployment notes (Available for ECE only)
 
 ```
 ecctl deployment note list <deployment id> [flags]
@@ -37,5 +37,5 @@ ecctl deployment note list <deployment id> [flags]
 
 ### SEE ALSO
 
-* [ecctl deployment note](ecctl_deployment_note.md)	 - Manages a deployment's notes
+* [ecctl deployment note](ecctl_deployment_note.md)	 - Manages a deployment's notes (Available for ECE only)
 

--- a/docs/ecctl_deployment_note_show.adoc
+++ b/docs/ecctl_deployment_note_show.adoc
@@ -1,7 +1,7 @@
 [#ecctl_deployment_note_show]
 == ecctl deployment note show
 
-Shows a deployment note
+Shows a deployment note {ece-icon} (Available for ECE only)
 
 ----
 ecctl deployment note show <deployment id> --id <note id> [flags]
@@ -42,4 +42,4 @@ ecctl deployment note show <deployment id> --id <note id> [flags]
 [float]
 === SEE ALSO
 
-* xref:ecctl_deployment_note[ecctl deployment note]	 - Manages a deployment's notes
+* xref:ecctl_deployment_note[ecctl deployment note]	 - Manages a deployment's notes {ece-icon} (Available for ECE only)

--- a/docs/ecctl_deployment_note_show.md
+++ b/docs/ecctl_deployment_note_show.md
@@ -1,6 +1,6 @@
 ## ecctl deployment note show
 
-Shows a deployment note
+Shows a deployment note (Available for ECE only)
 
 ```
 ecctl deployment note show <deployment id> --id <note id> [flags]
@@ -38,5 +38,5 @@ ecctl deployment note show <deployment id> --id <note id> [flags]
 
 ### SEE ALSO
 
-* [ecctl deployment note](ecctl_deployment_note.md)	 - Manages a deployment's notes
+* [ecctl deployment note](ecctl_deployment_note.md)	 - Manages a deployment's notes (Available for ECE only)
 

--- a/docs/ecctl_deployment_note_update.adoc
+++ b/docs/ecctl_deployment_note_update.adoc
@@ -1,7 +1,7 @@
 [#ecctl_deployment_note_update]
 == ecctl deployment note update
 
-Updates the deployment notes
+Updates the deployment notes {ece-icon} (Available for ECE only)
 
 ----
 ecctl deployment note update <deployment id> --id <note id> --comment <comment content> [flags]
@@ -43,4 +43,4 @@ ecctl deployment note update <deployment id> --id <note id> --comment <comment c
 [float]
 === SEE ALSO
 
-* xref:ecctl_deployment_note[ecctl deployment note]	 - Manages a deployment's notes
+* xref:ecctl_deployment_note[ecctl deployment note]	 - Manages a deployment's notes {ece-icon} (Available for ECE only)

--- a/docs/ecctl_deployment_note_update.md
+++ b/docs/ecctl_deployment_note_update.md
@@ -1,6 +1,6 @@
 ## ecctl deployment note update
 
-Updates the deployment notes
+Updates the deployment notes (Available for ECE only)
 
 ```
 ecctl deployment note update <deployment id> --id <note id> --comment <comment content> [flags]
@@ -39,5 +39,5 @@ ecctl deployment note update <deployment id> --id <note id> --comment <comment c
 
 ### SEE ALSO
 
-* [ecctl deployment note](ecctl_deployment_note.md)	 - Manages a deployment's notes
+* [ecctl deployment note](ecctl_deployment_note.md)	 - Manages a deployment's notes (Available for ECE only)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
When adding documentation regarding ECE specific commands
we forgot to mark the `ecctl deplyoment note` command and its
subcommands as one of them. This patch fixes this issue.

## Related Issues
Closes https://github.com/elastic/ecctl/issues/437

## Motivation and Context
Let's not confuse our users :)

## How Has This Been Tested?
By running `make docs`

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Documentation

