### PR TITLE
Correct arguments on ConfirmAction()

### DIFF
--- a/cmd/deployment/resource/delete.go
+++ b/cmd/deployment/resource/delete.go
@@ -39,7 +39,7 @@ var deleteCmd = &cobra.Command{
 
 		force, _ := cmd.Flags().GetBool("force")
 		var msg = "This action will delete a deployment's resource kind and its configuration history. Do you want to continue? [y/n]: "
-		if !force && !sdkcmdutil.ConfirmAction(msg, os.Stderr, os.Stdout) {
+		if !force && !sdkcmdutil.ConfirmAction(msg, os.Stdin, ecctl.Get().Config.OutputDevice) {
 			return nil
 		}
 

--- a/cmd/deployment/resource/restore.go
+++ b/cmd/deployment/resource/restore.go
@@ -43,7 +43,7 @@ var restoreCmd = &cobra.Command{
 		var esKind = resKind == "elasticsearch"
 		var dataLoss = esKind && !restoreSnapshot
 		var msg = "This action restores an Elasticsearch resource without its snapshot which might incur data loss, do you want to continue? [y/n]: "
-		if dataLoss && !force && !sdkcmdutil.ConfirmAction(msg, os.Stderr, os.Stdout) {
+		if dataLoss && !force && !sdkcmdutil.ConfirmAction(msg, os.Stdin, ecctl.Get().Config.OutputDevice) {
 			return nil
 		}
 

--- a/cmd/deployment/resource/shutdown.go
+++ b/cmd/deployment/resource/shutdown.go
@@ -42,7 +42,7 @@ var shutdownCmd = &cobra.Command{
 
 		force, _ := cmd.Flags().GetBool("force")
 		var msg = "This action will shut down a deployment's resource kind. Do you want to continue? [y/n]: "
-		if !force && !sdkcmdutil.ConfirmAction(msg, os.Stderr, os.Stdout) {
+		if !force && !sdkcmdutil.ConfirmAction(msg, os.Stdin, ecctl.Get().Config.OutputDevice) {
 			return nil
 		}
 

--- a/cmd/deployment/resource/start-maintenance.go
+++ b/cmd/deployment/resource/start-maintenance.go
@@ -47,7 +47,7 @@ var startMaintCmd = &cobra.Command{
 		}
 
 		var msg = "This action will incur in downtime if used with the --all flag. Do you want to continue? [y/n]: "
-		if all && !force && !sdkcmdutil.ConfirmAction(msg, os.Stderr, os.Stdout) {
+		if all && !force && !sdkcmdutil.ConfirmAction(msg, os.Stdin, ecctl.Get().Config.OutputDevice) {
 			return nil
 		}
 

--- a/cmd/deployment/resource/stop.go
+++ b/cmd/deployment/resource/stop.go
@@ -47,7 +47,7 @@ var stopCmd = &cobra.Command{
 		}
 
 		var msg = "This action will incur in downtime if used with the --all flag. Do you want to continue? [y/n]: "
-		if all && !force && !sdkcmdutil.ConfirmAction(msg, os.Stderr, os.Stdout) {
+		if all && !force && !sdkcmdutil.ConfirmAction(msg, os.Stdin, ecctl.Get().Config.OutputDevice) {
 			return nil
 		}
 

--- a/cmd/deployment/shutdown.go
+++ b/cmd/deployment/shutdown.go
@@ -35,7 +35,7 @@ var shutdownCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		force, _ := cmd.Flags().GetBool("force")
 		var msg = "This action will delete the specified deployment ID and its associated sub-resources, do you want to continue? [y/n]: "
-		if !force && !sdkcmdutil.ConfirmAction(msg, os.Stderr, os.Stdout) {
+		if !force && !sdkcmdutil.ConfirmAction(msg, os.Stdin, ecctl.Get().Config.OutputDevice) {
 			return nil
 		}
 

--- a/cmd/deployment/update.go
+++ b/cmd/deployment/update.go
@@ -47,7 +47,7 @@ var updateCmd = &cobra.Command{
 
 		force, _ := cmd.Flags().GetBool("force")
 		var msg = `setting --prune-orphans to "true" will cause any resources not specified in the update request to be removed from the deployment, do you want to continue? [y/n]: `
-		if pruneOrphans && !force && !sdkcmdutil.ConfirmAction(msg, os.Stderr, os.Stdout) {
+		if pruneOrphans && !force && !sdkcmdutil.ConfirmAction(msg, os.Stdin, ecctl.Get().Config.OutputDevice) {
 			return nil
 		}
 

--- a/cmd/platform/allocator/vacate.go
+++ b/cmd/platform/allocator/vacate.go
@@ -99,7 +99,7 @@ var vacateAllocatorCmd = &cobra.Command{
 		overrideFailsafe, _ := cmd.Flags().GetBool("override-failsafe")
 		force, _ := cmd.Flags().GetBool("force")
 		var msg = "--override-failsafe has been flag specified. Are you sure you want to proceed? [y/N]: "
-		if overrideFailsafe && !force && !sdkcmdutil.ConfirmAction(msg, os.Stderr, os.Stdout) {
+		if overrideFailsafe && !force && !sdkcmdutil.ConfirmAction(msg, os.Stdin, ecctl.Get().Config.OutputDevice) {
 			return nil
 		}
 
@@ -132,7 +132,7 @@ var vacateAllocatorCmd = &cobra.Command{
 		}
 
 		skipTracking, _ := cmd.Flags().GetBool("skip-tracking")
-		if !force && skipTracking && !sdkcmdutil.ConfirmAction("--skip-tracking flag specified. Are you sure you want to proceed? [y/N]: ", os.Stdin, os.Stderr) {
+		if !force && skipTracking && !sdkcmdutil.ConfirmAction("--skip-tracking flag specified. Are you sure you want to proceed? [y/N]: ", os.Stdin, ecctl.Get().Config.OutputDevice) {
 			return nil
 		}
 


### PR DESCRIPTION
This PR fixes #560

<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Describe your changes in detail. -->

Here are the reasons behind the correction.

- 2nd arg must be `os.Stdin` instead of `os.Stderr`. Otherwise, the confirmation gets stuck on reading.
- 3rd arg should be `ecctl.Get().Config.OutputDevice` to respect the config.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->

https://github.com/elastic/ecctl/issues/560

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

I don't want to use `--force` option to work #560 around on every delete; the `--force` option should be never ever used by human beings.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Run a couple of commands on my laptop.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All ~~new and~~ existing tests passed
