### PR TITLE
Backport #669 to 1.14 branch

### DIFF
--- a/docs/ecctl_platform_instance-configuration_show.adoc
+++ b/docs/ecctl_platform_instance-configuration_show.adoc
@@ -11,7 +11,9 @@ ecctl platform instance-configuration show <config id> [flags]
 === Options
 
 ----
-  -h, --help   help for show
+  -v, --config-version string   Instance configuration version
+  -h, --help                    help for show
+      --show-deleted            If set to true, allows to show deleted instance configurations
 ----
 
 [float]

--- a/docs/ecctl_platform_instance-configuration_show.md
+++ b/docs/ecctl_platform_instance-configuration_show.md
@@ -9,7 +9,9 @@ ecctl platform instance-configuration show <config id> [flags]
 ### Options
 
 ```
-  -h, --help   help for show
+  -v, --config-version string   Instance configuration version
+  -h, --help                    help for show
+      --show-deleted            If set to true, allows to show deleted instance configurations
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Backports the changes in https://github.com/elastic/ecctl/pull/669 to branch `1.14`, in order to prepare for a patch release.