### PR TITLE
Fix env variable name with Github token

### DIFF
--- a/.github/workflows/on_master_generation.yml
+++ b/.github/workflows/on_master_generation.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GH_TOKEN_EXTRA }}
           fetch-depth: 0
 
       - name: Set up Go


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Describe your changes in detail. -->
This is a follow-up fix for https://github.com/elastic/ecctl/pull/524. In the added CI job name of the env variable with the Github token was set incorrectly.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
