### PR TITLE
docs: Improve `elasticsearch keystore` cmd help

### DIFF
--- a/docs/ecctl_deployment_elasticsearch_keystore_update.adoc
+++ b/docs/ecctl_deployment_elasticsearch_keystore_update.adoc
@@ -6,20 +6,67 @@ Updates the contents of an Elasticsearch keystore
 [float]
 === Synopsis
 
-Changes the contents of the Elasticsearch resource keystore from the
-specified deployment by using the PATCH method. The payload is a partial payload where
-any ignored current keystore items are not removed, unless the secrets are
-set to "null": {"secrets": {"my-secret": null}}.
+Changes the contents of the Elasticsearch resource keystore from the specified
+deployment by using the PATCH method. The payload is a partial payload where any
+omitted current keystore items are not removed, unless the secrets are set to "null":
+{"secrets": {"my-secret": null}}.
+
+The contents of the specified file should be formatted to match the Elasticsearch Service
+API "KeystoreContents" model. For more information on format, see the ESS API reference:
+https://www.elastic.co/guide/en/cloud/current/definitions.html#KeystoreContents.
 
 ----
 ecctl deployment elasticsearch keystore update <deployment id> [--ref-id <ref-id>] {--file=<filename>.json} [flags]
 ----
 
 [float]
+=== Examples
+
+----
+# Set credentials for a GCS snapshot repository
+$ cat gcs-creds.json
+{
+    "secrets": {
+        "gcs.client.default.credentials_file": {
+            "as_file": true,
+            "value": {
+                "type": "service_account",
+                "project_id": "project-id",
+                "private_key_id": "key-id",
+                "private_key": "-----BEGIN PRIVATE KEY-----\nprivate-key\n-----END PRIVATE KEY-----\n",
+                "client_email": "service-account-email",
+                "client_id": "client-id",
+                "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                "token_uri": "https://accounts.google.com/o/oauth2/token",
+                "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+                "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/service-account-email"
+            }
+        }
+    }
+}
+$ ecctl deployment elasticsearch keystore set --file=gcs-creds.json <Deployment ID>
+...
+# Set multiple secrets in one playload
+$ cat multiple.json
+{
+    "secrets": {
+        "my-secret": {
+            "value": "my-value"
+        },
+        "my-other-secret": {
+            "value": "my-other-value"
+        }
+    }
+}
+$ ecctl deployment elasticsearch keystore set --file=multiple.json <Deployment ID>
+...
+----
+
+[float]
 === Options
 
 ----
-  -p, --file string     Required json formatted file path with the keystore secret contents.
+  -f, --file string     Required json formatted file path with the keystore secret contents.
   -h, --help            help for update
       --ref-id string   Optional ref_id to use for the Elasticsearch resource, auto-discovered if not specified.
 ----

--- a/docs/ecctl_deployment_elasticsearch_keystore_update.md
+++ b/docs/ecctl_deployment_elasticsearch_keystore_update.md
@@ -4,19 +4,67 @@ Updates the contents of an Elasticsearch keystore
 
 ### Synopsis
 
-Changes the contents of the Elasticsearch resource keystore from the
-specified deployment by using the PATCH method. The payload is a partial payload where
-any ignored current keystore items are not removed, unless the secrets are
-set to "null": {"secrets": {"my-secret": null}}.
+Changes the contents of the Elasticsearch resource keystore from the specified
+deployment by using the PATCH method. The payload is a partial payload where any
+omitted current keystore items are not removed, unless the secrets are set to "null":
+{"secrets": {"my-secret": null}}.
+
+The contents of the specified file should be formatted to match the Elasticsearch Service
+API "KeystoreContents" model. For more information on format, see the ESS API reference:
+https://www.elastic.co/guide/en/cloud/current/definitions.html#KeystoreContents.
+
 
 ```
 ecctl deployment elasticsearch keystore update <deployment id> [--ref-id <ref-id>] {--file=<filename>.json} [flags]
 ```
 
+### Examples
+
+```
+# Set credentials for a GCS snapshot repository
+$ cat gcs-creds.json
+{
+    "secrets": {
+        "gcs.client.default.credentials_file": {
+            "as_file": true,
+            "value": {
+                "type": "service_account",
+                "project_id": "project-id",
+                "private_key_id": "key-id",
+                "private_key": "-----BEGIN PRIVATE KEY-----\nprivate-key\n-----END PRIVATE KEY-----\n",
+                "client_email": "service-account-email",
+                "client_id": "client-id",
+                "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                "token_uri": "https://accounts.google.com/o/oauth2/token",
+                "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+                "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/service-account-email"
+            }
+        }
+    }
+}
+$ ecctl deployment elasticsearch keystore set --file=gcs-creds.json <Deployment ID>
+...
+# Set multiple secrets in one playload
+$ cat multiple.json
+{
+    "secrets": {
+        "my-secret": {
+            "value": "my-value"
+        },
+        "my-other-secret": {
+            "value": "my-other-value"
+        }
+    }
+}
+$ ecctl deployment elasticsearch keystore set --file=multiple.json <Deployment ID>
+...
+
+```
+
 ### Options
 
 ```
-  -p, --file string     Required json formatted file path with the keystore secret contents.
+  -f, --file string     Required json formatted file path with the keystore secret contents.
   -h, --help            help for update
       --ref-id string   Optional ref_id to use for the Elasticsearch resource, auto-discovered if not specified.
 ```


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Improves the documentation for the `deployment elasticsearch keystore`
command adding more information about how to format the file that is
passed to the command, where to find more info and a couple of examples.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Closes #507 
