### PR TITLE
alings create comment command texts

### DIFF
--- a/cmd/comment/create.go
+++ b/cmd/comment/create.go
@@ -23,12 +23,13 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/commentapi"
 	"github.com/spf13/cobra"
 
+	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
 var createCmd = &cobra.Command{
 	Use:     "create <message> --resource-type <resource-type> --resource-id <resource-id>",
-	Short:   "Creates a new resource comment",
+	Short:   cmdutil.AdminReqDescription("Creates a new resource comment"),
 	PreRunE: cobra.ExactValidArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		resourceType, _ := cmd.Flags().GetString("resource-type")
@@ -57,8 +58,9 @@ func init() {
 func initCreateFlags() {
 	Command.AddCommand(createCmd)
 
-	createCmd.Flags().String("resource-type", "", "The kind of Resource that a Comment belongs to. Should be one of [elasticsearch, kibana, apm, appsearch, enterprise_search, allocator, constructor, runner, proxy].")
-	createCmd.Flags().String("resource-id", "", "Id of the Resource that a Comment belongs to.")
+	createCmd.Flags().String("resource-type", "", "The kind of resource that a comment belongs to. "+
+		"Should be one of [elasticsearch, kibana, apm, appsearch, enterprise_search, allocator, constructor, runner, proxy].")
+	createCmd.Flags().String("resource-id", "", "Id of the resource that a Comment belongs to.")
 
 	createCmd.MarkFlagRequired("resource-type")
 	createCmd.MarkFlagRequired("resource-id")

--- a/docs/ecctl_comment.adoc
+++ b/docs/ecctl_comment.adoc
@@ -42,4 +42,4 @@ ecctl comment [flags]
 === SEE ALSO
 
 * xref:ecctl[ecctl]	 - Elastic Cloud Control
-* xref:ecctl_comment_create[ecctl comment create]	 - Creates a new resource comment
+* xref:ecctl_comment_create[ecctl comment create]	 - Creates a new resource comment {ece-icon} (Available for ECE only)

--- a/docs/ecctl_comment.md
+++ b/docs/ecctl_comment.md
@@ -38,5 +38,5 @@ ecctl comment [flags]
 ### SEE ALSO
 
 * [ecctl](ecctl.md)	 - Elastic Cloud Control
-* [ecctl comment create](ecctl_comment_create.md)	 - Creates a new resource comment
+* [ecctl comment create](ecctl_comment_create.md)	 - Creates a new resource comment (Available for ECE only)
 

--- a/docs/ecctl_comment_create.adoc
+++ b/docs/ecctl_comment_create.adoc
@@ -1,7 +1,7 @@
 [#ecctl_comment_create]
 == ecctl comment create
 
-Creates a new resource comment
+Creates a new resource comment {ece-icon} (Available for ECE only)
 
 ----
 ecctl comment create <message> --resource-type <resource-type> --resource-id <resource-id> [flags]
@@ -12,8 +12,8 @@ ecctl comment create <message> --resource-type <resource-type> --resource-id <re
 
 ----
   -h, --help                   help for create
-      --resource-id string     Id of the Resource that a Comment belongs to.
-      --resource-type string   The kind of Resource that a Comment belongs to. Should be one of [elasticsearch, kibana, apm, appsearch, enterprise_search, allocator, constructor, runner, proxy].
+      --resource-id string     Id of the resource that a Comment belongs to.
+      --resource-type string   The kind of resource that a comment belongs to. Should be one of [elasticsearch, kibana, apm, appsearch, enterprise_search, allocator, constructor, runner, proxy].
 ----
 
 [float]

--- a/docs/ecctl_comment_create.md
+++ b/docs/ecctl_comment_create.md
@@ -1,6 +1,6 @@
 ## ecctl comment create
 
-Creates a new resource comment
+Creates a new resource comment (Available for ECE only)
 
 ```
 ecctl comment create <message> --resource-type <resource-type> --resource-id <resource-id> [flags]
@@ -10,8 +10,8 @@ ecctl comment create <message> --resource-type <resource-type> --resource-id <re
 
 ```
   -h, --help                   help for create
-      --resource-id string     Id of the Resource that a Comment belongs to.
-      --resource-type string   The kind of Resource that a Comment belongs to. Should be one of [elasticsearch, kibana, apm, appsearch, enterprise_search, allocator, constructor, runner, proxy].
+      --resource-id string     Id of the resource that a Comment belongs to.
+      --resource-type string   The kind of resource that a comment belongs to. Should be one of [elasticsearch, kibana, apm, appsearch, enterprise_search, allocator, constructor, runner, proxy].
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Aligns the text and help messages of the `comment create` command with the other sub-commands ( list and show ) 