### PR TITLE
Attempt to fix ecctl release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,7 +25,6 @@ builds:
       goarch: 386
   ldflags: -s -w -X main.version={{.Env.VERSION }} -X main.commit={{.Commit}} -X main.owner={{.Env.OWNER}} -X main.repo={{.Env.REPO}} -X main.built={{.Env.BUILT}}
   binary: ecctl
-  lang: go
 archives:
   - name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm}}v{{ .Arm }}{{ end }}'
     format: tar.gz


### PR DESCRIPTION
It's an attempt to fix https://github.com/elastic/ecctl/runs/4475470597?check_suite_focus=true. It looks like the issue is with config validation. 

Before this change I had locally:
```
$ goreleaser check -f .goreleaser.yml 
   • loading config file       file=.goreleaser.yml
   ⨯ command failed            error=yaml: unmarshal errors:
  line 28: field lang not found in type config.Build

```

With fix it seems to be valid now:
```
$ goreleaser check -f .goreleaser.yml
   • loading config file       file=.goreleaser.yml
   • checking config: 
      • snapshotting     
      • scm releases     
      • project name     
      • loading go mod information
      • building binaries
      • universal binaries
      • creating source archive
      • archives         
      • linux packages   
      • snapcraft packages
      • calculating checksums
      • signing artifacts
      • signing docker images
      • docker images    
      • docker manifests 
      • artifactory      
      • blobs            
      • homebrew tap formula
      • krew plugin manifest
      • gofish fish food cookbook
      • scoop manifests  
      • discord          
      • reddit           
      • slack            
      • teams            
      • twitter          
      • smtp             
      • mattermost       
      • milestones       
      • linkedin         
      • telegram         
   • config is valid  
```

No idea what's changed since last release though