### PR TITLE
New ecctl installation guide

### DIFF
--- a/docs/reference/ecctl-installing.md
+++ b/docs/reference/ecctl-installing.md
@@ -10,18 +10,18 @@ applies_to:
 
 # Installing [ecctl-installing]
 
-The latest stable binaries and Linux packages can be found on the [release page](https://github.com/elastic/ecctl/releases). If you need to use changes that are not part of the latest release, you can build `ecctl` from source.
+This guide explains how to install the current {{version.ecctl}} release of `ecctl` on supported operating systems. Release artifacts are available from the [release page](https://github.com/elastic/ecctl/releases). If you need changes that are not yet included in the latest release, you can build `ecctl` from source.
 
 ## Installation methods [ecctl-installing-methods]
 
 You can install `ecctl` using one of these methods:
 
-- **[macOS](#ecctl-installing-macos)**: Homebrew (recommended) or release binary
-- **[Linux](#ecctl-installing-linux)**: `deb`, `rpm`, or release binary
+- **[macOS](#ecctl-installing-macos)**: Homebrew (recommended) or archive (`.tar.gz`)
+- **[Linux](#ecctl-installing-linux)**: `deb`, `rpm`, or archive (`.tar.gz`)
 - **[Windows](#ecctl-installing-windows)**: install with `go install`
 - **[Any OS](#ecctl-installing-source)**: build from source
 
-For shell completions, refer to [Enable shell completions](#ecctl-installing-completions).
+For shell completions, refer to [Enable shell completions](#ecctl-installing-completions). If you download release artifacts (`.tar.gz`, `.deb`, or `.rpm`), refer to [Verify downloaded artifacts](#ecctl-installing-verify-checksums) to optionally verify their SHA-256 checksums before installation.
 
 ## Install on macOS [ecctl-installing-macos]
 
@@ -34,11 +34,19 @@ brew tap elastic/tap
 brew install elastic/tap/ecctl
 ```
 
-### Binary from GitHub release [ecctl-installing-macos-binary]
+### Install from archive (.tar.gz) [ecctl-installing-macos-archive]
 
-1. Download the archive for your architecture from the [release page](https://github.com/elastic/ecctl/releases), for example:
-   - `ecctl_<VERSION>_darwin_amd64.tar.gz`
-   - `ecctl_<VERSION>_darwin_arm64.tar.gz`
+1. Download the `.tar.gz` archive for your architecture from the [release page](https://github.com/elastic/ecctl/releases):
+
+    ```bash subs=true
+    # Apple Silicon
+    curl -L -O https://download.elastic.co/downloads/ecctl/{{version.ecctl}}/ecctl_{{version.ecctl}}_darwin_arm64.tar.gz
+
+    # Intel (x86_64)
+    curl -L -O https://download.elastic.co/downloads/ecctl/{{version.ecctl}}/ecctl_{{version.ecctl}}_darwin_amd64.tar.gz
+
+    ```
+
 2. Extract the archive and move the `ecctl` binary to a directory in your `PATH`, for example `/usr/local/bin`.
 3. Verify the installation:
 
@@ -48,90 +56,91 @@ ecctl version
 
 ## Install on Linux [ecctl-installing-linux]
 
-### Install with deb/rpm packages [ecctl-installing-linux-packages]
+### Install with deb/rpm packages (recommended) [ecctl-installing-linux-packages]
 
-Linux packages are published in every release:
+Linux packages are published with every release and are available from the [release page](https://github.com/elastic/ecctl/releases).
 
-- Debian/Ubuntu: `ecctl_<VERSION>_linux_64-bit.deb` or `ecctl_<VERSION>_linux_32-bit.deb`
-- RHEL/CentOS/Fedora: `ecctl_<VERSION>_linux_64-bit.rpm` or `ecctl_<VERSION>_linux_32-bit.rpm`
+- Debian/Ubuntu: `ecctl_<VERSION>_linux_64-bit.deb`, `ecctl_<VERSION>_linux_32-bit.deb`, or `ecctl_<VERSION>_linux_arm64.deb`
+- RHEL/CentOS/Fedora: `ecctl_<VERSION>_linux_64-bit.rpm`, `ecctl_<VERSION>_linux_32-bit.rpm`, or `ecctl_<VERSION>_linux_arm64.rpm`
 
-Download the package that matches your system, then install it with your package manager.
+Download the package that matches your system and architecture, then install it with your package manager. For example:
 
-Example (`deb`):
+* On Debian/Ubuntu systems:
 
-```bash
-sudo dpkg -i ecctl_<VERSION>_linux_64-bit.deb
-```
+  ```bash subs=true
+  curl -L -O https://download.elastic.co/downloads/ecctl/{{version.ecctl}}/ecctl_{{version.ecctl}}_linux_64-bit.deb
+  sudo dpkg -i ecctl_{{version.ecctl}}_linux_64-bit.deb
+  ```
 
-Example (`rpm`):
+* On RHEL/CentOS/Fedora systems:
 
-```bash
-sudo rpm -i ecctl_<VERSION>_linux_64-bit.rpm
-```
+  ```bash subs=true
+  curl -L -O https://download.elastic.co/downloads/ecctl/{{version.ecctl}}/ecctl_{{version.ecctl}}_linux_64-bit.rpm
+  sudo rpm -i ecctl_{{version.ecctl}}_linux_64-bit.rpm
+  ```
 
-### Binary from GitHub release [ecctl-installing-linux-binary]
+### Install from archive (.tar.gz) [ecctl-installing-linux-archive]
 
-1. Download the archive for your architecture from the [release page](https://github.com/elastic/ecctl/releases), for example:
-   - `ecctl_<VERSION>_linux_amd64.tar.gz`
-   - `ecctl_<VERSION>_linux_arm64.tar.gz`
-   - `ecctl_<VERSION>_linux_386.tar.gz`
+1. Download the Linux `.tar.gz` archive for your architecture from the [release page](https://github.com/elastic/ecctl/releases):
+
+    ```bash subs=true
+    # x86_64 (AMD64)
+    curl -L -O https://download.elastic.co/downloads/ecctl/{{version.ecctl}}/ecctl_{{version.ecctl}}_linux_amd64.tar.gz
+
+    # ARM64
+    curl -L -O https://download.elastic.co/downloads/ecctl/{{version.ecctl}}/ecctl_{{version.ecctl}}_linux_arm64.tar.gz
+
+    # x86 (386)
+    curl -L -O https://download.elastic.co/downloads/ecctl/{{version.ecctl}}/ecctl_{{version.ecctl}}_linux_386.tar.gz
+    ```
 
 2. Extract the archive and move the `ecctl` binary to a directory in your `PATH`, for example `/usr/local/bin`:
 
-```bash
-tar -xzf ecctl_<VERSION>_linux_amd64.tar.gz
-sudo cp ecctl /usr/local/bin
-```
+    ```bash subs=true
+    tar -xzf ecctl_{{version.ecctl}}_linux_amd64.tar.gz
+    sudo cp ecctl /usr/local/bin
+    ```
 
 3. Verify the installation:
 
-```bash
-ecctl version
-```
+    ```bash
+    ecctl version
+    ```
 
 ## Install on Windows [ecctl-installing-windows]
 
-Windows binaries are not currently published as part of the official release artifacts. Use `go install` to build and install `ecctl` from source:
+Official Windows binaries are not currently published. Install `ecctl` with `go install`:
 
 1. Install [Go](https://go.dev/dl/).
 2. Open **Command Prompt** or **PowerShell**.
 3. Confirm Go is available:
 
-```powershell
-go version
-```
+    ```powershell
+    go version
+    ```
 
 4. Install `ecctl`:
 
-```powershell
-go install github.com/elastic/ecctl@latest
-```
+    ```powershell
+    go install github.com/elastic/ecctl@latest
+    ```
+
+    To install a different version, replace `@latest` with a specific tag, for example:
+
+    ```powershell subs=true
+    go install github.com/elastic/ecctl@v{{version.ecctl}}
+    ```
 
 5. Add Go's binary directory to your `PATH` if needed (`%USERPROFILE%\go\bin` by default).
 6. Verify the installation:
 
-```powershell
-ecctl version
-```
-
-## Enable shell completions [ecctl-installing-completions]
-
-You can enable shell completions after installation. This setup applies to Bash and Zsh on macOS and Linux.
-
-Load completions for the current shell session:
-
-```bash
-source <(ecctl generate completions)
-```
-
-Persist completions across sessions:
-
-- Bash: `echo "source <(ecctl generate completions)" >> ~/.bash_profile`
-- Zsh: `echo "source <(ecctl generate completions)" >> ~/.zshrc`
+    ```powershell
+    ecctl version
+    ```
 
 ## Build from source (all operating systems) [ecctl-installing-source]
 
-Use this method if you need the latest unreleased changes or want to build from a specific branch or commit.
+Use this method if you need changes that are not yet included in an official release or want to build from a specific branch or commit.
 
 ### Prerequisites [ecctl-installing-source-prerequisites]
 
@@ -160,15 +169,42 @@ This installs the binary into `GOBIN` (or `GOPATH/bin` if `GOBIN` is not set). M
 
 For contributor-focused setup details, see [Setting up a dev environment](https://github.com/elastic/ecctl/blob/master/CONTRIBUTING.md#setting-up-a-dev-environment).
 
-## Verify installation [ecctl-installing-verify]
+## Verify downloaded artifacts (optional) [ecctl-installing-verify-checksums]
 
-After any installation method, verify that `ecctl` is available:
+If you download release artifacts (`.tar.gz`, `.deb`, or `.rpm`), you can optionally verify their SHA-256 checksums before installing them.
+
+1. Download the checksum file:
+
+    ```bash subs=true
+    curl -L -O https://download.elastic.co/downloads/ecctl/{{version.ecctl}}/ecctl_{{version.ecctl}}_checksums.txt
+    ```
+
+2. Compute the SHA-256 checksum of the downloaded artifact. For example:
+
+    ```bash subs=true
+    # macOS
+    shasum -a 256 ecctl_{{version.ecctl}}_darwin_arm64.tar.gz
+
+    # Linux
+    sha256sum ecctl_{{version.ecctl}}_linux_amd64.tar.gz
+    ```
+
+3. Compare the output with the corresponding entry in `ecctl_{{version.ecctl}}_checksums.txt`.
+
+## Enable shell completions [ecctl-installing-completions]
+
+You can enable shell completions after installation. These instructions apply to Bash and Zsh on macOS and Linux.
+
+Load completions for the current shell session:
 
 ```bash
-ecctl version
+source <(ecctl generate completions)
 ```
 
-If the command is not found, check that the binary location is in your `PATH`.
+Persist completions across sessions:
+
+- Bash: `echo "source <(ecctl generate completions)" >> ~/.bash_profile`
+- Zsh: `echo "source <(ecctl generate completions)" >> ~/.zshrc`
 
 ## Troubleshooting [ecctl-installing-verify-troubleshooting]
 
@@ -185,7 +221,7 @@ Use the same channel you used to install `ecctl`:
   brew upgrade ecctl
   ```
 - **Linux package (`deb`/`rpm`)**: install a newer package from the [release page](https://github.com/elastic/ecctl/releases)
-- **Release binary (macOS/Linux)**: replace the old binary with the new one
+- **Archive (`.tar.gz`) (macOS/Linux)**: replace the old binary with the new one
 - **Windows (`go install`)**:
   ```powershell
   go install github.com/elastic/ecctl@latest

--- a/docs/reference/ecctl-installing.md
+++ b/docs/reference/ecctl-installing.md
@@ -18,8 +18,8 @@ You can install `ecctl` using one of these methods:
 
 - **[macOS](#ecctl-installing-macos)**: Homebrew (recommended) or archive (`.tar.gz`)
 - **[Linux](#ecctl-installing-linux)**: `deb`, `rpm`, or archive (`.tar.gz`)
-- **[Windows](#ecctl-installing-windows)**: install with `go install`
-- **[Any OS](#ecctl-installing-source)**: build from source
+- **[Windows](#ecctl-installing-windows)**: Install with `go install`
+- **[Any OS](#ecctl-installing-source)**: Build from source
 
 For shell completions, refer to [Enable shell completions](#ecctl-installing-completions). If you download release artifacts (`.tar.gz`, `.deb`, or `.rpm`), refer to [Verify downloaded artifacts](#ecctl-installing-verify-checksums) to optionally verify their SHA-256 checksums before installation.
 

--- a/docs/reference/ecctl-installing.md
+++ b/docs/reference/ecctl-installing.md
@@ -215,7 +215,7 @@ Persist completions across sessions:
 ## Troubleshooting [ecctl-installing-verify-troubleshooting]
 
 - `ecctl: command not found`: Add the binary location to your `PATH`.
-- `permission denied` hen copying to system paths: Use elevated privileges (`sudo` on Linux/macOS).
+- `permission denied` when copying to system paths: Use elevated privileges (`sudo` on Linux/macOS).
 - `go: command not found` on Windows: Ensure Go is installed correctly and restart the terminal after installation.
 
 ## Upgrade [ecctl-upgrading]
@@ -243,6 +243,4 @@ After installing `ecctl`, continue with:
 - [Usage examples](/reference/ecctl-examples.md)
 - [Command reference](/reference/ecctl.md)
 
-If you use serverless projects, refer to:
-
-- [Manage serverless projects](/reference/ecctl_project.md)
+If you use serverless projects, refer to [Manage serverless projects](/reference/ecctl_project.md)

--- a/docs/reference/ecctl-installing.md
+++ b/docs/reference/ecctl-installing.md
@@ -1,6 +1,11 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/ecctl/current/ecctl-installing.html
+applies_to:
+  serverless: ga
+  deployment:
+    ess: ga
+    ece: ga all
 ---
 
 # Installing [ecctl-installing]
@@ -16,6 +21,8 @@ You can install `ecctl` using one of these methods:
 - **[Windows](#ecctl-installing-windows)**: install with `go install`
 - **[Any OS](#ecctl-installing-source)**: build from source
 
+For shell completions, refer to [Enable shell completions](#ecctl-installing-completions).
+
 ## Install on macOS [ecctl-installing-macos]
 
 ### Homebrew (recommended) [ecctl-installing-macos-homebrew]
@@ -26,17 +33,6 @@ The simplest installation for macOS users is to install `ecctl` with [Homebrew](
 brew tap elastic/tap
 brew install elastic/tap/ecctl
 ```
-
-To get shell completions working:
-
-```bash
-source <(ecctl generate completions)
-```
-
-Or add completions to your shell startup file:
-
-- Bash: `echo "source <(ecctl generate completions)" >> ~/.bash_profile`
-- Zsh: `echo "source <(ecctl generate completions)" >> ~/.zshrc`
 
 ### Binary from GitHub release [ecctl-installing-macos-binary]
 
@@ -118,6 +114,21 @@ go install github.com/elastic/ecctl@latest
 ecctl version
 ```
 
+## Enable shell completions [ecctl-installing-completions]
+
+You can enable shell completions after installation. This setup applies to Bash and Zsh on macOS and Linux.
+
+Load completions for the current shell session:
+
+```bash
+source <(ecctl generate completions)
+```
+
+Persist completions across sessions:
+
+- Bash: `echo "source <(ecctl generate completions)" >> ~/.bash_profile`
+- Zsh: `echo "source <(ecctl generate completions)" >> ~/.zshrc`
+
 ## Build from source (all operating systems) [ecctl-installing-source]
 
 Use this method if you need the latest unreleased changes or want to build from a specific branch or commit.
@@ -159,6 +170,12 @@ ecctl version
 
 If the command is not found, check that the binary location is in your `PATH`.
 
+## Troubleshooting [ecctl-installing-verify-troubleshooting]
+
+- `ecctl: command not found`: add the binary location to your `PATH`.
+- `permission denied` when copying to system paths: use elevated privileges (`sudo` on Linux/macOS).
+- `go: command not found` on Windows: ensure Go is installed correctly and restart the terminal after installation.
+
 ## Upgrade [ecctl-upgrading]
 
 Use the same channel you used to install `ecctl`:
@@ -174,8 +191,16 @@ Use the same channel you used to install `ecctl`:
   go install github.com/elastic/ecctl@latest
   ```
 
-## Troubleshooting [ecctl-installing-troubleshooting]
+## Next steps [ecctl-installing-next-steps]
 
-- `ecctl: command not found`: add the binary location to your `PATH`.
-- `permission denied` when copying to system paths: use elevated privileges (`sudo` on Linux/macOS).
-- `go: command not found` on Windows: ensure Go is installed correctly and restart the terminal after installation.
+After installing `ecctl`, continue with:
+
+- [Configure ecctl](/reference/ecctl-configuring.md)
+- [Initialize your first configuration](/reference/ecctl_init.md)
+- [Authentication methods](/reference/ecctl-authentication.md)
+- [Usage examples](/reference/ecctl-examples.md)
+- [Command reference](/reference/ecctl.md)
+
+If you use serverless projects, refer to:
+
+- [Manage serverless projects](/reference/ecctl_project.md)

--- a/docs/reference/ecctl-installing.md
+++ b/docs/reference/ecctl-installing.md
@@ -220,14 +220,14 @@ Persist completions across sessions:
 
 ## Upgrade [ecctl-upgrading]
 
-Use the same channel you used to install `ecctl`:
+Use the same installation method you used to install `ecctl`:
 
 - **Homebrew (macOS)**:
   ```bash
   brew upgrade ecctl
   ```
 - **Linux package (`deb`/`rpm`)**: Install a newer package from the [release page](https://github.com/elastic/ecctl/releases)
-- **Archive (`.tar.gz`) (macOS/Linux)**: Replace the old binary with the new one
+- **Archive (`.tar.gz`) (macOS/Linux)**: Download the latest archive from the [release page](https://github.com/elastic/ecctl/releases) and replace the existing binary.
 - **Windows (`go install`)**:
   ```powershell
   go install github.com/elastic/ecctl@latest

--- a/docs/reference/ecctl-installing.md
+++ b/docs/reference/ecctl-installing.md
@@ -208,9 +208,9 @@ Persist completions across sessions:
 
 ## Troubleshooting [ecctl-installing-verify-troubleshooting]
 
-- `ecctl: command not found`: add the binary location to your `PATH`.
-- `permission denied` when copying to system paths: use elevated privileges (`sudo` on Linux/macOS).
-- `go: command not found` on Windows: ensure Go is installed correctly and restart the terminal after installation.
+- `ecctl: command not found`: Add the binary location to your `PATH`.
+- `permission denied` hen copying to system paths: Use elevated privileges (`sudo` on Linux/macOS).
+- `go: command not found` on Windows: Ensure Go is installed correctly and restart the terminal after installation.
 
 ## Upgrade [ecctl-upgrading]
 

--- a/docs/reference/ecctl-installing.md
+++ b/docs/reference/ecctl-installing.md
@@ -220,8 +220,8 @@ Use the same channel you used to install `ecctl`:
   ```bash
   brew upgrade ecctl
   ```
-- **Linux package (`deb`/`rpm`)**: install a newer package from the [release page](https://github.com/elastic/ecctl/releases)
-- **Archive (`.tar.gz`) (macOS/Linux)**: replace the old binary with the new one
+- **Linux package (`deb`/`rpm`)**: Install a newer package from the [release page](https://github.com/elastic/ecctl/releases)
+- **Archive (`.tar.gz`) (macOS/Linux)**: Replace the old binary with the new one
 - **Windows (`go install`)**:
   ```powershell
   go install github.com/elastic/ecctl@latest

--- a/docs/reference/ecctl-installing.md
+++ b/docs/reference/ecctl-installing.md
@@ -189,7 +189,13 @@ If you download release artifacts (`.tar.gz`, `.deb`, or `.rpm`), you can option
     sha256sum ecctl_{{version.ecctl}}_linux_amd64.tar.gz
     ```
 
-3. Compare the output with the corresponding entry in `ecctl_{{version.ecctl}}_checksums.txt`.
+3. Display the expected checksum from the checksums file. For example:
+
+    ```bash subs=true
+    grep "ecctl_{{version.ecctl}}_linux_amd64.tar.gz" ecctl_{{version.ecctl}}_checksums.txt
+    ```
+
+    Verify that the checksum matches the value returned by the checksum command.
 
 ## Enable shell completions [ecctl-installing-completions]
 

--- a/docs/reference/ecctl-installing.md
+++ b/docs/reference/ecctl-installing.md
@@ -5,42 +5,177 @@ mapped_pages:
 
 # Installing [ecctl-installing]
 
-The latest stable binaries can be found on the [release page](https://github.com/elastic/ecctl/releases) or compiled from the latest on the master branch to leverage the most recently merged features.
+The latest stable binaries and Linux packages can be found on the [release page](https://github.com/elastic/ecctl/releases). If you need to use changes that are not part of the latest release, you can build `ecctl` from source.
 
-To learn more about building ecctl from the source, see the steps from our [Setting up a dev environment](https://github.com/elastic/ecctl/blob/master/CONTRIBUTING.md#setting-up-a-dev-environment).
+## Installation methods [ecctl-installing-methods]
 
+You can install `ecctl` using one of these methods:
+
+- **macOS**: Homebrew (recommended) or release binary
+- **Linux**: `deb`, `rpm`, or release binary
+- **Windows**: install with `go install`
+- **Any OS**: build from source
 
 ## Install on macOS [ecctl-installing-macos]
 
-The simplest installation for macOS users is to install ecctl with [Homebrew](https://brew.sh/):
+### Homebrew (recommended) [ecctl-installing-macos-homebrew]
 
-```
-$ brew tap elastic/tap
-$ brew install elastic/tap/ecctl
+The simplest installation for macOS users is to install `ecctl` with [Homebrew](https://brew.sh/):
 
-Updating Homebrew...
-==> Installing ecctl from elastic/tap
-...
-==> Caveats
-To get autocompletions working make sure to run "source <(ecctl generate completions)".
-If you prefer to add to your shell interpreter configuration file run, for bash or zsh respectively:
-* `echo "source <(ecctl generate completions)" >> ~/.bash_profile`
-* `echo "source <(ecctl generate completions)" >> ~/.zshrc`.
-==> Summary
-🍺  /usr/local/Cellar/ecctl/1.5.0: 5 files, 22.6MB, built in 4 seconds
+```bash
+brew tap elastic/tap
+brew install elastic/tap/ecctl
 ```
 
-::::{note}
-To get autocompletions working, follow the instructions in the Homebrew output.
-::::
+To get shell completions working:
 
-
-
-## Upgrade on macOS [ecctl-upgrading-macos]
-
-To upgrade ecctl via brew:
-
-```
-$ brew upgrade ecctl
+```bash
+source <(ecctl generate completions)
 ```
 
+Or add completions to your shell startup file:
+
+- Bash: `echo "source <(ecctl generate completions)" >> ~/.bash_profile`
+- Zsh: `echo "source <(ecctl generate completions)" >> ~/.zshrc`
+
+### Binary from GitHub release [ecctl-installing-macos-binary]
+
+1. Download the archive for your architecture from the [release page](https://github.com/elastic/ecctl/releases), for example:
+   - `ecctl_<VERSION>_darwin_amd64.tar.gz`
+   - `ecctl_<VERSION>_darwin_arm64.tar.gz`
+2. Extract the archive and move the `ecctl` binary to a directory in your `PATH`, for example `/usr/local/bin`.
+3. Verify the installation:
+
+```bash
+ecctl version
+```
+
+## Install on Linux [ecctl-installing-linux]
+
+### Install with deb/rpm packages [ecctl-installing-linux-packages]
+
+Linux packages are published in every release:
+
+- Debian/Ubuntu: `ecctl_<VERSION>_linux_64-bit.deb` or `ecctl_<VERSION>_linux_32-bit.deb`
+- RHEL/CentOS/Fedora: `ecctl_<VERSION>_linux_64-bit.rpm` or `ecctl_<VERSION>_linux_32-bit.rpm`
+
+Download the package that matches your system, then install it with your package manager.
+
+Example (`deb`):
+
+```bash
+sudo dpkg -i ecctl_<VERSION>_linux_64-bit.deb
+```
+
+Example (`rpm`):
+
+```bash
+sudo rpm -i ecctl_<VERSION>_linux_64-bit.rpm
+```
+
+### Binary from GitHub release [ecctl-installing-linux-binary]
+
+1. Download the archive for your architecture from the [release page](https://github.com/elastic/ecctl/releases), for example:
+   - `ecctl_<VERSION>_linux_amd64.tar.gz`
+   - `ecctl_<VERSION>_linux_arm64.tar.gz`
+   - `ecctl_<VERSION>_linux_386.tar.gz`
+
+2. Extract the archive and move the `ecctl` binary to a directory in your `PATH`, for example `/usr/local/bin`:
+
+```bash
+tar -xzf ecctl_<VERSION>_linux_amd64.tar.gz
+sudo cp ecctl /usr/local/bin
+```
+
+3. Verify the installation:
+
+```bash
+ecctl version
+```
+
+## Install on Windows [ecctl-installing-windows]
+
+Windows binaries are not currently published as part of the official release artifacts. Use `go install` to build and install `ecctl` from source:
+
+1. Install [Go](https://go.dev/dl/).
+2. Open **Command Prompt** or **PowerShell**.
+3. Confirm Go is available:
+
+```powershell
+go version
+```
+
+4. Install `ecctl`:
+
+```powershell
+go install github.com/elastic/ecctl@latest
+```
+
+5. Add Go's binary directory to your `PATH` if needed (`%USERPROFILE%\go\bin` by default).
+6. Verify the installation:
+
+```powershell
+ecctl version
+```
+
+## Build from source (all operating systems) [ecctl-installing-source]
+
+Use this method if you need the latest unreleased changes or want to build from a specific branch or commit.
+
+### Prerequisites [ecctl-installing-source-prerequisites]
+
+- [Go](https://go.dev/doc/install)
+- `git`
+
+### Build steps [ecctl-installing-source-steps]
+
+Clone the repository and build locally:
+
+```bash
+git clone https://github.com/elastic/ecctl.git
+cd ecctl
+go build .
+```
+
+This command produces an `ecctl` binary (`ecctl.exe` on Windows) in the current directory.
+
+You can also install directly with Go:
+
+```bash
+go install .
+```
+
+This installs the binary into `GOBIN` (or `GOPATH/bin` if `GOBIN` is not set). Make sure that location is in your `PATH`.
+
+For contributor-focused setup details, see [Setting up a dev environment](https://github.com/elastic/ecctl/blob/master/CONTRIBUTING.md#setting-up-a-dev-environment).
+
+## Verify installation [ecctl-installing-verify]
+
+After any installation method, verify that `ecctl` is available:
+
+```bash
+ecctl version
+```
+
+If the command is not found, check that the binary location is in your `PATH`.
+
+## Upgrade [ecctl-upgrading]
+
+Use the same channel you used to install `ecctl`:
+
+- **Homebrew (macOS)**:
+  ```bash
+  brew upgrade ecctl
+  ```
+- **Linux package (`deb`/`rpm`)**: install a newer package from the [release page](https://github.com/elastic/ecctl/releases)
+- **Release binary (macOS/Linux)**: replace the old binary with the new one
+- **Windows (`go install`)**:
+  ```powershell
+  go install github.com/elastic/ecctl@latest
+  ```
+
+## Troubleshooting [ecctl-installing-troubleshooting]
+
+- `ecctl: command not found`: add the binary location to your `PATH`.
+- `permission denied` when copying to system paths: use elevated privileges (`sudo` on Linux/macOS).
+- `go: command not found` on Windows: ensure Go is installed correctly and restart the terminal after installation.

--- a/docs/reference/ecctl-installing.md
+++ b/docs/reference/ecctl-installing.md
@@ -11,10 +11,10 @@ The latest stable binaries and Linux packages can be found on the [release page]
 
 You can install `ecctl` using one of these methods:
 
-- **macOS**: Homebrew (recommended) or release binary
-- **Linux**: `deb`, `rpm`, or release binary
-- **Windows**: install with `go install`
-- **Any OS**: build from source
+- **[macOS](#ecctl-installing-macos)**: Homebrew (recommended) or release binary
+- **[Linux](#ecctl-installing-linux)**: `deb`, `rpm`, or release binary
+- **[Windows](#ecctl-installing-windows)**: install with `go install`
+- **[Any OS](#ecctl-installing-source)**: build from source
 
 ## Install on macOS [ecctl-installing-macos]
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description

Updates the `ecctl` installation guide to cover multiple operating systems instead of only macOS.

Adds Linux (deb/rpm and binary), Windows (go install), and source-build installation paths, plus verification, upgrade, and basic troubleshooting sections.

This PR also promotes the info from the public KB article https://support.elastic.co/knowledge/f454ec94 ([internal link](https://support.elastic.dev/knowledge/view/f454ec94)) and the internal article https://support.elastic.dev/knowledge/view/1a0ccf8a into docs.

## Related Issues
Closes https://github.com/elastic/ecctl/issues/582

## Motivation and Context

[Existing installation guide](https://www.elastic.co/docs/reference/ecctl/ecctl-installing) only covers MacOS, and we create also binaries and RPM/DEB packages for Linux .

## How Has This Been Tested?
Untested (planning to test)

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
