### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # These owners will be the default owners for everything in
 # the repository.
-*       @elastic/cloud-delivery
-docs/   @alaudazzi @nrichers @elastic/cloud-delivery
+*       @elastic/cloud-applications-solutions 
+docs/   @alaudazzi @nrichers @elastic/cloud-applications-solutions


### PR DESCRIPTION
Much like https://github.com/elastic/cloud-sdk-go/pull/385, There's been a formal agreement to move the ecctl over to the applications team and they are actively working on it and unfortunately it requires Delivery to approve PRs. With this change, Delivery will no longer be a blocker.  This shifts the codeowners to the responsible team. 


@pcsanwald @StaceyKingPoling heads up for awareness.
