### PR TITLE
Fix goreleaser-action

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.20"
+          go-version: "1.23"
         id: go
 
       - name: Bump patch version
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.20"
+          go-version: "1.23"
         id: go
 
       - name: Bump main version

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: "1.20"
+        go-version: "1.23"
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.20"
+          go-version: "1.23"
         id: go
 
       - name: Cache Go Modules
@@ -62,8 +62,8 @@ jobs:
           OWNER: elastic
           REPO: ecctl
         with:
-          version: latest
-          args: release --rm-dist
+          version: '~> v2'
+          args: release --clean
 
       - name: Run release post actions
         run: ./scripts/goreleaser-post-actions.sh $VERSION

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 reports
 .idea/
 html_docs/
+ecctl.iml

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,14 +4,21 @@ linters:
     - lll
     - gochecknoglobals
     - gochecknoinits
-    - scopelint
     - funlen
     - wsl
     - gomnd
 
 linters-settings:
   errcheck:
-    exclude: build/errcheck-exclusions.txt
+    exclude-functions:
+      - (*github.com/spf13/cobra.Command).MarkFlagRequired
+      - (*github.com/spf13/cobra.Command).MarkFlagFilename
+      - github.com/spf13/cobra.MarkFlagRequired
+      - github.com/spf13/cobra.MarkFlagFilename
+      - github.com/spf13/cobra.MarkFlagFilename
+      - (*github.com/spf13/cobra.Command).Help
+      - (*github.com/spf13/viper.Viper).BindPFlags
+      - (*github.com/spf13/pflag.FlagSet).MarkHidden
   govet:
     check-shadowing: false
 
@@ -64,4 +71,6 @@ issues:
 
 
 output:
-  format: tab
+  formats:
+    - format: tab
+      path: stderr

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 project_name: ecctl
 before:
   hooks:
@@ -34,7 +35,7 @@ archives:
     - README*
     - docs/*
 snapshot:
-  name_template: "{{ .Version }}_SNAPSHOT_{{ .ShortCommit }}"
+  version_template: "{{ .Version }}_SNAPSHOT_{{ .ShortCommit }}"
 nfpms:
   - file_name_template: >-
       {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_

--- a/build/Makefile.build
+++ b/build/Makefile.build
@@ -56,4 +56,4 @@ changelog:
 
 ## Generates a snapshot of the potential release
 snapshot: deps
-	@ $(GOBIN)/goreleaser release --rm-dist --snapshot --skip-validate
+	@ $(GOBIN)/goreleaser release --clean --snapshot --skip-validate

--- a/build/Makefile.deps
+++ b/build/Makefile.deps
@@ -6,12 +6,12 @@ VERSION_DIR:=$(GOBIN)/versions
 
 VERSION_GOLICENSER:=v0.4.1
 VERSION_GOLICENCEDETECTOR:=v0.6.0
-VERSION_GOLANGCILINT:=v1.54.2
+VERSION_GOLANGCILINT:=v1.61.0
 VERSION_GOBINDATA:=v0.0.0-20190711162640-ee3c2418e368
-VERSION_GORELEASER:=v1.21.2
+VERSION_GORELEASER:=v2.3.2
 VERSION_VERSIONBUMP:=v1.1.0
 
-deps: $(GOBIN)/go-licenser $(GOBIN)/go-licence-detector $(GOBIN)/golangci-lint $(GOBIN)/go-bindata
+deps: $(GOBIN)/go-licenser $(GOBIN)/go-licence-detector $(GOBIN)/golangci-lint $(GOBIN)/go-bindata $(GOBIN)/goreleaser
 
 $(GOBIN):
 	@ mkdir -p $(GOBIN)
@@ -57,7 +57,7 @@ $(VERSION_DIR)/.version-goreleaser-$(VERSION_GORELEASER): | $(VERSION_DIR)
 
 $(GOBIN)/goreleaser: $(VERSION_DIR)/.version-goreleaser-$(VERSION_GORELEASER) | $(GOBIN)
 	@ echo "-> Installing goreleaser..."
-	@ go install github.com/goreleaser/goreleaser@$(VERSION_GORELEASER)
+	@ go install github.com/goreleaser/goreleaser/v2@$(VERSION_GORELEASER)
 
 $(VERSION_DIR)/.version-versionbump-$(VERSION_VERSIONBUMP): | $(VERSION_DIR)
 	@ rm -f $(VERSION_DIR)/.version-versionbump-*

--- a/build/Makefile.dev
+++ b/build/Makefile.dev
@@ -43,7 +43,7 @@ _bindata:
 format: deps
 	@ echo "-> Formatting Go files..."
 	@ $(GOBIN)/go-licenser -license ASL2
-	@ $(GOBIN)/golangci-lint run --fix --deadline=5m
+	@ $(GOBIN)/golangci-lint run --fix --timeout 5m
 	@ echo "-> Done."
 
 ## Generates the notice file
@@ -55,7 +55,7 @@ notice: deps
 .PHONY: lint
 lint: deps
 	@ echo "-> Running linters..."
-	@ $(GOBIN)/golangci-lint run --deadline=5m
+	@ $(GOBIN)/golangci-lint run --timeout 5m
 	@ $(GOBIN)/go-licenser -d .
 	@ echo "-> Done."
 

--- a/build/errcheck-exclusions.txt
+++ b/build/errcheck-exclusions.txt
@@ -1,8 +1,0 @@
-(*github.com/spf13/cobra.Command).MarkFlagRequired
-(*github.com/spf13/cobra.Command).MarkFlagFilename
-github.com/spf13/cobra.MarkFlagRequired
-github.com/spf13/cobra.MarkFlagFilename
-github.com/spf13/cobra.MarkFlagFilename
-(*github.com/spf13/cobra.Command).Help
-(*github.com/spf13/viper.Viper).BindPFlags
-(*github.com/spf13/pflag.FlagSet).MarkHidden

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/ecctl
 
-go 1.20
+go 1.23
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,7 @@ github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDD
 github.com/elastic/cloud-sdk-go v1.22.0 h1:sPjvu7zZeDbgl6eufy41VH0TjWbaMgDS+Cy9qIvdFZ4=
 github.com/elastic/cloud-sdk-go v1.22.0/go.mod h1:k0ZebhZKX22l6Ysl5Zbpc8VLF54hfwDtHppEEEVUJ04=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
+github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
@@ -167,9 +168,11 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.4.0 h1:MtMxsa51/r9yyhkyLsVeVt0B+BGQZzpQiTQ4eHZ8bc4=
+github.com/google/uuid v1.4.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -194,6 +197,7 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -241,6 +245,7 @@ github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
+github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6keLGt6kNQ=


### PR DESCRIPTION
The release github action is currently broken:

We were using the `latest` gorelease-action, which had changed from 1->2 recently. The main breaking change for us was that `--rm-dist` flag was replaced by `--clean`

But this change causes some other changes:
- Some smaller changes in the goreleaser config
- To run the newest goreleaser, we have to upgrade to golang 1.23.0
- When using go 1.23.0, golangci-lint also needs upgrading
- golanci-lint on the new version also has some config deprecations/changes 

But with all these changes, the local build/lint runs without errors or warnings and the dry-run gorelease also runs through (hopefully the same is the case in the github action).