### PR TITLE
Update CODEOWNERS for docs directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # These owners will be the default owners for everything in
 # the repository.
 *       @elastic/control-plane-hosted-applications
-docs/   @alaudazzi @elastic/control-plane-hosted-applications
+docs/   @elastic/admin-docs @elastic/control-plane-hosted-applications


### PR DESCRIPTION
Adding admin-docs as codeowners for docs content of this repo.

cc: @shainaraskas , for your consideration too.

Do we need anything else? I can't find admin-docs for example in the reviewers pop-up list.