### PR TITLE
[1.8] [DOCS] Remove broken link to Cloud API doc (#679)

### DIFF
--- a/cmd/deployment/elasticsearch/keystore/update.go
+++ b/cmd/deployment/elasticsearch/keystore/update.go
@@ -37,8 +37,7 @@ omitted current keystore items are not removed, unless the secrets are set to "n
 {"secrets": {"my-secret": null}}.
 
 The contents of the specified file should be formatted to match the Elasticsearch Service
-API "KeystoreContents" model. For more information on format, see the ESS API reference:
-https://www.elastic.co/guide/en/cloud/current/definitions.html#KeystoreContents.
+API "KeystoreContents" model.
 `
 
 const updateExample = `# Set credentials for a GCS snapshot repository

--- a/docs/ecctl_deployment_elasticsearch_keystore_update.adoc
+++ b/docs/ecctl_deployment_elasticsearch_keystore_update.adoc
@@ -12,8 +12,7 @@ omitted current keystore items are not removed, unless the secrets are set to "n
 {"secrets": {"my-secret": null}}.
 
 The contents of the specified file should be formatted to match the Elasticsearch Service
-API "KeystoreContents" model. For more information on format, see the ESS API reference:
-https://www.elastic.co/guide/en/cloud/current/definitions.html#KeystoreContents.
+API "KeystoreContents" model.
 
 ----
 ecctl deployment elasticsearch keystore update <deployment id> [--ref-id <ref-id>] {--file=<filename>.json} [flags]

--- a/docs/ecctl_deployment_elasticsearch_keystore_update.md
+++ b/docs/ecctl_deployment_elasticsearch_keystore_update.md
@@ -10,8 +10,7 @@ omitted current keystore items are not removed, unless the secrets are set to "n
 {"secrets": {"my-secret": null}}.
 
 The contents of the specified file should be formatted to match the Elasticsearch Service
-API "KeystoreContents" model. For more information on format, see the ESS API reference:
-https://www.elastic.co/guide/en/cloud/current/definitions.html#KeystoreContents.
+API "KeystoreContents" model.
 
 
 ```


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.8`:
 - [[DOCS] Remove broken link to Cloud API doc (#679)](https://github.com/elastic/ecctl/pull/679)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)