### PR TITLE
[docs] Clean up cross-repo links

### DIFF
--- a/docs/reference/ecctl-example-create-deployment.md
+++ b/docs/reference/ecctl-example-create-deployment.md
@@ -5,7 +5,7 @@ mapped_pages:
 
 # Create a deployment [ecctl-example-create-deployment]
 
-Let’s create a basic deployment. Elasticsearch Service supports [solutions](docs-content://get-started/index.md) and [hardware profiles](docs-content://deploy-manage/deploy/elastic-cloud/ec-configure-deployment-settings.md#ec-hardware-profiles), which pre-configure the Elastic Stack components in your deployment to best suit your particular use case. For this example, use Google Cloud Platform (GCP) to host the deployment in region `US Central 1 (Iowa)`. To know which deployment options are available by platform, see [available regions, deployment templates and instance configurations](cloud://docs/reference/cloud-hosted/ec-regions-templates-instances.md).
+Let’s create a basic deployment. Elasticsearch Service supports [solutions](docs-content://get-started/index.md) and [hardware profiles](docs-content://deploy-manage/deploy/elastic-cloud/ec-configure-deployment-settings.md#ec-hardware-profiles), which pre-configure the Elastic Stack components in your deployment to best suit your particular use case. For this example, use Google Cloud Platform (GCP) to host the deployment in region `US Central 1 (Iowa)`. To know which deployment options are available by platform, see [available regions, deployment templates and instance configurations](cloud://reference/cloud-hosted/ec-regions-templates-instances.md).
 
 Copy the following JSON payload and save it as file `create-deployment.json`.
 

--- a/docs/reference/ecctl-examples.md
+++ b/docs/reference/ecctl-examples.md
@@ -12,7 +12,7 @@ Once you’ve [installed](/reference/ecctl-installing.md) and [configured](/refe
 * [Update a deployment](/reference/ecctl-example-update-deployment.md)
 * [Delete a deployment](/reference/ecctl-example-delete-deployment.md)
 
-To compare the ecctl commands against their API equivalents, see the [API examples](cloud://docs/reference/cloud-hosted/ec-api-examples.md).
+To compare the ecctl commands against their API equivalents, see the [API examples](cloud://reference/cloud-hosted/ec-api-examples.md).
 
 
 

--- a/docs/reference/ecctl_deployment_search.md
+++ b/docs/reference/ecctl_deployment_search.md
@@ -10,7 +10,7 @@ Performs advanced deployment search using the Elasticsearch Query DSL
 
 ## Synopsis [_synopsis_6]
 
-Read more about [Query DSL](elasticsearch://docs/reference/query-languages/querydsl.md).
+Read more about [Query DSL](elasticsearch://reference/query-languages/querydsl.md).
 
 ```
 ecctl deployment search -f <query file.json> [flags]

--- a/docs/reference/ecctl_platform_allocator_list.md
+++ b/docs/reference/ecctl_platform_allocator_list.md
@@ -19,7 +19,7 @@ Query examples:
 
 * Allocators with more than 10GB of capacity: --query capacity.memory.total:\>10240
 ```
-Read all the simple query string syntax in [/elasticsearch/docs/reference/query-languages/query-dsl-query-string-query.md#query-string-syntax](elasticsearch://docs/reference/query-languages/query-dsl-query-string-query.md#query-string-syntax)
+Read all the simple query string syntax in [/elasticsearch/docs/reference/query-languages/query-dsl-query-string-query.md#query-string-syntax](elasticsearch://reference/query-languages/query-dsl-query-string-query.md#query-string-syntax)
 
 Filter examples:
 

--- a/docs/reference/ecctl_platform_allocator_search.md
+++ b/docs/reference/ecctl_platform_allocator_search.md
@@ -10,7 +10,7 @@ Performs advanced allocator searching ![logo cloud ece](https://doc-icons.s3.us-
 
 ## Synopsis [_synopsis_9]
 
-Read more about [Query DSL](elasticsearch://docs/reference/query-languages/querydsl.md).
+Read more about [Query DSL](elasticsearch://reference/query-languages/querydsl.md).
 
 ```
 ecctl platform allocator search [flags]

--- a/docs/reference/ecctl_platform_runner_search.md
+++ b/docs/reference/ecctl_platform_runner_search.md
@@ -10,7 +10,7 @@ Performs advanced runner searching ![logo cloud ece](https://doc-icons.s3.us-eas
 
 ## Synopsis [_synopsis_12]
 
-Read more about [Query DSL](elasticsearch://docs/reference/query-languages/querydsl.md).
+Read more about [Query DSL](elasticsearch://reference/query-languages/querydsl.md).
 
 ```
 ecctl platform runner search [flags]


### PR DESCRIPTION
Follow up to #707 

When using cross-repo links, the path should be relative to the `docset.yml` not the full path within the repo ([updated docs-builder docs](https://elastic.github.io/docs-builder/syntax/links/#cross-repository-links)).