### PR TITLE
add a hidden file to make the child TOC valid

### DIFF
--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -7,6 +7,6 @@ cross_links:
   - elasticsearch
 toc:
   - toc: reference
-  - folder: release-notes
+  - toc: release-notes
 subs:
   ece:   "Elastic Cloud Enterprise"

--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -1,0 +1,7 @@
+---
+navigation_title: "Breaking changes"
+---
+
+# Elastic Cloud Control (ECCTL) breaking changes
+
+For future use

--- a/docs/release-notes/toc.yml
+++ b/docs/release-notes/toc.yml
@@ -1,0 +1,3 @@
+toc:
+  - file: index.md
+  - hidden: breaking-changes.md


### PR DESCRIPTION
Redoing my fix from https://github.com/elastic/ecctl/pull/733: the fix wasn't valid for the location where the release notes need to be hosted