### PR TITLE
Windows: Absorb the difference of syscall.Stdin

### DIFF
--- a/pkg/ecctl/read_secret.go
+++ b/pkg/ecctl/read_secret.go
@@ -35,7 +35,7 @@ var (
 // descriptor. If passFunc is empty, it defaults to terminal.
 func ReadSecret(w io.Writer, passFunc PassFunc, msg string) ([]byte, error) {
 	fmt.Fprint(w, msg)
-	b, err := passFunc(syscall.Stdin)
+	b, err := passFunc(int(syscall.Stdin))
 	fmt.Fprintln(w)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Have to cast `syscall.Stdin` to `int` on Windows because Stdin is not simple 0 but `Handle` (`uintptr`) there according to the following Godoc. https://pkg.go.dev/syscall?GOOS=windows#pkg-variables

## Description

Add simple cast to `int`, which doesn't have any effect on operating systems where `syscall.Stdin` is 0 but do have on Windows where type of `syscall.Stdin` is not `int`.

## Related Issues

The change in this PR will fix https://github.com/elastic/ecctl/issues/528.

## Motivation and Context

I move to Windows but I want to keep using ecctl command. With this change, I have succeeded to not only install ecctl but also complete `ecctl init` as well as run e.g. `ecctl deployment list` without any problems.

## How Has This Been Tested?

Install and run it with `go1.17.2 windows/amd64` on my Windows 10.0.19043.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All ~~new and~~ existing tests passed **[on GitHub Actions](https://github.com/sakurai-youhei/ecctl/runs/3988634185?check_suite_focus=true)**
