### PR TITLE
release: Add branch GitHub action

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -1,0 +1,25 @@
+name: release-branch
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+
+jobs:
+  branch-out:
+    name: Create a github branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Get the branch version
+        id: get_branch
+        run: echo ::set-output name=BRANCH::$(echo ${GITHUB_REF/refs\/tags\//#v} | cut -d '.' -f1-2)
+
+      - name: Create a github branch
+        uses: peterjgrainger/action-create-branch@v2.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_EXTRA }}
+        with:
+          branch: ${{ steps.get_branch.outputs.BRANCH }}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds a GitHub action which creates a new branch when a tag is pushed
with the tag's MAJOR.MINOR. If the branch already exists, the action
will fail, but it can be ignored. GitHub actions has no way to set the
step as successful on failure, we'd need to modify the source code of
the used action.
