### PR TITLE
Remove AWS CLI update from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,11 +35,6 @@ jobs:
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
-      - name: Update AWS cli
-        uses: chrislennon/action-aws-cli@v1.1
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: true
-
       - name: Get the version
         id: get_version
         run: |


### PR DESCRIPTION
As discussed in [slack](https://elastic.slack.com/archives/C01KXR8BQ2F/p1737041355441439?thread_ts=1737028137.317849&cid=C01KXR8BQ2F), we should remove the "Update AWS cli" step from the release workflow, because `aws-cli` should be installed by default in GH actions.