### PR TITLE
release: Use fetch-depth:0 on checkout

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Get the branch version
         id: get_branch


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Last fix to the branch action, it was using a shallow checkout, it needs to use 0 depth to be able to describe the tag.

