### PR TITLE
init: Add an ESS API Key creation link

### DIFF
--- a/docs/ecctl-getting-started.asciidoc
+++ b/docs/ecctl-getting-started.asciidoc
@@ -108,7 +108,7 @@ variables, or at runtime using the CLI’s global flags.
 === Before you begin
 The hierarchy for configuration parameters is as follows, from higher precedence to lower:
 
-. Command line flags `--host`, `--user`, `--pass`
+. Command line flags `--api-key`, `--region`, `--verbose`
 . Environment variables
 . Shared configuration file
 `$HOME/.ecctl/config.<json|toml|yaml|hcl>`
@@ -173,6 +173,7 @@ Select a region you would like to have as default:
 
 Please enter your choice: 1
 
+Create a new Elasticsearch Service API key (https://cloud.elastic.co/deployment-features/keys) and/or
 Paste your API Key and press enter: xxxxx
 
 What default output format would you like?

--- a/pkg/ecctl/init.go
+++ b/pkg/ecctl/init.go
@@ -103,8 +103,9 @@ const (
 	esspHostMsg    = "Enter the URL of your ESSP installation: "
 	essChoiceMsg   = "Using \"%s\" as the API endpoint.\n"
 
-	apiKeyMsg = "Paste your API Key and press enter: "
-	userMsg   = "Type in your username: "
+	essAPIKeyCreateMsg = "Create a new Elasticsearch Service API key (https://cloud.elastic.co/deployment-features/keys) and/or"
+	apiKeyMsg          = "Paste your API Key and press enter: "
+	userMsg            = "Type in your username: "
 	//nolint
 	passMsg = "Type in your password: "
 
@@ -386,6 +387,7 @@ func askInfraSelection(cfg *Config, scanner *input.Scanner, writer, errWriter io
 		if err := askRegionSelection(cfg, scanner, writer, essRegions); err != nil {
 			return err
 		}
+		fmt.Fprintln(writer, essAPIKeyCreateMsg)
 		if err := askAPIKey(cfg, writer, passFunc); err != nil {
 			return err
 		}

--- a/pkg/ecctl/init_test.go
+++ b/pkg/ecctl/init_test.go
@@ -264,6 +264,7 @@ func TestInitConfig(t *testing.T) {
 			},
 			wantOutput: disclaimer + missingConfigMsg + hostChoiceMsg + "\n" +
 				fmt.Sprintf(essChoiceMsg, essHostAddress) + regionChoiceMsg + "\n" +
+				essAPIKeyCreateMsg + "\n" +
 				apiKeyMsg + "\n" + formatChoiceMsg + "\n" + "\n" +
 				fmt.Sprintf(validCredentialsMsg, "anacleto") + finalMsg + "\n",
 		},


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds a link in the `ecctl init` workflow when the Elasticsearch Service
option has been selected to the ESS API Key feature page.
Additionally, updates the configuration precedence documentation to use
a different set of flags rather than `--user` and `--pass`, since these
are only relevant for ECE users.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Closes #505 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit & manual tested.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Documentation
