### PR TITLE
scripts: Use go install rather than gobin

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,6 @@ issues:
   max-same-issues: 0
 
 linters:
-  enable-all: true
   disable:
     - dupl
     - lll

--- a/build/Makefile.deps
+++ b/build/Makefile.deps
@@ -4,14 +4,13 @@ OS:=$(shell uname -s | tr '[:upper:]' '[:lower:]')
 ARCH:=$(shell $(PWD)/scripts/uname_arch.sh)
 VERSION_DIR:=$(GOBIN)/versions
 
-VERSION_GOBIN:=v0.0.13
 VERSION_GOLINT:=v0.0.0-20191125180803-fdd1cda4f05f
 VERSION_GOLICENSER:=v0.3.0
-VERSION_GOLANGCILINT:=v1.23.8
+VERSION_GOLANGCILINT:=v1.38.0
 VERSION_GOBINDATA:=v0.0.0-20190711162640-ee3c2418e368
-VERSION_GORELEASER:=v0.136.0
+VERSION_GORELEASER:=v0.156.1
 
-deps: $(GOBIN)/gobin $(GOBIN)/golint $(GOBIN)/go-licenser $(GOBIN)/golangci-lint $(GOBIN)/go-bindata $(GOBIN)/goreleaser
+deps: $(GOBIN)/golint $(GOBIN)/go-licenser $(GOBIN)/golangci-lint $(GOBIN)/go-bindata $(GOBIN)/goreleaser
 
 $(GOBIN):
 	@ mkdir -p $(GOBIN)
@@ -19,31 +18,21 @@ $(GOBIN):
 $(VERSION_DIR): | $(GOBIN)
 	@ mkdir -p $(GOBIN)/versions
 
-
-$(VERSION_DIR)/.version-gobin-$(VERSION_GOBIN): | $(VERSION_DIR)
-	@ rm -f $(VERSION_DIR)/.version-gobin-*
-	@ echo $(VERSION_GOBIN) > $(VERSION_DIR)/.version-gobin-$(VERSION_GOBIN)
-
-$(GOBIN)/gobin: $(VERSION_DIR)/.version-gobin-$(VERSION_GOBIN) | $(GOBIN)
-	@ echo "-> Installing gobin..."
-	@ curl -sL -o $(GOBIN)/gobin https://github.com/myitcv/gobin/releases/download/$(VERSION_GOBIN)/$(OS)-$(ARCH)
-	@ chmod +x $(GOBIN)/gobin
-
 $(VERSION_DIR)/.version-golint-$(VERSION_GOLINT): | $(VERSION_DIR)
 	@ rm -f $(VERSION_DIR)/.version-golint-*
 	@ echo $(VERSION_GOLINT) > $(VERSION_DIR)/.version-golint-$(VERSION_GOLINT)
 
-$(GOBIN)/golint: $(GOBIN)/gobin $(VERSION_DIR)/.version-golint-$(VERSION_GOLINT) | $(GOBIN)
+$(GOBIN)/golint: $(VERSION_DIR)/.version-golint-$(VERSION_GOLINT) | $(GOBIN)
 	@ echo "-> Installing golint..."
-	@ $(GOBIN)/gobin golang.org/x/lint/golint@$(VERSION_GOLINT)
+	@ go install golang.org/x/lint/golint@$(VERSION_GOLINT)
 
 $(VERSION_DIR)/.version-go-licenser-$(VERSION_GOLICENSER): | $(VERSION_DIR)
 	@ rm -f $(VERSION_DIR)/.version-go-licenser-*
 	@ echo $(VERSION_GOLICENSER) > $(VERSION_DIR)/.version-go-licenser-$(VERSION_GOLICENSER)
 
-$(GOBIN)/go-licenser: $(GOBIN)/gobin $(VERSION_DIR)/.version-go-licenser-$(VERSION_GOLICENSER) | $(GOBIN)
+$(GOBIN)/go-licenser: $(VERSION_DIR)/.version-go-licenser-$(VERSION_GOLICENSER) | $(GOBIN)
 	@ echo "-> Installing go-licenser..."
-	@ $(GOBIN)/gobin github.com/elastic/go-licenser@$(VERSION_GOLICENSER)
+	@ go install github.com/elastic/go-licenser@$(VERSION_GOLICENSER)
 
 $(VERSION_DIR)/.version-golangci-lint-$(VERSION_GOLANGCILINT): | $(VERSION_DIR)
 	@ rm -f $(VERSION_DIR)/.version-golangci-lint-*
@@ -57,9 +46,9 @@ $(VERSION_DIR)/.version-go-bindata-$(VERSION_GOBINDATA):
 	@ rm -f $(VERSION_DIR)/.version-go-bindata-*
 	@ echo $(VERSION_GOBINDATA) > $(VERSION_DIR)/.version-go-bindata-$(VERSION_GOBINDATA)
 
-$(GOBIN)/go-bindata: $(GOBIN)/gobin $(VERSION_DIR)/.version-go-bindata-$(VERSION_GOBINDATA) | $(GOBIN)
+$(GOBIN)/go-bindata: $(VERSION_DIR)/.version-go-bindata-$(VERSION_GOBINDATA) | $(GOBIN)
 	@ echo "-> Installing go-bindata..."
-	@ $(GOBIN)/gobin github.com/go-bindata/go-bindata/go-bindata@$(VERSION_GOBINDATA)
+	@ go install github.com/go-bindata/go-bindata/go-bindata@$(VERSION_GOBINDATA)
 
 $(VERSION_DIR)/.version-goreleaser-$(VERSION_GORELEASER): | $(VERSION_DIR)
 	@ rm -f $(VERSION_DIR)/.version-goreleaser-*


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Uses the built in `go install` that newer versions of Go have to install
the Go binary dependencies that this project relies on.
