### PR TITLE
Prepare 1.14.4 Patch Release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-export VERSION ?= v1.14.3
+export VERSION ?= v1.14.4
 export GO111MODULE ?= on
 export GOBIN = $(shell pwd)/bin
 BINARY := ecctl

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23
 require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
 	github.com/blang/semver/v4 v4.0.0
-	github.com/elastic/cloud-sdk-go v1.22.0
+	github.com/elastic/cloud-sdk-go v1.24.1
 	github.com/go-openapi/runtime v0.23.0
 	github.com/go-openapi/strfmt v0.21.2
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/elastic/cloud-sdk-go v1.22.0 h1:sPjvu7zZeDbgl6eufy41VH0TjWbaMgDS+Cy9qIvdFZ4=
-github.com/elastic/cloud-sdk-go v1.22.0/go.mod h1:k0ZebhZKX22l6Ysl5Zbpc8VLF54hfwDtHppEEEVUJ04=
+github.com/elastic/cloud-sdk-go v1.24.1 h1:grLfqFeyeQdF5y8Fb2zycyWqIFbPloZVqPVz3k9MBvU=
+github.com/elastic/cloud-sdk-go v1.24.1/go.mod h1:pvE/y2hboD2yGzpJnBc4ZhfazYJF/V2qdhXzXeU2hDs=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=

--- a/notes/v1.14.4.md
+++ b/notes/v1.14.4.md
@@ -1,0 +1,21 @@
+v1.14.4
+
+# Changelog
+
+Download the release binaries:
+
+<https://download.elastic.co/downloads/ecctl/1.14.4/ecctl_1.14.4_darwin_amd64.tar.gz>
+<https://download.elastic.co/downloads/ecctl/1.14.4/ecctl_1.14.4_darwin_arm64.tar.gz>
+<https://download.elastic.co/downloads/ecctl/1.14.4/ecctl_1.14.4_linux_32-bit.deb>
+<https://download.elastic.co/downloads/ecctl/1.14.4/ecctl_1.14.4_linux_32-bit.rpm>
+<https://download.elastic.co/downloads/ecctl/1.14.4/ecctl_1.14.4_linux_386.tar.gz>
+<https://download.elastic.co/downloads/ecctl/1.14.4/ecctl_1.14.4_linux_64-bit.deb>
+<https://download.elastic.co/downloads/ecctl/1.14.4/ecctl_1.14.4_linux_64-bit.rpm>
+<https://download.elastic.co/downloads/ecctl/1.14.4/ecctl_1.14.4_linux_amd64.tar.gz>
+<https://download.elastic.co/downloads/ecctl/1.14.4/ecctl_1.14.4_linux_arm64.tar.gz>
+
+Checksums are at [ecctl_1.14.4_checksums.txt](https://download.elastic.co/downloads/ecctl/1.14.4/ecctl_1.14.4_checksums.txt).
+
+## Release notes
+
+<https://www.elastic.co/guide/en/ecctl/1.14/ecctl-release-notes-v1.14.4.html>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Describe your changes in detail. -->

Pulls in cloud-sdk-go [v1.24.1](https://github.com/elastic/cloud-sdk-go/tree/refs/tags/v1.24.1). Which includes: https://github.com/elastic/cloud-sdk-go/pull/498 to support the Integration Server payload when building update payload from get response. (eg ecctl deployment show 7d8ef46efeae4490a48eba6b91b704d6 --generate-update-payload)

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->

Rel: https://github.com/elastic/ecctl/issues/722

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

When a user gets a deployment with the update payload flags (eg `ecctl deployment show 7d8ef46efeae4490a48eba6b91b704d6 --generate-update-payload`) the integration server payload is always excluded even if the cluster has an integrations server running.

Example output:

```
json.resources.integrations_server = null;
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


```
➜  ecctl git:(master) ✗ EC_CONFIG=qa ./ecctl deployment show  61042f21dbfb4a2c87627998bded9e04  --generate-update-payload | gron | grep integrations_server
json.resources.integrations_server = [];
json.resources.integrations_server[0] = {};
json.resources.integrations_server[0].display_name = "My deployment";
json.resources.integrations_server[0].elasticsearch_cluster_ref_id = "main-elasticsearch";
json.resources.integrations_server[0].plan = {};
json.resources.integrations_server[0].plan.cluster_topology = [];
json.resources.integrations_server[0].plan.cluster_topology[0] = {};
json.resources.integrations_server[0].plan.cluster_topology[0].instance_configuration_id = "aws.integrationsserver.c5d";
json.resources.integrations_server[0].plan.cluster_topology[0].instance_configuration_version = 3;
json.resources.integrations_server[0].plan.cluster_topology[0].integrations_server = {};
json.resources.integrations_server[0].plan.cluster_topology[0].integrations_server.system_settings = {};
json.resources.integrations_server[0].plan.cluster_topology[0].integrations_server.system_settings.debug_enabled = false;
json.resources.integrations_server[0].plan.cluster_topology[0].size = {};
json.resources.integrations_server[0].plan.cluster_topology[0].size.resource = "memory";
json.resources.integrations_server[0].plan.cluster_topology[0].size.value = 1024;
json.resources.integrations_server[0].plan.cluster_topology[0].zone_count = 1;
json.resources.integrations_server[0].plan.integrations_server = {};
json.resources.integrations_server[0].plan.integrations_server.system_settings = {};
json.resources.integrations_server[0].plan.integrations_server.system_settings.secret_token = "xxxxxxxx"; // manually redacted for PR 
json.resources.integrations_server[0].plan.integrations_server.version = "9.0.2";
json.resources.integrations_server[0].ref_id = "main-integrations_server";
json.resources.integrations_server[0].region = "aws-eu-west-1";
json.resources.integrations_server[0].settings = {};

```


## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
