### PR TITLE
docs: Add note about the EC Terraform provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ The goal of this project is to provide an easier way to interact with the Elasti
 
 To get started with Elastic Cloud Control, see the [official documentation](https://www.elastic.co/guide/en/ecctl/current/index.html).
 
+_NOTE: While it's posibble to create and manage deployments through ecctl, the [Elastic Cloud Terraform provider](https://github.com/elastic/terraform-provider-ec) provides a better interface._
+
 ## Contributing
 
 If you are interested in becoming a part of this project, take a look at our [contribution guidelines](./CONTRIBUTING.md).


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Mentions the EC Terraform provider as the preferred tool to manage
deployments.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
None

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Some users are still relying on `ecctl` to create and manage ESS deployments, while the tool allows it since it can create deployments from a JSON definition, it's not the most suitable tool for the job.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Documentation
