### PR TITLE
[doc] rebranding traffic filters to network security policies in ECH

### DIFF
--- a/cmd/deployment/trafficfilter/association/command.go
+++ b/cmd/deployment/trafficfilter/association/command.go
@@ -26,7 +26,7 @@ const entityType = "deployment"
 // Command represents the deployment traffic-filter association subcommand.
 var Command = &cobra.Command{
 	Use:     "association",
-	Short:   "Manages traffic filter ruleset associations",
+	Short:   "Manages network security policy or traffic filter ruleset associations",
 	PreRunE: cobra.MaximumNArgs(0),
 	Run:     func(cmd *cobra.Command, args []string) { cmd.Help() },
 }

--- a/cmd/deployment/trafficfilter/command.go
+++ b/cmd/deployment/trafficfilter/command.go
@@ -26,7 +26,7 @@ import (
 // Command represents the deployment traffic-filter subcommand.
 var Command = &cobra.Command{
 	Use:     "traffic-filter",
-	Short:   "Manages traffic filter rulesets",
+	Short:   "Manages network security policies or traffic filter rulesets",
 	PreRunE: cobra.MaximumNArgs(0),
 	Run:     func(cmd *cobra.Command, args []string) { cmd.Help() },
 }

--- a/cmd/deployment/trafficfilter/create.go
+++ b/cmd/deployment/trafficfilter/create.go
@@ -28,7 +28,7 @@ import (
 
 var createCmd = &cobra.Command{
 	Use:     "create --region <region> --name <filter name> --type <filter type> --source <filter source>,<filter source> ",
-	Short:   "Creates traffic filter rulesets",
+	Short:   "Creates network security policies or traffic filter rulesets",
 	PreRunE: cobra.MaximumNArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		region := ecctl.Get().Config.Region

--- a/cmd/deployment/trafficfilter/delete.go
+++ b/cmd/deployment/trafficfilter/delete.go
@@ -27,7 +27,7 @@ import (
 
 var deleteCmd = &cobra.Command{
 	Use:     "delete <ruleset id> [--ignore-associations]",
-	Short:   "Deletes a traffic filter ruleset",
+	Short:   "Deletes a network security policy or traffic filter ruleset",
 	PreRunE: sdkcmdutil.MinimumNArgsAndUUID(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		assoc, _ := cmd.Flags().GetBool("ignore-associations")

--- a/cmd/deployment/trafficfilter/list.go
+++ b/cmd/deployment/trafficfilter/list.go
@@ -26,7 +26,7 @@ import (
 
 var listCmd = &cobra.Command{
 	Use:     "list [--include-associations] [--single-region <region>]",
-	Short:   "Lists the traffic filter rulesets",
+	Short:   "Lists the network security policies or traffic filter rulesets",
 	PreRunE: cobra.MaximumNArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		region, _ := cmd.Flags().GetString("single-region")

--- a/cmd/deployment/trafficfilter/show.go
+++ b/cmd/deployment/trafficfilter/show.go
@@ -27,7 +27,7 @@ import (
 
 var showCmd = &cobra.Command{
 	Use:     "show <ruleset id> [--include-associations]",
-	Short:   "Shows information about a traffic filter ruleset",
+	Short:   "Shows information about a network security policy or traffic filter ruleset",
 	PreRunE: sdkcmdutil.MinimumNArgsAndUUID(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		assoc, _ := cmd.Flags().GetBool("include-associations")

--- a/docs/reference/ecctl_deployment.md
+++ b/docs/reference/ecctl_deployment.md
@@ -45,6 +45,6 @@ ecctl deployment [flags]
 * [ecctl deployment show](/reference/ecctl_deployment_show.md)	 - Shows the specified deployment resources
 * [ecctl deployment shutdown](/reference/ecctl_deployment_shutdown.md)	 - Shuts down a deployment and all of its associated sub-resources
 * [ecctl deployment template](/reference/ecctl_deployment_template.md)	 - Interacts with deployment template APIs
-* [ecctl deployment traffic-filter](/reference/ecctl_deployment_traffic-filter.md)	 - Manages traffic filter rulesets
+* [ecctl deployment traffic-filter](/reference/ecctl_deployment_traffic-filter.md)	 - Manages network security policies or traffic filter rulesets
 * [ecctl deployment update](/reference/ecctl_deployment_update.md)	 - Updates a deployment from a file definition, allowing certain flag overrides
 

--- a/docs/reference/ecctl_deployment_traffic-filter.md
+++ b/docs/reference/ecctl_deployment_traffic-filter.md
@@ -9,7 +9,7 @@ applies_to:
 
 # ecctl deployment traffic-filter [ecctl_deployment_traffic-filter]
 
-Manages {{ecloud}} network security policies and {{ece}} traffic filter rulesets. [Learn more about network security](docs-content://deploy-manage/security/network-security.md).
+Manages Elastic Cloud network security policies and Elastic Cloud Enterprise traffic filter rulesets. [Learn more about network security](docs-content://deploy-manage/security/network-security.md).
 
 ```
 ecctl deployment traffic-filter [flags]

--- a/docs/reference/ecctl_deployment_traffic-filter.md
+++ b/docs/reference/ecctl_deployment_traffic-filter.md
@@ -9,7 +9,7 @@ applies_to:
 
 # ecctl deployment traffic-filter [ecctl_deployment_traffic-filter]
 
-Manages traffic filter rulesets.
+Manages {{ecloud}} network security policies and {{ece}} traffic filter rulesets. [Learn more about network security](docs-content://deploy-manage/security/network-security.md).
 
 ```
 ecctl deployment traffic-filter [flags]
@@ -32,10 +32,10 @@ ecctl deployment traffic-filter [flags]
 ## See also [_see_also_50]
 
 * [ecctl deployment](/reference/ecctl_deployment.md)	 - Manages deployments
-* [ecctl deployment traffic-filter association](/reference/ecctl_deployment_traffic-filter_association.md)	 - Manages traffic filter ruleset associations
-* [ecctl deployment traffic-filter create](/reference/ecctl_deployment_traffic-filter_create.md)	 - Creates traffic filter rulesets
-* [ecctl deployment traffic-filter delete](/reference/ecctl_deployment_traffic-filter_delete.md)	 - Deletes a traffic filter ruleset
-* [ecctl deployment traffic-filter list](/reference/ecctl_deployment_traffic-filter_list.md)	 - Lists the traffic filter rulesets
-* [ecctl deployment traffic-filter show](/reference/ecctl_deployment_traffic-filter_show.md)	 - Shows information about a traffic filter ruleset
-* [ecctl deployment traffic-filter update](/reference/ecctl_deployment_traffic-filter_update.md)	 - Updates a traffic-filter
+* [ecctl deployment traffic-filter association](/reference/ecctl_deployment_traffic-filter_association.md)	 - Manages network security policy or traffic filter ruleset associations
+* [ecctl deployment traffic-filter create](/reference/ecctl_deployment_traffic-filter_create.md)	 - Creates a network security policy or traffic filter ruleset
+* [ecctl deployment traffic-filter delete](/reference/ecctl_deployment_traffic-filter_delete.md)	 - Deletes a network security policy or traffic filter ruleset
+* [ecctl deployment traffic-filter list](/reference/ecctl_deployment_traffic-filter_list.md)	 - Lists the network security policies or traffic filter rulesets
+* [ecctl deployment traffic-filter show](/reference/ecctl_deployment_traffic-filter_show.md)	 - Shows information about a network security policy or traffic filter ruleset
+* [ecctl deployment traffic-filter update](/reference/ecctl_deployment_traffic-filter_update.md)	 - Updates a network security policy or traffic filter ruleset
 

--- a/docs/reference/ecctl_deployment_traffic-filter_association.md
+++ b/docs/reference/ecctl_deployment_traffic-filter_association.md
@@ -9,7 +9,7 @@ applies_to:
 
 # ecctl deployment traffic-filter association [ecctl_deployment_traffic-filter_association]
 
-Manages traffic filter ruleset associations.
+Manages network security policy or traffic filter ruleset associations.
 
 ```
 ecctl deployment traffic-filter association [flags]
@@ -31,7 +31,7 @@ ecctl deployment traffic-filter association [flags]
 
 ## See also [_see_also_51]
 
-* [ecctl deployment traffic-filter](/reference/ecctl_deployment_traffic-filter.md)	 - Manages traffic filter rulesets
-* [ecctl deployment traffic-filter association create](/reference/ecctl_deployment_traffic-filter_association_create.md)	 - Applies the ruleset to the specified deployment.
-* [ecctl deployment traffic-filter association delete](/reference/ecctl_deployment_traffic-filter_association_delete.md)	 - Deletes the traffic rules in the ruleset from the deployment.
+* [ecctl deployment traffic-filter](/reference/ecctl_deployment_traffic-filter.md)	- Manages network security policies or traffic filter rulesets
+* [ecctl deployment traffic-filter association create](/reference/ecctl_deployment_traffic-filter_association_create.md)	 - Applies the policy or ruleset to the specified deployment.
+* [ecctl deployment traffic-filter association delete](/reference/ecctl_deployment_traffic-filter_association_delete.md)	 - Deletes the network security policy or traffic filter ruleset from the deployment.
 

--- a/docs/reference/ecctl_deployment_traffic-filter_association_create.md
+++ b/docs/reference/ecctl_deployment_traffic-filter_association_create.md
@@ -32,5 +32,5 @@ ecctl deployment traffic-filter association create <ruleset id> --deployment-id 
 
 ## See also [_see_also_52]
 
-* [ecctl deployment traffic-filter association](/reference/ecctl_deployment_traffic-filter_association.md)	 - Manages traffic filter ruleset associations
+* [ecctl deployment traffic-filter association](/reference/ecctl_deployment_traffic-filter_association.md) - Manages network security policy or traffic filter ruleset associations
 

--- a/docs/reference/ecctl_deployment_traffic-filter_association_delete.md
+++ b/docs/reference/ecctl_deployment_traffic-filter_association_delete.md
@@ -32,5 +32,5 @@ ecctl deployment traffic-filter association delete <ruleset id> --deployment-id 
 
 ## See also [_see_also_53]
 
-* [ecctl deployment traffic-filter association](/reference/ecctl_deployment_traffic-filter_association.md)	 - Manages traffic filter ruleset associations
+* [ecctl deployment traffic-filter association](/reference/ecctl_deployment_traffic-filter_association.md) - Manages network security policy or traffic filter ruleset associations
 

--- a/docs/reference/ecctl_deployment_traffic-filter_create.md
+++ b/docs/reference/ecctl_deployment_traffic-filter_create.md
@@ -9,7 +9,7 @@ applies_to:
 
 # ecctl deployment traffic-filter create [ecctl_deployment_traffic-filter_create]
 
-Creates traffic filter rulesets.
+Creates network security policies or traffic filter rulesets.
 
 ```
 ecctl deployment traffic-filter create --region <region> --name <filter name> --type <filter type> --source <filter source>,<filter source>  [flags]
@@ -36,5 +36,5 @@ ecctl deployment traffic-filter create --region <region> --name <filter name> --
 
 ## See also [_see_also_54]
 
-* [ecctl deployment traffic-filter](/reference/ecctl_deployment_traffic-filter.md)	 - Manages traffic filter rulesets
+* [ecctl deployment traffic-filter](/reference/ecctl_deployment_traffic-filter.md) - Manages network security policies or traffic filter rulesets
 

--- a/docs/reference/ecctl_deployment_traffic-filter_delete.md
+++ b/docs/reference/ecctl_deployment_traffic-filter_delete.md
@@ -9,8 +9,7 @@ applies_to:
 
 # ecctl deployment traffic-filter delete [ecctl_deployment_traffic-filter_delete]
 
-Deletes a traffic filter ruleset.
-
+Deletes a network security policy or traffic filter ruleset.
 ```
 ecctl deployment traffic-filter delete <ruleset id> [--ignore-associations] [flags]
 ```
@@ -32,5 +31,5 @@ ecctl deployment traffic-filter delete <ruleset id> [--ignore-associations] [fla
 
 ## See also [_see_also_55]
 
-* [ecctl deployment traffic-filter](/reference/ecctl_deployment_traffic-filter.md)	 - Manages traffic filter rulesets
+* [ecctl deployment traffic-filter](/reference/ecctl_deployment_traffic-filter.md) - Manages network security policies or traffic filter rulesets
 

--- a/docs/reference/ecctl_deployment_traffic-filter_list.md
+++ b/docs/reference/ecctl_deployment_traffic-filter_list.md
@@ -9,7 +9,7 @@ applies_to:
 
 # ecctl deployment traffic-filter list [ecctl_deployment_traffic-filter_list]
 
-Lists the traffic filter rulesets.
+Lists the network security policies or traffic filter rulesets.
 
 ```
 ecctl deployment traffic-filter list [--include-associations] [--single-region <region>] [flags]
@@ -33,5 +33,5 @@ ecctl deployment traffic-filter list [--include-associations] [--single-region <
 
 ## See also [_see_also_56]
 
-* [ecctl deployment traffic-filter](/reference/ecctl_deployment_traffic-filter.md)	 - Manages traffic filter rulesets
+* [ecctl deployment traffic-filter](/reference/ecctl_deployment_traffic-filter.md) - Manages network security policies or traffic filter rulesets
 

--- a/docs/reference/ecctl_deployment_traffic-filter_show.md
+++ b/docs/reference/ecctl_deployment_traffic-filter_show.md
@@ -9,7 +9,7 @@ applies_to:
 
 # ecctl deployment traffic-filter show [ecctl_deployment_traffic-filter_show]
 
-Shows information about a traffic filter ruleset.
+Shows information about a network security policy or traffic filter ruleset.
 
 ```
 ecctl deployment traffic-filter show <ruleset id> [--include-associations] [flags]
@@ -32,5 +32,5 @@ ecctl deployment traffic-filter show <ruleset id> [--include-associations] [flag
 
 ## See also [_see_also_57]
 
-* [ecctl deployment traffic-filter](/reference/ecctl_deployment_traffic-filter.md)	 - Manages traffic filter rulesets
+* [ecctl deployment traffic-filter](/reference/ecctl_deployment_traffic-filter.md) - Manages network security policies or traffic filter rulesets
 

--- a/docs/reference/ecctl_deployment_traffic-filter_update.md
+++ b/docs/reference/ecctl_deployment_traffic-filter_update.md
@@ -9,7 +9,7 @@ applies_to:
 
 # ecctl deployment traffic-filter update [ecctl_deployment_traffic-filter_update]
 
-Updates a traffic-filter.
+Updates a network security policy or traffic filter ruleset.
 
 ```
 ecctl deployment traffic-filter update <traffic-filter id> {--file <file-path> | --generate-payload} [flags]
@@ -44,5 +44,5 @@ ecctl deployment traffic-filter update <traffic-filter id> {--file <file-path> |
 
 ## See also [_see_also_58]
 
-* [ecctl deployment traffic-filter](/reference/ecctl_deployment_traffic-filter.md)	 - Manages traffic filter rulesets
+* [ecctl deployment traffic-filter](/reference/ecctl_deployment_traffic-filter.md)	 - Manages network security policies or traffic filter rulesets
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
In ECH, traffic filter rulesets are being rebranded to network security policies. this PR updates the docs and the in-product strings

## Related Issues
https://github.com/elastic/platform-docs-team/issues/682
prereq: https://github.com/elastic/docs-content/pull/1785/ + https://github.com/elastic/docs-content/pull/2047

## Motivation and Context
see description

## How Has This Been Tested?
docs preview: https://docs-v3-preview.elastic.dev/elastic/ecctl/pull/735/reference/ecctl_deployment_traffic-filter

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
