### PR TITLE
Add --config-version flag to instance configuration `show` command

### DIFF
--- a/docs/ecctl_platform_instance-configuration_show.adoc
+++ b/docs/ecctl_platform_instance-configuration_show.adoc
@@ -11,7 +11,9 @@ ecctl platform instance-configuration show <config id> [flags]
 === Options
 
 ----
-  -h, --help   help for show
+  -v, --config-version string   Instance configuration version
+  -h, --help                    help for show
+      --show-deleted            If set to true, allows to show deleted instance configurations
 ----
 
 [float]

--- a/docs/ecctl_platform_instance-configuration_show.md
+++ b/docs/ecctl_platform_instance-configuration_show.md
@@ -9,7 +9,9 @@ ecctl platform instance-configuration show <config id> [flags]
 ### Options
 
 ```
-  -h, --help   help for show
+  -v, --config-version string   Instance configuration version
+  -h, --help                    help for show
+      --show-deleted            If set to true, allows to show deleted instance configurations
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
This PR adds the `config-version` and `show-deleted` flags to the `instance-configuration` command, so that's possible to fetch a specific instance configuration version, even if it's marked as deleted.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
https://elasticco.atlassian.net/browse/CP-6292

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need to be able to fetch specific config versions in order to get the testing version of an IC. We use the testing version when introducing a new IC or updating an existing one, before making the changes public.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This has been tested by building `ecctl` locally and performing some tests against ICs in QA. 

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
