### PR TITLE
scripts: Remove goreleaser from deps target

### DIFF
--- a/build/Makefile.deps
+++ b/build/Makefile.deps
@@ -11,7 +11,7 @@ VERSION_GOBINDATA:=v0.0.0-20190711162640-ee3c2418e368
 VERSION_GORELEASER:=v0.156.1
 VERSION_VERSIONBUMP:=v1.1.0
 
-deps: $(GOBIN)/golint $(GOBIN)/go-licenser $(GOBIN)/golangci-lint $(GOBIN)/go-bindata $(GOBIN)/goreleaser
+deps: $(GOBIN)/golint $(GOBIN)/go-licenser $(GOBIN)/golangci-lint $(GOBIN)/go-bindata
 
 $(GOBIN):
 	@ mkdir -p $(GOBIN)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Removes the installation of Goreleaser from the main `deps` target since
it's not necessary to perform any of the development tasks and it can be
installed manually if a release needs to be manually run.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Broken Go builds.
