### PR TITLE
release: Automate version updates on all branches

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -25,9 +25,55 @@ jobs:
           fi
           echo ::set-output name=BRANCH::$(echo ${BRANCH} | cut -d '.' -f1-2 | tr -d 'v')
 
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+        id: go
+
+      - name: Bump main version
+        run: make patch
+
       - name: Create a github branch
         uses: peterjgrainger/action-create-branch@v2.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GH_TOKEN }}
         with:
           branch: ${{ steps.get_branch.outputs.BRANCH }}
+
+      - name: Commit changes to the minor branch
+        uses: EndBug/add-and-commit@v7
+        with:
+          default_author: user_info
+          message: 'Update patch version'
+          branch: ${{ steps.get_branch.outputs.BRANCH }}
+          author_name: elasticcloudclients
+          author_email: elasticcloudclients@elastic.co
+
+  bump-minor-version:
+    name: Bump main version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: master
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+        id: go
+
+      - name: Bump main version
+        run: make minor; git diff
+
+      - name: Commit changes to main
+        uses: EndBug/add-and-commit@v7
+        with:
+          default_author: user_info
+          message: 'Update minor version'
+          branch: master
+          author_name: elasticcloudclients
+          author_email: elasticcloudclients@elastic.co

--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,4 @@ include scripts/Makefile.help
 include build/Makefile.build
 include build/Makefile.dev
 include build/Makefile.deps
+include build/Makefile.version

--- a/build/Makefile.deps
+++ b/build/Makefile.deps
@@ -9,6 +9,7 @@ VERSION_GOLICENSER:=v0.3.0
 VERSION_GOLANGCILINT:=v1.38.0
 VERSION_GOBINDATA:=v0.0.0-20190711162640-ee3c2418e368
 VERSION_GORELEASER:=v0.156.1
+VERSION_VERSIONBUMP:=v1.1.0
 
 deps: $(GOBIN)/golint $(GOBIN)/go-licenser $(GOBIN)/golangci-lint $(GOBIN)/go-bindata $(GOBIN)/goreleaser
 
@@ -57,3 +58,11 @@ $(VERSION_DIR)/.version-goreleaser-$(VERSION_GORELEASER): | $(VERSION_DIR)
 $(GOBIN)/goreleaser: $(VERSION_DIR)/.version-goreleaser-$(VERSION_GORELEASER) | $(GOBIN)
 	@ echo "-> Installing goreleaser..."
 	@ curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh| sh -s -- -b $(GOBIN) $(VERSION_GORELEASER)
+
+$(VERSION_DIR)/.version-versionbump-$(VERSION_VERSIONBUMP):
+	@ rm -f $(VERSION_DIR)/.version-versionbump-*
+	@ echo $(VERSION_VERSIONBUMP) > $(VERSION_DIR)/.version-versionbump-$(VERSION_VERSIONBUMP)
+
+$(GOBIN)/versionbump: $(VERSION_DIR)/.version-versionbump-$(VERSION_VERSIONBUMP) | $(GOBIN)
+	@ echo "-> Installing versionbump..."
+	@ go install github.com/crosseyed/versionbump/cmd/versionbump@$(VERSION_VERSIONBUMP)

--- a/build/Makefile.version
+++ b/build/Makefile.version
@@ -1,0 +1,13 @@
+### Manage repository versions
+
+## Bump the major version for ecctl.
+major: $(GOBIN)/versionbump
+	@ $(GOBIN)/versionbump -c major Makefile
+
+## Bump the minor o feature version for ecctl.
+minor: $(GOBIN)/versionbump
+	@ $(GOBIN)/versionbump -c minor Makefile
+
+## Bump the patch o bugfix version for ecctl.
+patch: $(GOBIN)/versionbump
+	@ $(GOBIN)/versionbump -c patch Makefile


### PR DESCRIPTION
## Description

Adds the `versionbump` binary and github action workflows:

Updates `branch-out` to bump the patch version and commit it to the
relevant branch.

`bump-main-version` checks out the `master` branch and updates the minor
version. Since Major version updates are rare enough where they can be
done manually (still leveraging `make major`).

